### PR TITLE
Hint where the test logs are

### DIFF
--- a/tutorials/Alltest
+++ b/tutorials/Alltest
@@ -269,6 +269,8 @@ then
         grep "ERROR" testLoopReport
         echo
     fi
+    echo "The tests were executed in $TEST_RUN_DIR. You can find logs there."
+    echo
     exit 1
 else
     echo "All tests passed: enjoy solids4foam."


### PR DESCRIPTION
Some tests were failing for me, but it took me a bit to understand where the logs were. I think such an information message would help.

I have not tried to run the updated script yet, but it should be a straight-forward change. shellcheck does not complain about this line.

I hope that `development` is the right target branch (there seems to be no `CONTRIBUTING.md` or similar page in the documentation).

This is in the context of my review for the JOSS publication (https://github.com/openjournals/joss-reviews/issues/7407).