### PR TITLE
compile solids4Foam as dockeruser and not as root in docker container for foam-extend-4.1

### DIFF
--- a/Dockerfile.foamextend41
+++ b/Dockerfile.foamextend41
@@ -15,6 +15,12 @@ SHELL ["/bin/bash", "-c"]
 # Add solids4Foam 
 COPY . /home/dockeruser/solids4foam
 
+# Change ownership to dockeruser
+RUN chown -R dockeruser:dockeruser /home/dockeruser/solids4foam
+
+# Change user to dockeruser
+USER dockeruser
+
 # Compile solids4Foam
 RUN source /home/dockeruser/foam/foam-extend-4.1/etc/bashrc && \
     cd /home/dockeruser/solids4foam && \


### PR DESCRIPTION
The current dockerfile for foam-extend-4.1 seems to compile solids4Foam 
as root user. Therefore, the executable is created in the home folder of 
the root user and does not seem to be available for the dockeruser.
The commit compiles it correctly using dockeruser.