### PR TITLE
Make denom always displacement increment in solidModel::converged

### DIFF
--- a/src/solids4FoamModels/solidModels/solidModel/solidModelTemplates.C
+++ b/src/solids4FoamModels/solidModels/solidModel/solidModelTemplates.C
@@ -47,34 +47,31 @@ bool Foam::solidModel::converged
     {
         // Incremental approach
         denom = gMax
-            (
+        (
 #ifdef OPENFOAM_NOT_EXTEND
-                DimensionedField<scalar, volMesh>
+            DimensionedField<scalar, volMesh>
 #else
-                Field<scalar>
+            Field<scalar>
 #endif
-                (
+            (
                     mag(vf.internalField())
-                )
-            );
-
-        Info<< "Taking incremental approach" << denom << endl;
+            )
+        );
     }
     else
     {
         // Total appraoch
         denom = gMax
-            (
+        (
 #ifdef OPENFOAM_NOT_EXTEND
-                DimensionedField<scalar, volMesh>
+            DimensionedField<scalar, volMesh>
 #else
-                Field<scalar>
+            Field<scalar>
 #endif
-                (
-                    mag(vf.internalField() - vf.oldTime().internalField())
-                )
-            );
-        Info << "taking total appriach" << endl;
+            (
+                mag(vf.internalField() - vf.oldTime().internalField())
+            )
+        );
     }
 
     if (denom < SMALL)
@@ -92,7 +89,6 @@ bool Foam::solidModel::converged
             SMALL
         );
     }
-Info<<denom<<endl;
     const scalar residualvf =
         gMax
         (

--- a/src/solids4FoamModels/solidModels/solidModel/solidModelTemplates.C
+++ b/src/solids4FoamModels/solidModels/solidModel/solidModelTemplates.C
@@ -40,17 +40,43 @@ bool Foam::solidModel::converged
     bool converged = false;
 
     // Calculate displacement residual based on the relative change of vf
-    scalar denom = gMax
-    (
+    scalar denom = 0.0;
+
+    // Denom is displacement increment
+    if(incremental())
+    {
+        // Incremental approach
+        denom = gMax
+            (
 #ifdef OPENFOAM_NOT_EXTEND
-        DimensionedField<scalar, volMesh>
+                DimensionedField<scalar, volMesh>
 #else
-        Field<scalar>
+                Field<scalar>
 #endif
-        (
-            mag(vf.internalField() - vf.oldTime().internalField())
-        )
-    );
+                (
+                    mag(vf.internalField())
+                )
+            );
+
+        Info<< "Taking incremental approach" << denom << endl;
+    }
+    else
+    {
+        // Total appraoch
+        denom = gMax
+            (
+#ifdef OPENFOAM_NOT_EXTEND
+                DimensionedField<scalar, volMesh>
+#else
+                Field<scalar>
+#endif
+                (
+                    mag(vf.internalField() - vf.oldTime().internalField())
+                )
+            );
+        Info << "taking total appriach" << endl;
+    }
+
     if (denom < SMALL)
     {
         denom = max
@@ -66,6 +92,7 @@ bool Foam::solidModel::converged
             SMALL
         );
     }
+Info<<denom<<endl;
     const scalar residualvf =
         gMax
         (

--- a/src/solids4FoamModels/solidModels/solidModel/solidModelTemplates.C
+++ b/src/solids4FoamModels/solidModels/solidModel/solidModelTemplates.C
@@ -43,7 +43,7 @@ bool Foam::solidModel::converged
     scalar denom = 0.0;
 
     // Denom is displacement increment
-    if(incremental())
+    if (incremental())
     {
         // Incremental approach
         denom = gMax
@@ -54,7 +54,7 @@ bool Foam::solidModel::converged
             Field<scalar>
 #endif
             (
-                    mag(vf.internalField())
+                mag(vf.internalField())
             )
         );
     }

--- a/tutorials/solids/linearElasticity/pressurisedCylinder/0/D
+++ b/tutorials/solids/linearElasticity/pressurisedCylinder/0/D
@@ -33,7 +33,7 @@ boundaryField
     inner-wall
     {
         type            solidTraction;
-		traction		uniform (0 0 0);
+	traction	uniform (0 0 0);
         pressureSeries
         {
             "fileName|file"    "$FOAM_CASE/constant/timeVsPressure";
@@ -44,17 +44,21 @@ boundaryField
     outer-wall
     {
         type            solidTraction;
-		traction		uniform (0 0 0);
-        pressure		uniform 0;
+	traction	uniform (0 0 0);
+        pressure	uniform 0;
         value           uniform (0 0 0);
     }
     symmetry-x
     {
-        type             	symmetryPlane;	
+        type            solidSymmetry;
+        patchType       symmetryPlane;
+        value           uniform (0 0 0);
     }
     symmetry-y
     {
-        type             	symmetryPlane;	
+        type            solidSymmetry;
+        patchType       symmetryPlane;
+        value           uniform (0 0 0);
     }
 }
 


### PR DESCRIPTION
In the case of incremental solvers, the relative residual is less prone to show values above 1 if the denom is the increment of displacement instead of the increment of the displacement increment.