### PR TITLE
Fixes and hints related to the optional file fixes

### DIFF
--- a/Allwmake
+++ b/Allwmake
@@ -26,7 +26,8 @@ if [[ $N_FIXES -gt 0 ]]
 then
     echo "** ERROR with optionalFixes **"
     echo "Please make the file replacements described above, or skip these "
-    echo "checks by setting 'export S4F_NO_FILE_FIXES=1'"; echo
+    echo "checks by setting 'export S4F_NO_FILE_FIXES=1'."
+    echo "Read more details on https://www.solids4foam.com/installation/optionalFixes/"; echo
     exit 1
 fi
 

--- a/Allwmake
+++ b/Allwmake
@@ -25,8 +25,8 @@ N_FIXES=$(grep "PLEASE FIX THIS" optionalFixes/log.Allcheck | wc -l)
 if [[ $N_FIXES -gt 0 ]]
 then
     echo "** ERROR with optionalFixes **"
-    echo "Please make the file replacements described above, or skip these "
-    echo "checks by setting 'export S4F_NO_FILE_FIXES=1'."
+    echo "Please make the file replacements described above and rebuild OpenFOAM,"
+    echo "or skip these checks by setting 'export S4F_NO_FILE_FIXES=1'."
     echo "Read more details on https://www.solids4foam.com/installation/optionalFixes/"; echo
     exit 1
 fi

--- a/optionalFixes/Allcheck
+++ b/optionalFixes/Allcheck
@@ -27,6 +27,7 @@ checkAndReport()
         echo
         echo "******** PLEASE FIX THIS ***********"
         echo "You should replace the file '${3}/${2}' with 'optionalFixes/${1}/${2}'"
+        echo "and re-build the library '${4}'."
         echo
         echo "You can do it by running the following commands:"
         echo "    cp optionalFixes/${1}/${2} ${3}/"

--- a/optionalFixes/README.md
+++ b/optionalFixes/README.md
@@ -6,7 +6,7 @@ sort: 1
 
 As described below, there are different optional fixes depending on whether you are using OpenFOAM.org, OpenFOAM.com, or foam-extend.
 
-## OpenFOAM.com
+## OpenFOAM.org
 
   * `GeometricField.C`: this fix is required for consistent time discretisation. Some FSI cases may crash without this fix.
 


### PR DESCRIPTION
1. The [documentation page](https://www.solids4foam.com/installation/optionalFixes/) includes a typo, leading to two sections for OpenFOAM.com and none for OpenFOAM.org. This PR fixes that.
2. The `Allwmake` script suggests to edit or skip, but does not explain what would one miss by skipping. This PR adds a link to the documentation where this is explained. Sure, the URL could eventually get out of date, but I think it helps more being there than not.
3. The `Allcheck` script suggests to copy the files and then later also asks to rebuild a library. This PR adds a hint earlier that this is also required.

It actually happened to me that I started following the suggestions, I went ahead and copied with `sudo` (I have OpenFOAM installed via APT on Ubuntu), and then I aborted when I realized that I also needed to build parts of OpenFOAM again, which would have been complicated in my case. I then needed to revert my change (by re-installing the OpenFOAM package). I think that by hinting earlier, including the path, one would notice sooner that this might not be easy.

This is in the context of my review for the JOSS publication (https://github.com/openjournals/joss-reviews/issues/7407).
