### PR TITLE
change petsc build options to use petscvariables

### DIFF
--- a/src/solids4FoamModels/Make/options
+++ b/src/solids4FoamModels/Make/options
@@ -29,19 +29,23 @@ else
 endif
 
 ifdef PETSC_DIR
+    include ${PETSC_DIR}/lib/petsc/conf/petscvariables
     ifeq ($(WM_PROJECT), foam)
         include $(RULES)/mplib$(WM_MPLIB)
     else
         ifneq (,$(findstring v,$(WM_PROJECT_VERSION)))
             include $(GENERAL_RULES)/mpi-rules
         else
-            include $(GENERAL_RULES)/mplibType
+            -include $(GENERAL_RULES)/mplibType
         endif
     endif
     VERSION_SPECIFIC_INC += \
-        $(PINC) -I$(PETSC_DIR)/include -I$(PETSC_DIR)/$(PETSC_ARCH)/include \
+        $(PINC) $(PETSC_CC_INCLUDES) \
         -DUSE_PETSC
-    VERSION_SPECIFIC_LIBS += -L$(PETSC_DIR)/$(PETSC_ARCH)/lib -lpetsc
+    VERSION_SPECIFIC_INC += \
+        $(PETSC_CC_INCLUDES) \
+        -DUSE_PETSC
+    VERSION_SPECIFIC_LIBS += $(PETSC_LIB)
 endif
 
 ifdef S4F_NO_USE_EIGEN

--- a/src/solids4FoamModels/Make/options
+++ b/src/solids4FoamModels/Make/options
@@ -36,7 +36,7 @@ ifdef PETSC_DIR
         ifneq (,$(findstring v,$(WM_PROJECT_VERSION)))
             include $(GENERAL_RULES)/mpi-rules
         else
-            -include $(GENERAL_RULES)/mplibType
+            include $(GENERAL_RULES)/mplibType
         endif
     endif
     VERSION_SPECIFIC_INC += \

--- a/src/solids4FoamModels/Make/options
+++ b/src/solids4FoamModels/Make/options
@@ -40,11 +40,7 @@ ifdef PETSC_DIR
         endif
     endif
     VERSION_SPECIFIC_INC += \
-        $(PINC) $(PETSC_CC_INCLUDES) \
-        -DUSE_PETSC
-    VERSION_SPECIFIC_INC += \
-        $(PETSC_CC_INCLUDES) \
-        -DUSE_PETSC
+        $(PINC) $(PETSC_CC_INCLUDES) -DUSE_PETSC
     VERSION_SPECIFIC_LIBS += $(PETSC_LIB)
 endif
 


### PR DESCRIPTION
I would use ${PETSC_DIR}/lib/petsc/conf/petscvariables to pick up PETSc include path and linking options which is neat solution for various HPC platforms. I have tested on archer2. though we still -lmpifort to pick up fortran wrapper, but I don't think it is relevant to other system if petsc fortran is not enabled.