### PR TITLE
Link to tutorial files (featured tutorials)

### DIFF
--- a/tutorials/fluidSolidInteraction/3dTube/README.md
+++ b/tutorials/fluidSolidInteraction/3dTube/README.md
@@ -4,6 +4,8 @@ sort: 4
 
 # My fourth tutorial: `3dTube`
 
+You can find the files for this tutorial under [`tutorials/fluidSolidInteraction/3dTube`](https://github.com/solids4foam/solids4foam/tree/master/tutorials/fluidSolidInteraction/3dTube).
+
 ---
 
 ## Tutorial Aims

--- a/tutorials/fluidSolidInteraction/beamInCrossFlow/README.md
+++ b/tutorials/fluidSolidInteraction/beamInCrossFlow/README.md
@@ -4,6 +4,8 @@ sort: 3
 
 # My third tutorial: `beamInCrossFlow`
 
+You can find the files for this tutorial under [`tutorials/fluidSolidInteraction/beamInCrossFlow`](https://github.com/solids4foam/solids4foam/tree/master/tutorials/fluidSolidInteraction/beamInCrossFlow).
+
 ---
 
 ## Tutorial Aims

--- a/tutorials/fluids/cylinderInChannel/README.md
+++ b/tutorials/fluids/cylinderInChannel/README.md
@@ -4,6 +4,8 @@ sort: 2
 
 # My second tutorial: `cylinderInChannel`
 
+You can find the files for this tutorial under [`tutorials/fluids/cylinderInChannel`](https://github.com/solids4foam/solids4foam/tree/master/tutorials/fluids/cylinderInChannel).
+
 ---
 
 ## Tutorial Aims

--- a/tutorials/solids/thermoelasticity/hotSphere/README.md
+++ b/tutorials/solids/thermoelasticity/hotSphere/README.md
@@ -4,6 +4,8 @@ sort: 1
 
 # My first tutorial: `hotSphere`
 
+You can find the files for this tutorial under [`tutorials/solids/thermoelasticity/hotSphere`](https://github.com/solids4foam/solids4foam/tree/master/tutorials/solids/thermoelasticity/hotSphere).
+
 ---
 
 ## Tutorial Aims


### PR DESCRIPTION
If one looks at the tutorials on the website, it is not clear where to find the respective files. This is a side-effect of the (good) practice of sourcing the content of each page directly from each tutorial folder.

This PR adds a link at the beginning of the four featured tutorials.
There are many more tutorials, but I guess this is already something helpful for the user to navigate, especially in the beginning.

This is in the context of my review for the JOSS publication (https://github.com/openjournals/joss-reviews/issues/7407).