### PR TITLE
Replacing NamedEnum with Enum for OPENFOAM_COM

### DIFF
--- a/src/solids4FoamModels/solidModels/solidModel/nonLinearGeometry/nonLinearGeometry.C
+++ b/src/solids4FoamModels/solidModels/solidModel/nonLinearGeometry/nonLinearGeometry.C
@@ -1,19 +1,19 @@
 /*---------------------------------------------------------------------------*\
-License
-    This file is part of solids4foam.
+ License
+     This file is part of solids4foam.
 
-    solids4foam is free software: you can redistribute it and/or modify it
-    under the terms of the GNU General Public License as published by the
-    Free Software Foundation, either version 3 of the License, or (at your
-    option) any later version.
+     solids4foam is free software: you can redistribute it and/or modify it
+     under the terms of the GNU General Public License as published by the
+     Free Software Foundation, either version 3 of the License, or (at your
+     option) any later version.
 
-    solids4foam is distributed in the hope that it will be useful, but
-    WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    General Public License for more details.
+     solids4foam is distributed in the hope that it will be useful, but
+     WITHOUT ANY WARRANTY; without even the implied warranty of
+     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+     General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
-    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+     You should have received a copy of the GNU General Public License
+     along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
 
 \*---------------------------------------------------------------------------*/
 
@@ -26,6 +26,18 @@ namespace Foam
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
+#ifdef OPENFOAM_COM
+const Foam::Enum
+<
+    Foam::nonLinearGeometry::nonLinearType
+>
+Foam::NonLinearGeometry::nonLinearNames_;
+({
+    {nonLinearType::LINEAR_GEOMETRY, "linearGeometry"},
+    {nonLinearType::UPDATED_LAGRANGIAN, "updatedLagrangian"},
+    {nonLinearType::TOTAL_LAGRANGIAN, "totalLagrangian"},
+});
+#else
 template<>
 const char*
 Foam::NamedEnum<Foam::nonLinearGeometry::nonLinearType, 3>::names[] =
@@ -37,7 +49,7 @@ Foam::NamedEnum<Foam::nonLinearGeometry::nonLinearType, 3>::names[] =
 
 const Foam::NamedEnum<Foam::nonLinearGeometry::nonLinearType, 3>
 Foam::nonLinearGeometry::nonLinearNames_;
-
+#endif
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 

--- a/src/solids4FoamModels/solidModels/solidModel/nonLinearGeometry/nonLinearGeometry.C
+++ b/src/solids4FoamModels/solidModels/solidModel/nonLinearGeometry/nonLinearGeometry.C
@@ -1,19 +1,19 @@
 /*---------------------------------------------------------------------------*\
- License
-     This file is part of solids4foam.
+License
+    This file is part of solids4foam.
 
-     solids4foam is free software: you can redistribute it and/or modify it
-     under the terms of the GNU General Public License as published by the
-     Free Software Foundation, either version 3 of the License, or (at your
-     option) any later version.
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
 
-     solids4foam is distributed in the hope that it will be useful, but
-     WITHOUT ANY WARRANTY; without even the implied warranty of
-     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-     General Public License for more details.
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
 
-     You should have received a copy of the GNU General Public License
-     along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/solidModels/solidModel/nonLinearGeometry/nonLinearGeometry.H
+++ b/src/solids4FoamModels/solidModels/solidModel/nonLinearGeometry/nonLinearGeometry.H
@@ -1,19 +1,19 @@
 /*---------------------------------------------------------------------------*\
-License
-    This file is part of solids4foam.
+ License
+     This file is part of solids4foam.
 
-    solids4foam is free software: you can redistribute it and/or modify it
-    under the terms of the GNU General Public License as published by the
-    Free Software Foundation, either version 3 of the License, or (at your
-    option) any later version.
+     solids4foam is free software: you can redistribute it and/or modify it
+     under the terms of the GNU General Public License as published by the
+     Free Software Foundation, either version 3 of the License, or (at your
+     option) any later version.
 
-    solids4foam is distributed in the hope that it will be useful, but
-    WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    General Public License for more details.
+     solids4foam is distributed in the hope that it will be useful, but
+     WITHOUT ANY WARRANTY; without even the implied warranty of
+     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+     General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
-    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+     You should have received a copy of the GNU General Public License
+     along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
 
 Class
     nonLinearGeometry
@@ -35,7 +35,11 @@ SourceFiles
 #ifndef nonLinearGeometry_H
 #define nonLinearGeometry_H
 
+#ifdef OPENFOAM_COM
+#include "Enum.H"
+#else
 #include "NamedEnum.H"
+#endif
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
@@ -58,7 +62,11 @@ public:
             TOTAL_LAGRANGIAN
         };
 
+#ifdef OPENFOAM_COM
+        static const Enum<nonLinearType> nonLinearNames_;
+#else
         static const NamedEnum<nonLinearType, 3> nonLinearNames_;
+#endif
 };
 
 

--- a/src/solids4FoamModels/solidModels/solidModel/nonLinearGeometry/nonLinearGeometry.H
+++ b/src/solids4FoamModels/solidModels/solidModel/nonLinearGeometry/nonLinearGeometry.H
@@ -1,19 +1,19 @@
 /*---------------------------------------------------------------------------*\
- License
-     This file is part of solids4foam.
+License
+    This file is part of solids4foam.
 
-     solids4foam is free software: you can redistribute it and/or modify it
-     under the terms of the GNU General Public License as published by the
-     Free Software Foundation, either version 3 of the License, or (at your
-     option) any later version.
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
 
-     solids4foam is distributed in the hope that it will be useful, but
-     WITHOUT ANY WARRANTY; without even the implied warranty of
-     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-     General Public License for more details.
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
 
-     You should have received a copy of the GNU General Public License
-     along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
 
 Class
     nonLinearGeometry


### PR DESCRIPTION
NamedEnum is replaced with Enum to get rid of warning during application compilation:
```
warning: ‘template<class EnumType, int nEnum> class Foam::NamedEnum’ is depr
ecated: Since 2017-05; use "Foam::Enum" [-Wdeprecated-declarations]
```

To get this warning, a compiled app needs to have `#include solidModel.H`