### PR TITLE
Update preCICE configuration files to v3

### DIFF
--- a/tutorials/fluidSolidInteraction-preCICE/3dTube/precice-config.xml
+++ b/tutorials/fluidSolidInteraction-preCICE/3dTube/precice-config.xml
@@ -7,64 +7,58 @@
       enabled="true" />
   </log>
 
-  <solver-interface dimensions="3">
-    <data:vector name="Force" />
-    <data:vector name="Displacement" />
+  <data:vector name="Force" />
+  <data:vector name="Displacement" />
 
-    <mesh name="Fluid-Mesh">
-      <use-data name="Force" />
-      <use-data name="Displacement" />
-    </mesh>
+  <mesh name="Fluid-Mesh" dimensions="3">
+    <use-data name="Force" />
+    <use-data name="Displacement" />
+  </mesh>
 
-    <mesh name="Solid-Mesh">
-      <use-data name="Displacement" />
-      <use-data name="Force" />
-    </mesh>
+  <mesh name="Solid-Mesh" dimensions="3">
+    <use-data name="Displacement" />
+    <use-data name="Force" />
+  </mesh>
 
-    <participant name="Fluid">
-      <use-mesh name="Fluid-Mesh" provide="yes" />
-      <use-mesh name="Solid-Mesh" from="Solid" />
-      <write-data name="Force" mesh="Fluid-Mesh" />
-      <read-data name="Displacement" mesh="Fluid-Mesh" />
-      <mapping:rbf-thin-plate-splines
-        direction="write"
-        from="Fluid-Mesh"
-        to="Solid-Mesh"
-        constraint="conservative" />
-      <mapping:rbf-thin-plate-splines
-        direction="read"
-        from="Solid-Mesh"
-        to="Fluid-Mesh"
-        constraint="consistent" />
-    </participant>
+  <participant name="Fluid">
+    <provide-mesh name="Fluid-Mesh" />
+    <receive-mesh name="Solid-Mesh" from="Solid" />
+    <write-data name="Force" mesh="Fluid-Mesh" />
+    <read-data name="Displacement" mesh="Fluid-Mesh" />
+    <mapping:rbf direction="write" from="Fluid-Mesh" to="Solid-Mesh" constraint="conservative">
+      <basis-function:thin-plate-splines />
+    </mapping:rbf >
+    <mapping:rbf direction="read" from="Solid-Mesh" to="Fluid-Mesh" constraint="consistent">
+      <basis-function:thin-plate-splines />
+    </mapping:rbf >
+  </participant>
 
-    <participant name="Solid">
-      <use-mesh name="Solid-Mesh" provide="yes" />
-      <write-data name="Displacement" mesh="Solid-Mesh" />
-      <read-data name="Force" mesh="Solid-Mesh" />
-      <watch-point mesh="Solid-Mesh" name="Flap-Tip" coordinate="0.0;0.005;0.025" />
-    </participant>
+  <participant name="Solid">
+    <provide-mesh name="Solid-Mesh" />
+    <write-data name="Displacement" mesh="Solid-Mesh" />
+    <read-data name="Force" mesh="Solid-Mesh" />
+    <watch-point mesh="Solid-Mesh" name="Flap-Tip" coordinate="0.0;0.005;0.025" />
+  </participant>
 
-    <m2n:sockets from="Fluid" to="Solid" exchange-directory=".." />
+  <m2n:sockets acceptor="Fluid" connector="Solid" exchange-directory=".." />
 
-    <coupling-scheme:parallel-implicit>
-      <time-window-size value="2.5e-5" />
-      <max-time value="0.02" />
-      <participants first="Fluid" second="Solid" />
-      <exchange data="Force" mesh="Solid-Mesh" from="Fluid" to="Solid" />
-      <exchange data="Displacement" mesh="Solid-Mesh" from="Solid" to="Fluid" />
-      <max-iterations value="100" />
-      <relative-convergence-measure limit="1e-6" data="Displacement" mesh="Solid-Mesh" />
-      <relative-convergence-measure limit="1e-3" data="Force" mesh="Solid-Mesh" />
-      <acceleration:IQN-ILS>
-        <data name="Displacement" mesh="Solid-Mesh" />
-        <data name="Force" mesh="Solid-Mesh" />
-        <preconditioner type="residual-sum" />
-        <filter type="QR2" limit="1e-2" />
-        <initial-relaxation value="0.5" />
-        <max-used-iterations value="100" />
-        <time-windows-reused value="15" />
-      </acceleration:IQN-ILS>
-    </coupling-scheme:parallel-implicit>
-  </solver-interface>
+  <coupling-scheme:parallel-implicit>
+    <time-window-size value="2.5e-5" />
+    <max-time value="0.02" />
+    <participants first="Fluid" second="Solid" />
+    <exchange data="Force" mesh="Solid-Mesh" from="Fluid" to="Solid" />
+    <exchange data="Displacement" mesh="Solid-Mesh" from="Solid" to="Fluid" />
+    <max-iterations value="100" />
+    <relative-convergence-measure limit="1e-6" data="Displacement" mesh="Solid-Mesh" />
+    <relative-convergence-measure limit="1e-3" data="Force" mesh="Solid-Mesh" />
+    <acceleration:IQN-ILS>
+      <data name="Displacement" mesh="Solid-Mesh" />
+      <data name="Force" mesh="Solid-Mesh" />
+      <preconditioner type="residual-sum" />
+      <filter type="QR2" limit="1e-2" />
+      <initial-relaxation value="0.5" />
+      <max-used-iterations value="100" />
+      <time-windows-reused value="15" />
+    </acceleration:IQN-ILS>
+  </coupling-scheme:parallel-implicit>
 </precice-configuration>

--- a/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/precice-config.xml
+++ b/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/precice-config.xml
@@ -7,63 +7,57 @@
       enabled="true" />
   </log>
 
-  <solver-interface dimensions="2">
-    <data:vector name="Force" />
-    <data:vector name="Displacement" />
+  <data:vector name="Force" />
+  <data:vector name="Displacement" />
 
-    <mesh name="Fluid-Mesh">
-      <use-data name="Force" />
-      <use-data name="Displacement" />
-    </mesh>
+  <mesh name="Fluid-Mesh" dimensions="2">
+    <use-data name="Force" />
+    <use-data name="Displacement" />
+  </mesh>
 
-    <mesh name="Solid-Mesh">
-      <use-data name="Displacement" />
-      <use-data name="Force" />
-    </mesh>
+  <mesh name="Solid-Mesh" dimensions="2">
+    <use-data name="Displacement" />
+    <use-data name="Force" />
+  </mesh>
 
-    <participant name="Fluid">
-      <use-mesh name="Fluid-Mesh" provide="yes" />
-      <use-mesh name="Solid-Mesh" from="Solid" />
-      <write-data name="Force" mesh="Fluid-Mesh" />
-      <read-data name="Displacement" mesh="Fluid-Mesh" />
-      <mapping:rbf-thin-plate-splines
-        direction="write"
-        from="Fluid-Mesh"
-        to="Solid-Mesh"
-        constraint="conservative" />
-      <mapping:rbf-thin-plate-splines
-        direction="read"
-        from="Solid-Mesh"
-        to="Fluid-Mesh"
-        constraint="consistent" />
-    </participant>
+  <participant name="Fluid">
+    <provide-mesh name="Fluid-Mesh" />
+    <receive-mesh name="Solid-Mesh" from="Solid" />
+    <write-data name="Force" mesh="Fluid-Mesh" />
+    <read-data name="Displacement" mesh="Fluid-Mesh" />
+    <mapping:rbf direction="write" from="Fluid-Mesh" to="Solid-Mesh" constraint="conservative" >
+      <basis-function:thin-plate-splines />
+    </mapping:rbf>
+    <mapping:rbf direction="read" from="Solid-Mesh" to="Fluid-Mesh" constraint="consistent" >
+      <basis-function:thin-plate-splines />
+    </mapping:rbf>
+  </participant>
 
-    <participant name="Solid">
-      <use-mesh name="Solid-Mesh" provide="yes" />
-      <write-data name="Displacement" mesh="Solid-Mesh" />
-      <read-data name="Force" mesh="Solid-Mesh" />
-    </participant>
+  <participant name="Solid">
+    <provide-mesh name="Solid-Mesh" />
+    <write-data name="Displacement" mesh="Solid-Mesh" />
+    <read-data name="Force" mesh="Solid-Mesh" />
+  </participant>
 
-    <m2n:sockets from="Fluid" to="Solid" exchange-directory=".." />
+  <m2n:sockets acceptor="Fluid" connector="Solid" exchange-directory=".." />
 
-    <coupling-scheme:parallel-implicit>
-      <time-window-size value="0.005" />
-      <max-time value="2" />
-      <participants first="Fluid" second="Solid" />
-      <exchange data="Force" mesh="Solid-Mesh" from="Fluid" to="Solid" />
-      <exchange data="Displacement" mesh="Solid-Mesh" from="Solid" to="Fluid" />
-      <max-iterations value="100" />
-      <relative-convergence-measure limit="5e-3" data="Displacement" mesh="Solid-Mesh" />
-      <relative-convergence-measure limit="5e-3" data="Force" mesh="Solid-Mesh" />
-      <acceleration:IQN-ILS>
-        <data name="Displacement" mesh="Solid-Mesh" />
-        <data name="Force" mesh="Solid-Mesh" />
-        <preconditioner type="residual-sum" />
-        <filter type="QR2" limit="1e-2" />
-        <initial-relaxation value="0.5" />
-        <max-used-iterations value="100" />
-        <time-windows-reused value="15" />
-      </acceleration:IQN-ILS>
-    </coupling-scheme:parallel-implicit>
-  </solver-interface>
+  <coupling-scheme:parallel-implicit>
+    <time-window-size value="0.005" />
+    <max-time value="2" />
+    <participants first="Fluid" second="Solid" />
+    <exchange data="Force" mesh="Solid-Mesh" from="Fluid" to="Solid" />
+    <exchange data="Displacement" mesh="Solid-Mesh" from="Solid" to="Fluid" />
+    <max-iterations value="100" />
+    <relative-convergence-measure limit="5e-3" data="Displacement" mesh="Solid-Mesh" />
+    <relative-convergence-measure limit="5e-3" data="Force" mesh="Solid-Mesh" />
+    <acceleration:IQN-ILS>
+      <data name="Displacement" mesh="Solid-Mesh" />
+      <data name="Force" mesh="Solid-Mesh" />
+      <preconditioner type="residual-sum" />
+      <filter type="QR2" limit="1e-2" />
+      <initial-relaxation value="0.5" />
+      <max-used-iterations value="100" />
+      <time-windows-reused value="15" />
+    </acceleration:IQN-ILS>
+  </coupling-scheme:parallel-implicit>
 </precice-configuration>

--- a/tutorials/fluidSolidInteraction/3dTube/README.md
+++ b/tutorials/fluidSolidInteraction/3dTube/README.md
@@ -49,7 +49,7 @@ In this tutorial, we will compare six variants of the approaches above:
 3. **Dirichlet-Neumann formulation with Aitken's acceleration and a weakly compressible fluid model**: We use the `sonicLiquidFluid` fluid model.
 4. **Dirichlet-Neumann formulation with IQNILS acceleration and a weakly compressible fluid model**: We use the `sonicLiquidFluid` fluid model.
 5. **Robin-Neumann formulation with an incompressible fluid**: Support for this approach is implemented in the `pimpleFluid` model, where we apply special interface boundary conditions: `elasticWallPressure` for the fluid pressure field; and `elasticWallVelocity` for the fluid velocity field. 
-6. **Dirichlet-Neumann formulation with Aitken's acceleration and an incompressible fluid model using preCICE**: This approach is the same as approach 1, except the [preCICE](http://precice.org) coupling implementation is used. preCICE is an open-source coupling library for partitioned multi-physics simulations. In this case, `solids4Foam` is used as the solid solver, and standard `pimpleFoam` is used as the fluid solver (as opposed to solids4foam's `pimpleFluid` fluid model). Due to implementation differences, this preCICE IQNILS approach may perform differently than the built-in solids4foam approach.
+6. **Dirichlet-Neumann formulation with IQNILS acceleration and an incompressible fluid model using preCICE**: This approach is the same as approach 1, except the [preCICE](http://precice.org) coupling implementation is used. preCICE is an open-source coupling library for partitioned multi-physics simulations. In this case, `solids4Foam` is used as the solid solver, and standard `pimpleFoam` is used as the fluid solver (as opposed to solids4foam's `pimpleFluid` fluid model). Due to implementation differences, this preCICE IQNILS approach may perform differently than the built-in solids4foam approach.
 
 In all approaches, the solid domain setup is exactly the same, where an incremental small strain formulation is used (the `linearGeometry` solid model). One-quarter of the tube's cross-section is considered, although the case could actually be modelled as 2-D axisymmetric. The test is run for 0.02 s. A relatively tight FSI loop tolerance of 1e-6 is used for all approaches based on the interface motion. For approach 6 (preCICE), the relative displacement tolerance was set to 1e-6, and the relative force tolerance was set to 1e-3.
 
@@ -84,7 +84,7 @@ Initially, we compare the solutions using a relatively large time step size of 1
 - WC-DNF-Aitken: Dirichlet-Neumann formulation with Aitken's acceleration and a weakly compressible fluid model;
 - WC-DNF-IQNILS: Dirichlet-Neumann formulation with IQNILS acceleration and a weakly compressible fluid model;
 - RNF: Robin-Neumann formulation with an incompressible fluid;
-- preCICE-DN-IQNILS: Dirichlet-Neumann formulation with Aitken's acceleration and an incompressible fluid model using preCICE.
+- preCICE-DN-IQNILS: Dirichlet-Neumann formulation with IQNILS acceleration and an incompressible fluid model using preCICE.
 
 ![](./images/axial-displacement-deltaT1e-4.png)
 


### PR DESCRIPTION
Since I have the latest preCICE version installed on my system, the tests were executed on my system (instead of skipped), but failing, since they were made for preCICE v2 (not supported anymore).

Following the [porting guide](https://precice.org/couple-your-code-porting-v2-3.html), I updated the preCICE configuration files for the preCICE-related tutorials to v3. All the tests are now passing.

I also took the chance to update two I believe typos in one of the tutorials, where it was stated that the preCICE test was running with Aitken, but I understand from the configuration that that was IQN-ILS. Please double-check.

Note that the CI workflows cannot test this PR, as none of the respective [Docker images](https://github.com/solids4foam/solids4foam/tree/master/.docker)) includes preCICE. I am happy to help there, if requested.

This is in the context of my review for the JOSS publication (https://github.com/openjournals/joss-reviews/issues/7407).