### PR TITLE
fixed problem with poroMechLaw when used with a stress state dependen effStressMechLaw

### DIFF
--- a/optionalFixes/Allcheck
+++ b/optionalFixes/Allcheck
@@ -58,6 +58,21 @@ then
         "$FOAM_SRC/foam/meshes/pointMesh/pointBoundaryMesh" \
         "$FOAM_SRC/foam"
     if [ $? -ne 0 ]; then result=1; fi
+    
+    # This fixes consistent Rhie-Chow interpolation
+    # for Euler scheme
+    checkAndReport \
+        "EulerDdtScheme.C" \
+        "$FOAM_SRC/finiteVolume/finiteVolume/ddtSchemes/EulerDdtScheme" \
+        "$FOAM_SRC/finiteVolume"
+    if [ $? -ne 0 ]; then result=1; fi
+    # This fixes consistent Rhie-Chow interpolation
+    # for Euler scheme
+    checkAndReport \
+        "backwardDdtScheme.C" \
+        "$FOAM_SRC/finiteVolume/finiteVolume/ddtSchemes/backwardDdtScheme" \
+        "$FOAM_SRC/finiteVolume"
+    if [ $? -ne 0 ]; then result=1; fi
 else
     echo "No fixes needed for this version of OpenFOAM"; echo
     exit 0;

--- a/optionalFixes/EulerDdtScheme.C
+++ b/optionalFixes/EulerDdtScheme.C
@@ -1,0 +1,635 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | foam-extend: Open Source CFD
+   \\    /   O peration     | Version:     4.1
+    \\  /    A nd           | Web:         http://www.foam-extend.org
+     \\/     M anipulation  | For copyright notice see file Copyright
+-------------------------------------------------------------------------------
+License
+    This file is part of foam-extend.
+
+    foam-extend is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    foam-extend is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with foam-extend.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "EulerDdtScheme.H"
+#include "surfaceInterpolate.H"
+#include "fvcDiv.H"
+#include "fvMatrices.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace fv
+{
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+template<class Type>
+tmp<GeometricField<Type, fvPatchField, volMesh> >
+EulerDdtScheme<Type>::fvcDdt
+(
+    const dimensioned<Type>& dt
+)
+{
+    dimensionedScalar rDeltaT = 1.0/mesh().time().deltaT();
+
+    IOobject ddtIOobject
+    (
+        "ddt("+dt.name()+')',
+        mesh().time().timeName(),
+        mesh()
+    );
+
+    if (mesh().moving())
+    {
+        tmp<GeometricField<Type, fvPatchField, volMesh> > tdtdt
+        (
+            new GeometricField<Type, fvPatchField, volMesh>
+            (
+                ddtIOobject,
+                mesh(),
+                dimensioned<Type>
+                (
+                    "0",
+                    dt.dimensions()/dimTime,
+                    pTraits<Type>::zero
+                )
+            )
+        );
+
+        tdtdt().internalField() =
+            rDeltaT.value()*dt.value()*(1.0 - mesh().V0()/mesh().V());
+
+        return tdtdt;
+    }
+    else
+    {
+        return tmp<GeometricField<Type, fvPatchField, volMesh> >
+        (
+            new GeometricField<Type, fvPatchField, volMesh>
+            (
+                ddtIOobject,
+                mesh(),
+                dimensioned<Type>
+                (
+                    "0",
+                    dt.dimensions()/dimTime,
+                    pTraits<Type>::zero
+                ),
+                calculatedFvPatchField<Type>::typeName
+            )
+        );
+    }
+}
+
+
+template<class Type>
+tmp<GeometricField<Type, fvPatchField, volMesh> >
+EulerDdtScheme<Type>::fvcDdt
+(
+    const GeometricField<Type, fvPatchField, volMesh>& vf
+)
+{
+    dimensionedScalar rDeltaT = 1.0/mesh().time().deltaT();
+
+    IOobject ddtIOobject
+    (
+        "ddt("+vf.name()+')',
+        mesh().time().timeName(),
+        mesh()
+    );
+
+    if (mesh().moving())
+    {
+        return tmp<GeometricField<Type, fvPatchField, volMesh> >
+        (
+            new GeometricField<Type, fvPatchField, volMesh>
+            (
+                ddtIOobject,
+                mesh(),
+                rDeltaT.dimensions()*vf.dimensions(),
+                rDeltaT.value()*
+                (
+                    vf.internalField()
+                  - vf.oldTime().internalField()*mesh().V0()/mesh().V()
+                ),
+                rDeltaT.value()*
+                (
+                    vf.boundaryField() - vf.oldTime().boundaryField()
+                )
+            )
+        );
+    }
+    else
+    {
+        return tmp<GeometricField<Type, fvPatchField, volMesh> >
+        (
+            new GeometricField<Type, fvPatchField, volMesh>
+            (
+                ddtIOobject,
+                rDeltaT*(vf - vf.oldTime())
+            )
+        );
+    }
+}
+
+
+template<class Type>
+tmp<GeometricField<Type, fvPatchField, volMesh> >
+EulerDdtScheme<Type>::fvcDdt
+(
+    const dimensionedScalar& rho,
+    const GeometricField<Type, fvPatchField, volMesh>& vf
+)
+{
+    dimensionedScalar rDeltaT = 1.0/mesh().time().deltaT();
+
+    IOobject ddtIOobject
+    (
+        "ddt("+rho.name()+','+vf.name()+')',
+        mesh().time().timeName(),
+        mesh()
+    );
+
+    if (mesh().moving())
+    {
+        return tmp<GeometricField<Type, fvPatchField, volMesh> >
+        (
+            new GeometricField<Type, fvPatchField, volMesh>
+            (
+                ddtIOobject,
+                mesh(),
+                rDeltaT.dimensions()*rho.dimensions()*vf.dimensions(),
+                rDeltaT.value()*rho.value()*
+                (
+                    vf.internalField()
+                  - vf.oldTime().internalField()*mesh().V0()/mesh().V()
+                ),
+                rDeltaT.value()*rho.value()*
+                (
+                    vf.boundaryField() - vf.oldTime().boundaryField()
+                )
+            )
+        );
+    }
+    else
+    {
+        return tmp<GeometricField<Type, fvPatchField, volMesh> >
+        (
+            new GeometricField<Type, fvPatchField, volMesh>
+            (
+                ddtIOobject,
+                rDeltaT*rho*(vf - vf.oldTime())
+            )
+        );
+    }
+}
+
+
+template<class Type>
+tmp<GeometricField<Type, fvPatchField, volMesh> >
+EulerDdtScheme<Type>::fvcDdt
+(
+    const volScalarField& rho,
+    const GeometricField<Type, fvPatchField, volMesh>& vf
+)
+{
+    dimensionedScalar rDeltaT = 1.0/mesh().time().deltaT();
+
+    IOobject ddtIOobject
+    (
+        "ddt("+rho.name()+','+vf.name()+')',
+        mesh().time().timeName(),
+        mesh()
+    );
+
+    if (mesh().moving())
+    {
+        return tmp<GeometricField<Type, fvPatchField, volMesh> >
+        (
+            new GeometricField<Type, fvPatchField, volMesh>
+            (
+                ddtIOobject,
+                mesh(),
+                rDeltaT.dimensions()*rho.dimensions()*vf.dimensions(),
+                rDeltaT.value()*
+                (
+                    rho.internalField()*vf.internalField()
+                  - rho.oldTime().internalField()
+                   *vf.oldTime().internalField()*mesh().V0()/mesh().V()
+                ),
+                rDeltaT.value()*
+                (
+                    rho.boundaryField()*vf.boundaryField()
+                  - rho.oldTime().boundaryField()
+                   *vf.oldTime().boundaryField()
+                )
+            )
+        );
+    }
+    else
+    {
+        return tmp<GeometricField<Type, fvPatchField, volMesh> >
+        (
+            new GeometricField<Type, fvPatchField, volMesh>
+            (
+                ddtIOobject,
+                rDeltaT*(rho*vf - rho.oldTime()*vf.oldTime())
+            )
+        );
+    }
+}
+
+
+template<class Type>
+tmp<fvMatrix<Type> >
+EulerDdtScheme<Type>::fvmDdt
+(
+    const GeometricField<Type, fvPatchField, volMesh>& vf
+)
+{
+    tmp<fvMatrix<Type> > tfvm
+    (
+        new fvMatrix<Type>
+        (
+            vf,
+            vf.dimensions()*dimVol/dimTime
+        )
+    );
+
+    fvMatrix<Type>& fvm = tfvm();
+
+    scalar rDeltaT = 1.0/mesh().time().deltaT().value();
+
+    fvm.diag() = rDeltaT*mesh().V();
+
+    if (mesh().moving())
+    {
+        fvm.source() = rDeltaT*vf.oldTime().internalField()*mesh().V0();
+    }
+    else
+    {
+        fvm.source() = rDeltaT*vf.oldTime().internalField()*mesh().V();
+    }
+
+    return tfvm;
+}
+
+
+template<class Type>
+tmp<fvMatrix<Type> >
+EulerDdtScheme<Type>::fvmDdt
+(
+    const dimensionedScalar& rho,
+    const GeometricField<Type, fvPatchField, volMesh>& vf
+)
+{
+    tmp<fvMatrix<Type> > tfvm
+    (
+        new fvMatrix<Type>
+        (
+            vf,
+            rho.dimensions()*vf.dimensions()*dimVol/dimTime
+        )
+    );
+    fvMatrix<Type>& fvm = tfvm();
+
+    scalar rDeltaT = 1.0/mesh().time().deltaT().value();
+
+    fvm.diag() = rDeltaT*rho.value()*mesh().V();
+
+    if (mesh().moving())
+    {
+        fvm.source() = rDeltaT
+            *rho.value()*vf.oldTime().internalField()*mesh().V0();
+    }
+    else
+    {
+        fvm.source() = rDeltaT
+            *rho.value()*vf.oldTime().internalField()*mesh().V();
+    }
+
+    return tfvm;
+}
+
+
+template<class Type>
+tmp<fvMatrix<Type> >
+EulerDdtScheme<Type>::fvmDdt
+(
+    const volScalarField& rho,
+    const GeometricField<Type, fvPatchField, volMesh>& vf
+)
+{
+    tmp<fvMatrix<Type> > tfvm
+    (
+        new fvMatrix<Type>
+        (
+            vf,
+            rho.dimensions()*vf.dimensions()*dimVol/dimTime
+        )
+    );
+    fvMatrix<Type>& fvm = tfvm();
+
+    scalar rDeltaT = 1.0/mesh().time().deltaT().value();
+
+    fvm.diag() = rDeltaT*rho.internalField()*mesh().V();
+
+    if (mesh().moving())
+    {
+        fvm.source() = rDeltaT
+            *rho.oldTime().internalField()
+            *vf.oldTime().internalField()*mesh().V0();
+    }
+    else
+    {
+        fvm.source() = rDeltaT
+            *rho.oldTime().internalField()
+            *vf.oldTime().internalField()*mesh().V();
+    }
+
+    return tfvm;
+}
+
+
+template<class Type>
+tmp<typename EulerDdtScheme<Type>::fluxFieldType>
+EulerDdtScheme<Type>::fvcDdtPhiCorr
+(
+    const volScalarField& rA,
+    const GeometricField<Type, fvPatchField, volMesh>& U,
+    const fluxFieldType& phiAbs
+)
+{
+    dimensionedScalar rDeltaT = 1.0/mesh().time().deltaT();
+
+    IOobject ddtIOobject
+    (
+        "ddtPhiCorr(" + rA.name() + ',' + U.name() + ',' + phiAbs.name() + ')',
+        mesh().time().timeName(),
+        mesh()
+    );
+
+    tmp<fluxFieldType> phiCorr =
+        phiAbs.oldTime() - (fvc::interpolate(U.oldTime()) & mesh().Sf());
+
+    return tmp<fluxFieldType>
+    (
+        new fluxFieldType
+        (
+            ddtIOobject,
+            this->fvcDdtPhiCoeff(U.oldTime(), phiAbs.oldTime(), phiCorr())
+           *fvc::interpolate(rDeltaT*rA)*phiCorr
+        )
+    );
+}
+
+
+template<class Type>
+tmp<typename EulerDdtScheme<Type>::fluxFieldType>
+EulerDdtScheme<Type>::fvcDdtPhiCorr
+(
+    const volScalarField& rA,
+    const volScalarField& rho,
+    const GeometricField<Type, fvPatchField, volMesh>& U,
+    const fluxFieldType& phiAbs
+)
+{
+    dimensionedScalar rDeltaT = 1.0/mesh().time().deltaT();
+
+    IOobject ddtIOobject
+    (
+        "ddtPhiCorr("
+      + rA.name() + ','
+      + rho.name() + ','
+      + U.name() + ','
+      + phiAbs.name() + ')',
+        mesh().time().timeName(),
+        mesh()
+    );
+
+    if
+    (
+        U.dimensions() == dimVelocity
+     && phiAbs.dimensions() == dimVelocity*dimArea
+    )
+    {
+        return tmp<fluxFieldType>
+        (
+            new fluxFieldType
+            (
+                ddtIOobject,
+                rDeltaT
+               *this->fvcDdtPhiCoeff(U.oldTime(), phiAbs.oldTime())
+               *(
+                   fvc::interpolate(rA*rho.oldTime())*phiAbs.oldTime()
+                 - (fvc::interpolate(rA*rho.oldTime()*U.oldTime())
+                  & mesh().Sf())
+                )
+            )
+        );
+    }
+    else if
+    (
+        U.dimensions() == dimVelocity
+     && phiAbs.dimensions() == rho.dimensions()*dimVelocity*dimArea
+    )
+    {
+        return tmp<fluxFieldType>
+        (
+            new fluxFieldType
+            (
+                ddtIOobject,
+                rDeltaT
+               *this->fvcDdtPhiCoeff
+                (
+                    U.oldTime(),
+                    phiAbs.oldTime()/fvc::interpolate(rho.oldTime())
+                )
+               *(
+                   fvc::interpolate(rA*rho.oldTime())
+                  *phiAbs.oldTime()/fvc::interpolate(rho.oldTime())
+                 - (
+                       fvc::interpolate
+                       (
+                           rA*rho.oldTime()*U.oldTime()
+                       ) & mesh().Sf()
+                   )
+                )
+            )
+        );
+    }
+    else if
+    (
+        U.dimensions() == rho.dimensions()*dimVelocity
+     && phiAbs.dimensions() == rho.dimensions()*dimVelocity*dimArea
+    )
+    {
+        return tmp<fluxFieldType>
+        (
+            new fluxFieldType
+            (
+                ddtIOobject,
+                rDeltaT
+               *this->fvcDdtPhiCoeff
+                (
+                    rho.oldTime(),
+                    U.oldTime(),
+                    phiAbs.oldTime()
+                )
+               *(
+                   fvc::interpolate(rA)*phiAbs.oldTime()
+                 - (fvc::interpolate(rA*U.oldTime()) & mesh().Sf())
+                )
+            )
+        );
+    }
+    else
+    {
+        FatalErrorIn
+        (
+            "EulerDdtScheme<Type>::fvcDdtPhiCorr"
+        )   << "dimensions of phiAbs are not correct"
+            << abort(FatalError);
+
+        return fluxFieldType::null();
+    }
+}
+
+
+template<class Type>
+tmp<typename EulerDdtScheme<Type>::fluxFieldType>
+EulerDdtScheme<Type>::fvcDdtConsistentPhiCorr
+(
+    const GeometricField<Type, fvsPatchField, surfaceMesh>& Uf,
+    const GeometricField<Type, fvPatchField, volMesh>& U,
+    const surfaceScalarField& rAUf
+)
+{
+    dimensionedScalar rDeltaT = 1.0/mesh().time().deltaT();
+
+    volScalarField V0oV
+    (
+        IOobject
+        (
+            "V0oV",
+            mesh().time().timeName(),
+            mesh(),
+            IOobject::NO_READ,
+            IOobject::NO_WRITE
+        ),
+        mesh(),
+        dimensionedScalar("1", dimless, 1),
+        zeroGradientFvPatchScalarField::typeName
+    );
+
+    if (mesh().moving())
+    {
+        V0oV.internalField() = mesh().V0()/mesh().V();
+        V0oV.correctBoundaryConditions();
+    }
+    
+    fluxFieldType phiUf0
+    (
+        (mesh().Sf() & Uf.oldTime())*
+        fvc::interpolate(V0oV)
+    );
+
+    fluxFieldType phiCorr
+    (
+        phiUf0 - (mesh().Sf() & fvc::interpolate(U.oldTime()*V0oV))
+    );
+
+    forAll(phiCorr.boundaryField(), patchI)
+    {
+        if
+        (
+            U.boundaryField()[patchI].fixesValue()
+        )
+        {
+            phiCorr.boundaryField()[patchI] *= 0.0;
+        }
+    }
+
+    return tmp<fluxFieldType>
+    (
+        new fluxFieldType
+        (
+            IOobject
+            (
+                "ddtCorr(" + U.name() + ',' + Uf.name() + ')',
+                mesh().time().timeName(),
+                mesh()
+            ),
+            rDeltaT*phiCorr*rAUf
+        )
+    );
+
+    
+    // tmp<fluxFieldType> toldTimeFlux =
+    //     (mesh().Sf() & faceU.oldTime())*rAUf/mesh().time().deltaT();
+
+    // if (mesh().moving())
+    // {
+    //     // Mesh is moving, need to take into account the ratio between old and
+    //     // current cell volumes
+    //     volScalarField V0ByV
+    //     (
+    //         IOobject
+    //         (
+    //             "V0ByV",
+    //             mesh().time().timeName(),
+    //             mesh(),
+    //             IOobject::NO_READ,
+    //             IOobject::NO_WRITE
+    //         ),
+    //         mesh(),
+    //         dimensionedScalar("one", dimless, 1.0),
+    //         zeroGradientFvPatchScalarField::typeName
+    //     );
+    //     V0ByV.internalField() = mesh().V0()/mesh().V();
+    //     V0ByV.correctBoundaryConditions();
+
+    //     // Correct the flux with interpolated volume ratio
+    //     toldTimeFlux() *= fvc::interpolate(V0ByV);
+    // }
+
+    // return toldTimeFlux;
+}
+
+
+template<class Type>
+tmp<surfaceScalarField> EulerDdtScheme<Type>::meshPhi
+(
+    const GeometricField<Type, fvPatchField, volMesh>&
+)
+{
+    return mesh().phi();
+}
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace fv
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace Foam
+
+// ************************************************************************* //

--- a/optionalFixes/backwardDdtScheme.C
+++ b/optionalFixes/backwardDdtScheme.C
@@ -1,0 +1,934 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | foam-extend: Open Source CFD
+   \\    /   O peration     | Version:     4.1
+    \\  /    A nd           | Web:         http://www.foam-extend.org
+     \\/     M anipulation  | For copyright notice see file Copyright
+-------------------------------------------------------------------------------
+License
+    This file is part of foam-extend.
+
+    foam-extend is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    foam-extend is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with foam-extend.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "backwardDdtScheme.H"
+#include "surfaceInterpolate.H"
+#include "fvcDiv.H"
+#include "fvMatrices.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace fv
+{
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+template<class Type>
+scalar backwardDdtScheme<Type>::deltaT_() const
+{
+    return mesh().time().deltaT().value();
+}
+
+
+template<class Type>
+scalar backwardDdtScheme<Type>::deltaT0_() const
+{
+    return mesh().time().deltaT0().value();
+}
+
+
+template<class Type>
+template<class GeoField>
+scalar backwardDdtScheme<Type>::deltaT0_(const GeoField& vf) const
+{
+    // Bug fix, Zeljko Tukovic: solver with outer iterations over a time-step
+    // HJ, 12/Feb/2010
+    if (vf.oldTime().timeIndex() == vf.oldTime().oldTime().timeIndex())
+    {
+        return GREAT;
+    }
+    else
+    {
+        return deltaT0_();
+    }
+}
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+template<class Type>
+tmp<GeometricField<Type, fvPatchField, volMesh> >
+backwardDdtScheme<Type>::fvcDdt
+(
+    const dimensioned<Type>& dt
+)
+{
+    dimensionedScalar rDeltaT = 1.0/mesh().time().deltaT();
+
+    IOobject ddtIOobject
+    (
+        "ddt("+dt.name()+')',
+        mesh().time().timeName(),
+        mesh()
+    );
+
+    scalar deltaT = deltaT_();
+    scalar deltaT0 = deltaT0_();
+
+    scalar coefft   = 1 + deltaT/(deltaT + deltaT0);
+    scalar coefft00 = deltaT*deltaT/(deltaT0*(deltaT + deltaT0));
+    scalar coefft0  = coefft + coefft00;
+
+    if (mesh().moving())
+    {
+        tmp<GeometricField<Type, fvPatchField, volMesh> > tdtdt
+        (
+            new GeometricField<Type, fvPatchField, volMesh>
+            (
+                ddtIOobject,
+                mesh(),
+                dimensioned<Type>
+                (
+                    "0",
+                    dt.dimensions()/dimTime,
+                    pTraits<Type>::zero
+                )
+            )
+        );
+
+        tdtdt().internalField() = rDeltaT.value()*dt.value()*
+        (
+            coefft - (coefft0*mesh().V0() - coefft00*mesh().V00())/mesh().V()
+        );
+
+        return tdtdt;
+    }
+    else
+    {
+        return tmp<GeometricField<Type, fvPatchField, volMesh> >
+        (
+            new GeometricField<Type, fvPatchField, volMesh>
+            (
+                ddtIOobject,
+                mesh(),
+                dimensioned<Type>
+                (
+                    "0",
+                    dt.dimensions()/dimTime,
+                    pTraits<Type>::zero
+                ),
+                calculatedFvPatchField<Type>::typeName
+            )
+        );
+    }
+}
+
+
+template<class Type>
+tmp<GeometricField<Type, fvPatchField, volMesh> >
+backwardDdtScheme<Type>::fvcDdt
+(
+    const GeometricField<Type, fvPatchField, volMesh>& vf
+)
+{
+    dimensionedScalar rDeltaT = 1.0/mesh().time().deltaT();
+
+    IOobject ddtIOobject
+    (
+        "ddt("+vf.name()+')',
+        mesh().time().timeName(),
+        mesh()
+    );
+
+    scalar deltaT = deltaT_();
+    scalar deltaT0 = deltaT0_(vf);
+
+    scalar coefft   = 1 + deltaT/(deltaT + deltaT0);
+    scalar coefft00 = deltaT*deltaT/(deltaT0*(deltaT + deltaT0));
+    scalar coefft0  = coefft + coefft00;
+
+    if (mesh().moving())
+    {
+        return tmp<GeometricField<Type, fvPatchField, volMesh> >
+        (
+            new GeometricField<Type, fvPatchField, volMesh>
+            (
+                ddtIOobject,
+                mesh(),
+                rDeltaT.dimensions()*vf.dimensions(),
+                rDeltaT.value()*
+                (
+                    coefft*vf.internalField() -
+                    (
+                        coefft0*vf.oldTime().internalField()*mesh().V0()
+                      - coefft00*vf.oldTime().oldTime().internalField()
+                       *mesh().V00()
+                    )/mesh().V()
+                ),
+                rDeltaT.value()*
+                (
+                    coefft*vf.boundaryField() -
+                    (
+                        coefft0*vf.oldTime().boundaryField()
+                      - coefft00*vf.oldTime().oldTime().boundaryField()
+                    )
+                )
+            )
+        );
+    }
+    else
+    {
+        return tmp<GeometricField<Type, fvPatchField, volMesh> >
+        (
+            new GeometricField<Type, fvPatchField, volMesh>
+            (
+                ddtIOobject,
+                rDeltaT*
+                (
+                    coefft*vf
+                  - coefft0*vf.oldTime()
+                  + coefft00*vf.oldTime().oldTime()
+                )
+            )
+        );
+    }
+}
+
+
+template<class Type>
+tmp<GeometricField<Type, fvPatchField, volMesh> >
+backwardDdtScheme<Type>::fvcDdt
+(
+    const dimensionedScalar& rho,
+    const GeometricField<Type, fvPatchField, volMesh>& vf
+)
+{
+    dimensionedScalar rDeltaT = 1.0/mesh().time().deltaT();
+
+    IOobject ddtIOobject
+    (
+        "ddt("+rho.name()+','+vf.name()+')',
+        mesh().time().timeName(),
+        mesh()
+    );
+
+    scalar deltaT = deltaT_();
+    scalar deltaT0 = deltaT0_(vf);
+
+    scalar coefft   = 1 + deltaT/(deltaT + deltaT0);
+    scalar coefft00 = deltaT*deltaT/(deltaT0*(deltaT + deltaT0));
+    scalar coefft0  = coefft + coefft00;
+
+    if (mesh().moving())
+    {
+        return tmp<GeometricField<Type, fvPatchField, volMesh> >
+        (
+            new GeometricField<Type, fvPatchField, volMesh>
+            (
+                ddtIOobject,
+                mesh(),
+                rDeltaT.dimensions()*rho.dimensions()*vf.dimensions(),
+                rDeltaT.value()*rho.value()*
+                (
+                    coefft*vf.internalField() -
+                    (
+                        coefft0*vf.oldTime().internalField()*mesh().V0()
+                      - coefft00*vf.oldTime().oldTime().internalField()
+                       *mesh().V00()
+                    )/mesh().V()
+                ),
+                rDeltaT.value()*rho.value()*
+                (
+                    coefft*vf.boundaryField() -
+                    (
+                        coefft0*vf.oldTime().boundaryField()
+                      - coefft00*vf.oldTime().oldTime().boundaryField()
+                    )
+                )
+            )
+        );
+    }
+    else
+    {
+        return tmp<GeometricField<Type, fvPatchField, volMesh> >
+        (
+            new GeometricField<Type, fvPatchField, volMesh>
+            (
+                ddtIOobject,
+                rDeltaT*rho*
+                (
+                    coefft*vf
+                  - coefft0*vf.oldTime()
+                 + coefft00*vf.oldTime().oldTime()
+                )
+            )
+        );
+    }
+}
+
+template<class Type>
+tmp<GeometricField<Type, fvPatchField, volMesh> >
+backwardDdtScheme<Type>::fvcDdt
+(
+    const volScalarField& rho,
+    const GeometricField<Type, fvPatchField, volMesh>& vf
+)
+{
+    dimensionedScalar rDeltaT = 1.0/mesh().time().deltaT();
+
+    IOobject ddtIOobject
+    (
+        "ddt("+rho.name()+','+vf.name()+')',
+        mesh().time().timeName(),
+        mesh()
+    );
+
+    scalar deltaT = deltaT_();
+    scalar deltaT0 = deltaT0_(vf);
+
+    scalar coefft   = 1 + deltaT/(deltaT + deltaT0);
+    scalar coefft00 = deltaT*deltaT/(deltaT0*(deltaT + deltaT0));
+    scalar coefft0  = coefft + coefft00;
+
+    if (mesh().moving())
+    {
+        return tmp<GeometricField<Type, fvPatchField, volMesh> >
+        (
+            new GeometricField<Type, fvPatchField, volMesh>
+            (
+                ddtIOobject,
+                mesh(),
+                rDeltaT.dimensions()*rho.dimensions()*vf.dimensions(),
+                rDeltaT.value()*
+                (
+                    coefft*rho.internalField()*vf.internalField() -
+                    (
+                        coefft0*rho.oldTime().internalField()
+                       *vf.oldTime().internalField()*mesh().V0()
+                      - coefft00*rho.oldTime().oldTime().internalField()
+                       *vf.oldTime().oldTime().internalField()*mesh().V00()
+                    )/mesh().V()
+                ),
+                rDeltaT.value()*
+                (
+                    coefft*rho.boundaryField()*vf.boundaryField() -
+                    (
+                        coefft0*rho.oldTime().boundaryField()
+                       *vf.oldTime().boundaryField()
+                      - coefft00*rho.oldTime().oldTime().boundaryField()
+                       *vf.oldTime().oldTime().boundaryField()
+                    )
+                )
+            )
+        );
+    }
+    else
+    {
+        return tmp<GeometricField<Type, fvPatchField, volMesh> >
+        (
+            new GeometricField<Type, fvPatchField, volMesh>
+            (
+                ddtIOobject,
+                rDeltaT*
+                (
+                    coefft*rho*vf
+                  - coefft0*rho.oldTime()*vf.oldTime()
+                  + coefft00*rho.oldTime().oldTime()*vf.oldTime().oldTime()
+                )
+            )
+        );
+    }
+}
+
+
+template<class Type>
+tmp<fvMatrix<Type> >
+backwardDdtScheme<Type>::fvmDdt
+(
+    const GeometricField<Type, fvPatchField, volMesh>& vf
+)
+{
+    tmp<fvMatrix<Type> > tfvm
+    (
+        new fvMatrix<Type>
+        (
+            vf,
+            vf.dimensions()*dimVol/dimTime
+        )
+    );
+
+    fvMatrix<Type>& fvm = tfvm();
+
+    scalar rDeltaT = 1.0/deltaT_();
+
+    scalar deltaT = deltaT_();
+    scalar deltaT0 = deltaT0_(vf);
+
+    scalar coefft   = 1 + deltaT/(deltaT + deltaT0);
+    scalar coefft00 = deltaT*deltaT/(deltaT0*(deltaT + deltaT0));
+    scalar coefft0  = coefft + coefft00;
+
+    fvm.diag() = (coefft*rDeltaT)*mesh().V();
+
+    if (mesh().moving())
+    {
+        fvm.source() = rDeltaT*
+        (
+            coefft0*vf.oldTime().internalField()*mesh().V0()
+          - coefft00*vf.oldTime().oldTime().internalField()
+           *mesh().V00()
+        );
+    }
+    else
+    {
+        fvm.source() = rDeltaT*mesh().V()*
+        (
+            coefft0*vf.oldTime().internalField()
+          - coefft00*vf.oldTime().oldTime().internalField()
+        );
+    }
+
+    return tfvm;
+}
+
+
+template<class Type>
+tmp<fvMatrix<Type> >
+backwardDdtScheme<Type>::fvmDdt
+(
+    const dimensionedScalar& rho,
+    const GeometricField<Type, fvPatchField, volMesh>& vf
+)
+{
+    tmp<fvMatrix<Type> > tfvm
+    (
+        new fvMatrix<Type>
+        (
+            vf,
+            rho.dimensions()*vf.dimensions()*dimVol/dimTime
+        )
+    );
+    fvMatrix<Type>& fvm = tfvm();
+
+    scalar rDeltaT = 1.0/deltaT_();
+
+    scalar deltaT = deltaT_();
+    scalar deltaT0 = deltaT0_(vf);
+
+    scalar coefft   = 1 + deltaT/(deltaT + deltaT0);
+    scalar coefft00 = deltaT*deltaT/(deltaT0*(deltaT + deltaT0));
+    scalar coefft0  = coefft + coefft00;
+
+    fvm.diag() = (coefft*rDeltaT*rho.value())*mesh().V();
+
+    if (mesh().moving())
+    {
+        fvm.source() = rDeltaT*rho.value()*
+        (
+            coefft0*vf.oldTime().internalField()*mesh().V0()
+          - coefft00*vf.oldTime().oldTime().internalField()
+           *mesh().V00()
+        );
+    }
+    else
+    {
+        fvm.source() = rDeltaT*mesh().V()*rho.value()*
+        (
+            coefft0*vf.oldTime().internalField()
+          - coefft00*vf.oldTime().oldTime().internalField()
+        );
+    }
+
+    return tfvm;
+}
+
+
+template<class Type>
+tmp<fvMatrix<Type> >
+backwardDdtScheme<Type>::fvmDdt
+(
+    const volScalarField& rho,
+    const GeometricField<Type, fvPatchField, volMesh>& vf
+)
+{
+    tmp<fvMatrix<Type> > tfvm
+    (
+        new fvMatrix<Type>
+        (
+            vf,
+            rho.dimensions()*vf.dimensions()*dimVol/dimTime
+        )
+    );
+    fvMatrix<Type>& fvm = tfvm();
+
+    scalar rDeltaT = 1.0/deltaT_();
+
+    scalar deltaT = deltaT_();
+    scalar deltaT0 = deltaT0_(vf);
+
+    scalar coefft   = 1 + deltaT/(deltaT + deltaT0);
+    scalar coefft00 = deltaT*deltaT/(deltaT0*(deltaT + deltaT0));
+    scalar coefft0  = coefft + coefft00;
+
+    fvm.diag() = (coefft*rDeltaT)*rho.internalField()*mesh().V();
+
+    if (mesh().moving())
+    {
+        fvm.source() = rDeltaT*
+        (
+            coefft0*rho.oldTime().internalField()
+           *vf.oldTime().internalField()*mesh().V0()
+          - coefft00*rho.oldTime().oldTime().internalField()
+           *vf.oldTime().oldTime().internalField()*mesh().V00()
+        );
+    }
+    else
+    {
+        fvm.source() = rDeltaT*mesh().V()*
+        (
+            coefft0*rho.oldTime().internalField()
+           *vf.oldTime().internalField()
+          - coefft00*rho.oldTime().oldTime().internalField()
+           *vf.oldTime().oldTime().internalField()
+        );
+    }
+
+    return tfvm;
+}
+
+
+template<class Type>
+tmp<typename backwardDdtScheme<Type>::fluxFieldType>
+backwardDdtScheme<Type>::fvcDdtPhiCorr
+(
+    const volScalarField& rA,
+    const GeometricField<Type, fvPatchField, volMesh>& U,
+    const fluxFieldType& phi
+)
+{
+    dimensionedScalar rDeltaT = 1.0/mesh().time().deltaT();
+
+    IOobject ddtIOobject
+    (
+        "ddtPhiCorr(" + rA.name() + ',' + U.name() + ',' + phi.name() + ')',
+        mesh().time().timeName(),
+        mesh()
+    );
+
+    scalar deltaT = deltaT_();
+    scalar deltaT0 = deltaT0_(U);
+
+    scalar coefft   = 1 + deltaT/(deltaT + deltaT0);
+    scalar coefft00 = deltaT*deltaT/(deltaT0*(deltaT + deltaT0));
+    scalar coefft0  = coefft + coefft00;
+
+    return tmp<fluxFieldType>
+    (
+        new fluxFieldType
+        (
+            ddtIOobject,
+            rDeltaT*this->fvcDdtPhiCoeff(U.oldTime(), phi.oldTime())
+           *(
+                fvc::interpolate(rA)
+               *(
+                   coefft0*phi.oldTime()
+                 - coefft00*phi.oldTime().oldTime()
+                )
+              - (
+                    fvc::interpolate
+                    (
+                        rA*
+                        (
+                            coefft0*U.oldTime()
+                          - coefft00*U.oldTime().oldTime()
+                        )
+                    ) & mesh().Sf()
+                )
+            )
+        )
+    );
+}
+
+
+template<class Type>
+tmp<typename backwardDdtScheme<Type>::fluxFieldType>
+backwardDdtScheme<Type>::fvcDdtPhiCorr
+(
+    const volScalarField& rA,
+    const volScalarField& rho,
+    const GeometricField<Type, fvPatchField, volMesh>& U,
+    const fluxFieldType& phiAbs
+)
+{
+    dimensionedScalar rDeltaT = 1.0/mesh().time().deltaT();
+
+    IOobject ddtIOobject
+    (
+        "ddtPhiCorr("
+      + rA.name() + ','
+      + rho.name() + ','
+      + U.name() + ','
+      + phiAbs.name() + ')',
+        mesh().time().timeName(),
+        mesh()
+    );
+
+    scalar deltaT = deltaT_();
+    scalar deltaT0 = deltaT0_(U);
+
+    scalar coefft   = 1 + deltaT/(deltaT + deltaT0);
+    scalar coefft00 = deltaT*deltaT/(deltaT0*(deltaT + deltaT0));
+    scalar coefft0  = coefft + coefft00;
+
+    if
+    (
+        U.dimensions() == dimVelocity
+     && phiAbs.dimensions() == dimVelocity*dimArea
+    )
+    {
+        return tmp<fluxFieldType>
+        (
+            new fluxFieldType
+            (
+                ddtIOobject,
+                rDeltaT*this->fvcDdtPhiCoeff(U.oldTime(), phiAbs.oldTime())
+               *(
+                    coefft0*fvc::interpolate(rA*rho.oldTime())
+                   *phiAbs.oldTime()
+                  - coefft00*fvc::interpolate(rA*rho.oldTime().oldTime())
+                   *phiAbs.oldTime().oldTime()
+                  - (
+                        fvc::interpolate
+                        (
+                            rA*
+                            (
+                                coefft0*rho.oldTime()*U.oldTime()
+                              - coefft00*rho.oldTime().oldTime()
+                               *U.oldTime().oldTime()
+                            )
+                        ) & mesh().Sf()
+                    )
+                )
+            )
+        );
+    }
+    else if
+    (
+        U.dimensions() == dimVelocity
+     && phiAbs.dimensions() == rho.dimensions()*dimVelocity*dimArea
+    )
+    {
+        return tmp<fluxFieldType>
+        (
+            new fluxFieldType
+            (
+                ddtIOobject,
+                rDeltaT
+               *this->fvcDdtPhiCoeff
+                (
+                    U.oldTime(),
+                    phiAbs.oldTime()/fvc::interpolate(rho.oldTime())
+                )
+               *(
+                    fvc::interpolate(rA*rho.oldTime())
+                   *(
+                       coefft0*phiAbs.oldTime()
+                      /fvc::interpolate(rho.oldTime())
+                     - coefft00*phiAbs.oldTime().oldTime()
+                      /fvc::interpolate(rho.oldTime().oldTime())
+                    )
+                  - (
+                        fvc::interpolate
+                        (
+                            rA*rho.oldTime()*
+                            (
+                                coefft0*U.oldTime()
+                              - coefft00*U.oldTime().oldTime()
+                            )
+                        ) & mesh().Sf()
+                    )
+                )
+            )
+        );
+    }
+    else if
+    (
+        U.dimensions() == rho.dimensions()*dimVelocity
+     && phiAbs.dimensions() == rho.dimensions()*dimVelocity*dimArea
+    )
+    {
+        return tmp<fluxFieldType>
+        (
+            new fluxFieldType
+            (
+                ddtIOobject,
+                rDeltaT
+               *this->fvcDdtPhiCoeff(rho.oldTime(), U.oldTime(), phiAbs.oldTime())
+               *(
+                    fvc::interpolate(rA)
+                   *(
+                       coefft0*phiAbs.oldTime()
+                     - coefft00*phiAbs.oldTime().oldTime()
+                    )
+                  - (
+                        fvc::interpolate
+                        (
+                            rA*
+                            (
+                                coefft0*U.oldTime()
+                              - coefft00*U.oldTime().oldTime()
+                            )
+                        ) & mesh().Sf()
+                    )
+                )
+            )
+        );
+    }
+    else
+    {
+        FatalErrorIn
+        (
+            "backwardDdtScheme<Type>::fvcDdtPhiCorr"
+        )   << "dimensions of phiAbs are not correct"
+            << abort(FatalError);
+
+        return fluxFieldType::null();
+    }
+}
+
+
+template<class Type>
+tmp<typename backwardDdtScheme<Type>::fluxFieldType>
+backwardDdtScheme<Type>::fvcDdtConsistentPhiCorr
+(
+    const GeometricField<Type, fvsPatchField, surfaceMesh>& Uf,
+    const GeometricField<Type, fvPatchField, volMesh>& U,
+    const surfaceScalarField& rAUf
+)
+{
+    dimensionedScalar rDeltaT = 1.0/mesh().time().deltaT();
+
+    scalar deltaT = deltaT_();
+    scalar deltaT0 = deltaT0_(U);
+
+    scalar coefft   = 1 + deltaT/(deltaT + deltaT0);
+    scalar coefft00 = deltaT*deltaT/(deltaT0*(deltaT + deltaT0));
+    scalar coefft0  = coefft + coefft00;
+
+    volScalarField V0oV
+    (
+        IOobject
+        (
+            "V0oV",
+            mesh().time().timeName(),
+            mesh(),
+            IOobject::NO_READ,
+            IOobject::NO_WRITE
+        ),
+        mesh(),
+        dimensionedScalar("1", dimless, 1),
+        zeroGradientFvPatchScalarField::typeName
+    );
+
+    volScalarField V00oV
+    (
+        IOobject
+        (
+            "V00oV",
+            mesh().time().timeName(),
+            mesh(),
+            IOobject::NO_READ,
+            IOobject::NO_WRITE
+        ),
+        mesh(),
+        dimensionedScalar("1", dimless, 1),
+        zeroGradientFvPatchScalarField::typeName
+    );
+
+    if (mesh().moving())
+    {
+        V0oV.internalField() = mesh().V0()/mesh().V();
+        V0oV.correctBoundaryConditions();
+    
+        V00oV.internalField() = mesh().V00()/mesh().V();
+        V00oV.correctBoundaryConditions();
+    }
+
+    fluxFieldType phiCorr
+    (
+        mesh().Sf()
+      & (
+            (
+                coefft0*Uf.oldTime()*fvc::interpolate(V0oV)
+              - coefft00*Uf.oldTime().oldTime()*fvc::interpolate(V00oV)
+            )
+          - (
+                coefft0*fvc::interpolate(U.oldTime()*V0oV)
+              - coefft00*fvc::interpolate(U.oldTime().oldTime()*V00oV)
+            )
+        )
+    );
+
+    forAll(phiCorr.boundaryField(), patchI)
+    {
+        if (U.boundaryField()[patchI].fixesValue())
+        {
+            phiCorr.boundaryField()[patchI] *= 0.0;
+        }
+    }
+
+    return tmp<fluxFieldType>
+    (
+        new fluxFieldType
+        (
+            IOobject
+            (
+                "ddtCorr(" + U.name() + ',' + Uf.name() + ')',
+                mesh().time().timeName(),
+                mesh()
+            ),
+            rDeltaT*phiCorr*rAUf
+        )
+    );
+
+
+    // const scalar deltaT = deltaT_();
+    // const scalar deltaT0 = deltaT0_(U);
+
+    // const scalar coefft   = 1 + deltaT/(deltaT + deltaT0);
+    // const scalar coefft00 = deltaT*deltaT/(deltaT0*(deltaT + deltaT0));
+    // const scalar coefft0  = coefft + coefft00;
+
+    // const scalar rDeltaT = 1.0/deltaT;
+
+    // // Note: minus sign in gamma coefficient so we can simply add the fluxes
+    // // together at the end
+    // const dimensionedScalar beta("beta", dimless/dimTime, coefft0*rDeltaT);
+    // const dimensionedScalar gamma("gamma", dimless/dimTime, -coefft00*rDeltaT);
+
+    // // Calculate old and old-old flux contributions
+    // fluxFieldType oldTimeFlux =
+    //     beta*rAUf*(mesh().Sf() & faceU.oldTime());
+    // fluxFieldType oldOldTimeFlux =
+    //     gamma*rAUf*(mesh().Sf() & faceU.oldTime().oldTime());
+
+    // if (mesh().moving())
+    // {
+    //     // Mesh is moving, need to take into account the ratio between old and
+    //     // current cell volumes for old flux contribution
+    //     volScalarField V0ByV
+    //     (
+    //         IOobject
+    //         (
+    //             "V0ByV",
+    //             mesh().time().timeName(),
+    //             mesh(),
+    //             IOobject::NO_READ,
+    //             IOobject::NO_WRITE
+    //         ),
+    //         mesh(),
+    //         dimensionedScalar("one", dimless, 1.0),
+    //         zeroGradientFvPatchScalarField::typeName
+    //     );
+    //     V0ByV.internalField() = mesh().V0()/mesh().V();
+    //     V0ByV.correctBoundaryConditions();
+
+    //     // Correct old time flux contribution
+    //     oldTimeFlux *= fvc::interpolate(V0ByV);
+
+
+    //     // Also need to take into account the ratio between old-old and current
+    //     // cell volumes for old-old time flux contribution
+    //     volScalarField V00ByV
+    //     (
+    //         IOobject
+    //         (
+    //             "V00ByV",
+    //             mesh().time().timeName(),
+    //             mesh(),
+    //             IOobject::NO_READ,
+    //             IOobject::NO_WRITE
+    //         ),
+    //         mesh(),
+    //         dimensionedScalar("one", dimless, 1.0),
+    //         zeroGradientFvPatchScalarField::typeName
+    //     );
+    //     V00ByV.internalField() = mesh().V00()/mesh().V();
+    //     V00ByV.correctBoundaryConditions();
+
+    //     // Correct old-old time flux contribution
+    //     oldOldTimeFlux *= fvc::interpolate(V00ByV);
+    // }
+
+    // return oldTimeFlux + oldOldTimeFlux;
+}
+
+
+template<class Type>
+tmp<surfaceScalarField> backwardDdtScheme<Type>::meshPhi
+(
+    const GeometricField<Type, fvPatchField, volMesh>& vf
+)
+{
+    const scalar deltaT = deltaT_();
+    const scalar deltaT0 = deltaT0_(vf);
+
+    // Coefficient for t-3/2 (between times 0 and 00)
+    scalar coefft0_00 = deltaT/(deltaT + deltaT0);
+
+    // Coefficient for t-1/2 (between times n and 0)
+    scalar coefftn_0 = 1 + coefft0_00;
+
+    return tmp<surfaceScalarField>
+    (
+        new surfaceScalarField
+        (
+            IOobject
+            (
+                mesh().phi().name(),
+                mesh().time().timeName(),
+                mesh(),
+                IOobject::NO_READ,
+                IOobject::NO_WRITE,
+                false
+            ),
+            coefftn_0*mesh().phi() - coefft0_00*mesh().phi().oldTime()
+        )
+    );
+
+    // ZT: This bugfix is not correct. ESI version is correct!
+    // Bugfix: missing possibility of having the variable time step
+    // Reported by Sopheak Seng, Bureau Veritas, 6/Sep/2018.
+    // const scalar coefft00 = deltaT*deltaT/(deltaT0*(deltaT + deltaT0));
+    // const scalar coefft  = 1 + deltaT/(deltaT + deltaT0);
+
+    // return coefft*mesh().phi() - coefft00*mesh().phi().oldTime();
+}
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace fv
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace Foam
+
+// ************************************************************************* //

--- a/optionalFixes/meshObjectBase.H
+++ b/optionalFixes/meshObjectBase.H
@@ -1,25 +1,19 @@
 /*---------------------------------------------------------------------------*\
-  =========                 |
-  \\      /  F ield         | foam-extend: Open Source CFD
-   \\    /   O peration     | Version:     4.1
-    \\  /    A nd           | Web:         http://www.foam-extend.org
-     \\/     M anipulation  | For copyright notice see file Copyright
--------------------------------------------------------------------------------
 License
-    This file is part of foam-extend.
+    This file is part of solids4foam.
 
-    foam-extend is free software: you can redistribute it and/or modify it
+    solids4foam is free software: you can redistribute it and/or modify it
     under the terms of the GNU General Public License as published by the
     Free Software Foundation, either version 3 of the License, or (at your
     option) any later version.
 
-    foam-extend is distributed in the hope that it will be useful, but
+    solids4foam is distributed in the hope that it will be useful, but
     WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
     General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with foam-extend.  If not, see <http://www.gnu.org/licenses/>.
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
 
 Class
     meshObjectBase
@@ -27,6 +21,8 @@ Class
 Description
     Abstract base-class for dynamic mesh objects used to automate
     their allocation to the mesh database and mesh-related updates
+
+    This is a modified version of meshObjectBase.C from foam-extend-4.1.
 
 SourceFiles
     meshObjectBase.C

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticMohrCoulombPlastic/linearElasticMohrCoulombPlastic.C
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticMohrCoulombPlastic/linearElasticMohrCoulombPlastic.C
@@ -413,7 +413,6 @@ void Foam::linearElasticMohrCoulombPlastic::calculateEigens
     }
 }
 
-
 // * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
 
 // Construct from dictionary
@@ -609,6 +608,15 @@ Foam::linearElasticMohrCoulombPlastic::linearElasticMohrCoulombPlastic
 
     // Create the initial stress field
     sigma0();
+
+    // Check and warn for zero inital stress
+    if (gsum(mag(sigma0())).value()==0.0)
+    {
+        FoamWarningIn("linearElasticMohrCoulombPlastic") 
+        << "Initial stress is zero everywhere, "
+        << "since Mohr-Coulomb material law is stress-state dependent, "
+        << "this may lead to problems. Proceed with caution." << endl;
+    }
 }
 
 
@@ -670,7 +678,7 @@ void Foam::linearElasticMohrCoulombPlastic::correct(volSymmTensorField& sigma)
     );
 
     // Set sigma to sigma effective trial, including the initial stress
-    sigma = sigma.oldTime() + DSigmaTrial + sigma0();
+    sigma = deltaSigma_.oldTime() + DSigmaTrial + sigma0();
 
     // Take a reference to internal fields for efficiency
     symmTensorField& sigmaI = sigma;
@@ -705,7 +713,7 @@ void Foam::linearElasticMohrCoulombPlastic::correct(volSymmTensorField& sigma)
     deltaSigma_.storePrevIter();
 
     // Update the stress variation tensor
-    deltaSigma_ = sigma-sigma0();
+    deltaSigma_ = sigma - sigma0();
     // Note: if a poro-elasto-plastic law is used then the pore-pressure term
     // will be added to the effective stress after this
 }
@@ -779,10 +787,10 @@ void Foam::linearElasticMohrCoulombPlastic::correct
     // residual
     deltaSigmaf_.storePrevIter();
 
-    // Update the effective stress tensor
+    // Update the stress variation tensor
+    deltaSigmaf_ = sigma-sigma0f();
     // Note: if a poro-elasto-plastic law is used then the pore-pressure term
     // will be added after this
-    deltaSigmaf_ = sigma-sigma0f();
 }
 
 

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticMohrCoulombPlastic/linearElasticMohrCoulombPlastic.C
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticMohrCoulombPlastic/linearElasticMohrCoulombPlastic.C
@@ -576,6 +576,19 @@ Foam::linearElasticMohrCoulombPlastic::linearElasticMohrCoulombPlastic
         mesh,
         dimensionedScalar("zero", dimless, 0.0)
     ),
+    deltaSigma_
+    (
+        IOobject
+        (
+            "deltaSigma_",
+            mesh.time().timeName(),
+            mesh,
+            IOobject::NO_READ,
+            IOobject::NO_WRITE
+        ),
+        mesh,
+        dimensionedSymmTensor("zero", dimPressure, symmTensor::zero)
+    ),
     activeYield_
     (
         IOobject
@@ -689,10 +702,10 @@ void Foam::linearElasticMohrCoulombPlastic::correct(volSymmTensorField& sigma)
 
     // Store previous iteration of deltaSigma as it is used to calculate the
     // residual
-    deltaSigma().storePrevIter();
+    deltaSigma_.storePrevIter();
 
     // Update the stress variation tensor
-    deltaSigma() = sigma-sigma0();
+    deltaSigma_ = sigma-sigma0();
     // Note: if a poro-elasto-plastic law is used then the pore-pressure term
     // will be added to the effective stress after this
 }
@@ -811,19 +824,19 @@ Foam::scalar Foam::linearElasticMohrCoulombPlastic::residual()
             (
                 mag
                 (
-                    deltaSigma().primitiveField()
-                  - deltaSigma().prevIter().primitiveField()
+                    deltaSigma_.primitiveField()
+                  - deltaSigma_.prevIter().primitiveField()
                 )
-            )/gMax(SMALL + mag(deltaSigma().primitiveField()));
+            )/gMax(SMALL + mag(deltaSigma_.primitiveField()));
 #else
             gMax
             (
                 mag
                 (
-                    deltaSigma().internalField()
-                  - deltaSigma().prevIter().internalField()
+                    deltaSigma_.internalField()
+                  - deltaSigma_.prevIter().internalField()
                 )
-            )/gMax(SMALL + mag(deltaSigma().internalField()));
+            )/gMax(SMALL + mag(deltaSigma_.internalField()));
 #endif
     }
 }
@@ -848,7 +861,7 @@ void Foam::linearElasticMohrCoulombPlastic::updateTotalFields()
 #endif
 
     const symmTensorField& DEpsilonI = DEpsilon_;
-    const symmTensorField& deltaSigmaI = deltaSigma();
+    const symmTensorField& deltaSigmaI = deltaSigma_;
     const scalarField& activeYieldI = activeYield_;
     const scalar mu = mu_.value();
     const scalar lambda = lambda_.value();

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticMohrCoulombPlastic/linearElasticMohrCoulombPlastic.C
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticMohrCoulombPlastic/linearElasticMohrCoulombPlastic.C
@@ -610,9 +610,9 @@ Foam::linearElasticMohrCoulombPlastic::linearElasticMohrCoulombPlastic
     sigma0();
 
     // Check and warn for zero inital stress
-    if (gsum(mag(sigma0())).value()==0.0)
+    if (gSum(mag(sigma0())).value()==0.0)
     {
-        FoamWarningIn("linearElasticMohrCoulombPlastic") 
+        WarningIn("linearElasticMohrCoulombPlastic") 
         << "Initial stress is zero everywhere, "
         << "since Mohr-Coulomb material law is stress-state dependent, "
         << "this may lead to problems. Proceed with caution." << endl;

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticMohrCoulombPlastic/linearElasticMohrCoulombPlastic.C
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticMohrCoulombPlastic/linearElasticMohrCoulombPlastic.C
@@ -657,7 +657,7 @@ void Foam::linearElasticMohrCoulombPlastic::correct(volSymmTensorField& sigma)
     );
 
     // Set sigma to sigma effective trial, including the initial stress
-    sigma = deltaSigma().oldTime() + DSigmaTrial + sigma0();
+    sigma = sigma.oldTime() + DSigmaTrial + sigma0();
 
     // Take a reference to internal fields for efficiency
     symmTensorField& sigmaI = sigma;

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticMohrCoulombPlastic/linearElasticMohrCoulombPlastic.C
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticMohrCoulombPlastic/linearElasticMohrCoulombPlastic.C
@@ -610,7 +610,7 @@ Foam::linearElasticMohrCoulombPlastic::linearElasticMohrCoulombPlastic
     sigma0();
 
     // Check and warn for zero inital stress
-    if (gSum(mag(sigma0())).value() < SMALL)
+    if (sum(mag(sigma0())).value() < SMALL)
     {
         WarningIn("linearElasticMohrCoulombPlastic")
             << "Initial stress is zero everywhere, "

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticMohrCoulombPlastic/linearElasticMohrCoulombPlastic.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticMohrCoulombPlastic/linearElasticMohrCoulombPlastic.H
@@ -133,7 +133,7 @@ class linearElasticMohrCoulombPlastic
         const vector sigma_a_;
 
         //- Effective stress surface field
-        surfaceSymmTensorField sigmaEfff_;
+        surfaceSymmTensorField deltaSigmaf_;
 
         //- Incremental of strain
         volSymmTensorField DEpsilon_;

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticMohrCoulombPlastic/linearElasticMohrCoulombPlastic.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticMohrCoulombPlastic/linearElasticMohrCoulombPlastic.H
@@ -153,6 +153,10 @@ class linearElasticMohrCoulombPlastic
         //- Equivalent plastic strain
         volScalarField epsilonPEq_;
 
+        //- stress variation from initial (sigma = deltaSigma + sigma0), used in
+        //  some stress-state-dependent mechLaws for residual calculation
+        volSymmTensorField deltaSigma_;
+
         //- Active yielding flag
         //     1.0 for active yielding
         //     0.0 otherwise

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticMohrCoulombPlastic/linearElasticMohrCoulombPlastic.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticMohrCoulombPlastic/linearElasticMohrCoulombPlastic.H
@@ -132,7 +132,10 @@ class linearElasticMohrCoulombPlastic
         //- Derived plasticity parameter
         const vector sigma_a_;
 
-        //- Effective stress surface field
+        //- Stress variation from initial (sigma = deltaSigma + sigma0)
+        volSymmTensorField deltaSigma_;
+
+        //- Stress variation surface field
         surfaceSymmTensorField deltaSigmaf_;
 
         //- Incremental of strain
@@ -152,10 +155,6 @@ class linearElasticMohrCoulombPlastic
 
         //- Equivalent plastic strain
         volScalarField epsilonPEq_;
-
-        //- stress variation from initial (sigma = deltaSigma + sigma0), used in
-        //  some stress-state-dependent mechLaws for residual calculation
-        volSymmTensorField deltaSigma_;
 
         //- Active yielding flag
         //     1.0 for active yielding

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/poroMechanicalLaw/poroMechanicalLaw.C
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/poroMechanicalLaw/poroMechanicalLaw.C
@@ -44,7 +44,7 @@ namespace Foam
 
 bool Foam::poroMechanicalLaw::checkSigmaEffReady(const volSymmTensorField& sigma, const volScalarField& p)
 {
-    if (sigmaEff_)
+    if (sigmaEff_.valid())
     {
         return true;
     }
@@ -67,7 +67,7 @@ bool Foam::poroMechanicalLaw::checkSigmaEffReady(const volSymmTensorField& sigma
 
 bool Foam::poroMechanicalLaw::checkSigmaEffReady(const surfaceSymmTensorField& sigma, const surfaceScalarField& p)
 {
-    if (sigmaEfff_)
+    if (sigmaEfff_.valid())
     {
         return true;
     }

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/poroMechanicalLaw/poroMechanicalLaw.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/poroMechanicalLaw/poroMechanicalLaw.H
@@ -63,6 +63,12 @@ class poroMechanicalLaw
         //- Run-time selectable mechanical law to define the effective stress
         autoPtr<mechanicalLaw> effectiveStressMechLawPtr_;
 
+        //- effective stress
+        autoPtr<volSymmTensorField> sigmaEff_;
+
+        //- effective stress on surfaceMesh
+        autoPtr<surfaceSymmTensorField> sigmaEfff_;
+
         //- Biot's coefficient
         //  Optional coefficient to scalar the pressure contribution to the
         //  total stress. Defaults to 1.0.
@@ -84,6 +90,12 @@ class poroMechanicalLaw
 
     // Private Member Functions
 
+        //- check if sigmaEff has been initalized already
+        bool checkSigmaEffReady(const volSymmTensorField& sigma, const volScalarField& p);
+
+        //- check if sigmaEfff has been initalized already
+        bool checkSigmaEffReady(const surfaceSymmTensorField& sigma, const surfaceScalarField& p);
+        
         //- Make the initial pore-pressure surface field
         void makeP0f() const;
 

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/mechanicalLaw/mechanicalLaw.C
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/mechanicalLaw/mechanicalLaw.C
@@ -411,33 +411,6 @@ void Foam::mechanicalLaw::makeSigmaHyd()
 }
 
 
-void Foam::mechanicalLaw::makedeltaSigma()
-{
-    if (deltaSigmaPtr_.valid())
-    {
-        FatalErrorIn("void " + type() + "::makedeltaSigma()")
-            << "pointer already set" << abort(FatalError);
-    }
-
-    deltaSigmaPtr_.set
-    (
-        new volSymmTensorField
-        (
-            IOobject
-            (
-                "deltaSigma_",
-                mesh().time().timeName(),
-                mesh(),
-                IOobject::READ_IF_PRESENT,
-                IOobject::NO_WRITE
-            ),
-            mesh(),
-            dimensionedSymmTensor("zero", dimPressure, symmTensor::zero)
-        )
-    );
-}
-
-
 // * * * * * * * * * * * * * * Protected Members * * * * * * * * * * * * * * //
 
 bool Foam::mechanicalLaw::planeStress() const
@@ -823,17 +796,6 @@ Foam::volVectorField& Foam::mechanicalLaw::gradSigmaHyd()
     }
 
     return gradSigmaHydPtr_();
-}
-
-
-Foam::volSymmTensorField& Foam::mechanicalLaw::deltaSigma()
-{
-    if (deltaSigmaPtr_.empty())
-    {
-        makedeltaSigma();
-    }
-
-    return deltaSigmaPtr_();
 }
 
 
@@ -1355,7 +1317,6 @@ Foam::mechanicalLaw::mechanicalLaw
     ),
     sigmaHydPtr_(),
     gradSigmaHydPtr_(),
-    deltaSigmaPtr_(),
     curTimeIndex_(-1),
     warnAboutEnforceLinear_(true)
 {

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/mechanicalLaw/mechanicalLaw.C
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/mechanicalLaw/mechanicalLaw.C
@@ -411,25 +411,25 @@ void Foam::mechanicalLaw::makeSigmaHyd()
 }
 
 
-void Foam::mechanicalLaw::makeSigmaEff()
+void Foam::mechanicalLaw::makedeltaSigma()
 {
-    if (sigmaEffPtr_.valid())
+    if (deltaSigmaPtr_.valid())
     {
-        FatalErrorIn("void " + type() + "::makeSigmaEff()")
+        FatalErrorIn("void " + type() + "::makedeltaSigma()")
             << "pointer already set" << abort(FatalError);
     }
 
-    sigmaEffPtr_.set
+    deltaSigmaPtr_.set
     (
         new volSymmTensorField
         (
             IOobject
             (
-                "sigmaEff_",
+                "deltaSigma_",
                 mesh().time().timeName(),
                 mesh(),
                 IOobject::READ_IF_PRESENT,
-                IOobject::AUTO_WRITE
+                IOobject::NO_WRITE
             ),
             mesh(),
             dimensionedSymmTensor("zero", dimPressure, symmTensor::zero)
@@ -826,14 +826,14 @@ Foam::volVectorField& Foam::mechanicalLaw::gradSigmaHyd()
 }
 
 
-Foam::volSymmTensorField& Foam::mechanicalLaw::sigmaEff()
+Foam::volSymmTensorField& Foam::mechanicalLaw::deltaSigma()
 {
-    if (sigmaEffPtr_.empty())
+    if (deltaSigmaPtr_.empty())
     {
-        makeSigmaEff();
+        makedeltaSigma();
     }
 
-    return sigmaEffPtr_();
+    return deltaSigmaPtr_();
 }
 
 
@@ -1355,7 +1355,7 @@ Foam::mechanicalLaw::mechanicalLaw
     ),
     sigmaHydPtr_(),
     gradSigmaHydPtr_(),
-    sigmaEffPtr_(),
+    deltaSigmaPtr_(),
     curTimeIndex_(-1),
     warnAboutEnforceLinear_(true)
 {

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/mechanicalLaw/mechanicalLaw.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/mechanicalLaw/mechanicalLaw.H
@@ -138,12 +138,8 @@ class mechanicalLaw
         // Gradient of the hydrostatic stress field
         autoPtr<volVectorField> gradSigmaHydPtr_;
 
-        //- Effective stress (sigmaEff = sigma + p*I)
-        //  Where:
-        //      sigmaEff is the effective stress
-        //      sigma is the total stress
-        //      p is the pore pressure
-        autoPtr<volSymmTensorField> sigmaEffPtr_;
+        //- stress variation from initial (sigma = deltaSigma + sigma0), used in some stress-state-dependent mechLaws for residual calculation
+        autoPtr<volSymmTensorField> deltaSigmaPtr_;
 
         //- Current time index
         label curTimeIndex_;
@@ -193,8 +189,8 @@ class mechanicalLaw
         //- Make the sigmaHyd field
         void makeSigmaHyd();
 
-        //- Make the sigmaEff field
-        void makeSigmaEff();
+        //- Make the deltaSigma field
+        void makedeltaSigma();
 
         //- Disallow copy construct
         mechanicalLaw(const mechanicalLaw&);
@@ -316,8 +312,8 @@ protected:
         //- Return a reference to the gradSigmaHyd field
         volVectorField& gradSigmaHyd();
 
-        //- Return a reference to the sigmaEff field
-        volSymmTensorField& sigmaEff();
+        //- Return a reference to the deltaSigma field
+        volSymmTensorField& deltaSigma();
 
         //- Update epsilon
         void updateEpsilon();

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/mechanicalLaw/mechanicalLaw.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/mechanicalLaw/mechanicalLaw.H
@@ -138,9 +138,6 @@ class mechanicalLaw
         // Gradient of the hydrostatic stress field
         autoPtr<volVectorField> gradSigmaHydPtr_;
 
-        //- stress variation from initial (sigma = deltaSigma + sigma0), used in some stress-state-dependent mechLaws for residual calculation
-        autoPtr<volSymmTensorField> deltaSigmaPtr_;
-
         //- Current time index
         label curTimeIndex_;
 
@@ -188,9 +185,6 @@ class mechanicalLaw
 
         //- Make the sigmaHyd field
         void makeSigmaHyd();
-
-        //- Make the deltaSigma field
-        void makedeltaSigma();
 
         //- Disallow copy construct
         mechanicalLaw(const mechanicalLaw&);
@@ -311,9 +305,6 @@ protected:
 
         //- Return a reference to the gradSigmaHyd field
         volVectorField& gradSigmaHyd();
-
-        //- Return a reference to the deltaSigma field
-        volSymmTensorField& deltaSigma();
 
         //- Update epsilon
         void updateEpsilon();


### PR DESCRIPTION
renamed sigmaEff in mechLaw to deltaSigma,
added sigmaEff to poroMechlaw, and initialize it once at the start of the calculation from sigma and p

When using poroMechLaw with MohrCoulomb effective stress law, the effective stress should be calculated first, since the Mohr-Coulomb  Model depends on the current effective stress state! (It is mean effective pressure tr(sigmaEff) dependent)
Hence, the effective stress is calculated the first time it is needed as sigma+pI and then just saved for later use (next time step).

Since sigmaEff is most fittingly placed within poroMechLaw, I added it there.
I renamed the stress field in mechanicalLaw to deltaSigma, which represents the change of sigma from initial state.
This field is not nesseccarily needed, but since it's used to calculate the material residual in MohrCoulomb, I figured just renaming it is the least invasive option. It is lazyly evaluated anyways, only appearing when MohrCoulomb materialLaw is used.



