### PR TITLE
Refactor update deprecated keywords

### DIFF
--- a/src/solids4FoamModels/functionObjects/hydrostaticPressure/hydrostaticPressure.H
+++ b/src/solids4FoamModels/functionObjects/hydrostaticPressure/hydrostaticPressure.H
@@ -35,7 +35,7 @@ Description
 
         // Where to load it from (if not already in solver)
         // Note: this is not required if the solver already loads this library.
-        functionObjectLibs ("libsolids4FoamModels.so");
+        libs ("libsolids4FoamModels.so");
 
         // Optional: specifiy mesh region for multi-region solvers, defaults to
         // region0

--- a/src/solids4FoamModels/functionObjects/principalStresses/principalStresses.H
+++ b/src/solids4FoamModels/functionObjects/principalStresses/principalStresses.H
@@ -40,7 +40,7 @@ Description
 
         // Where to load it from (if not already in solver)
         // Note: this is not required if the solver already loads this library.
-        functionObjectLibs ("libsolids4FoamModels.so");
+        libs ("libsolids4FoamModels.so");
 
         // Optional: specifiy mesh region for multi-region solvers, defaults to
         // region0

--- a/src/solids4FoamModels/functionObjects/stressTriaxiality/stressTriaxiality.H
+++ b/src/solids4FoamModels/functionObjects/stressTriaxiality/stressTriaxiality.H
@@ -30,7 +30,7 @@ Description
 
         // Where to load it from (if not already in solver)
         // Note: this is not required if the solver already loads this library.
-        functionObjectLibs ("libsolids4FoamModels.so");
+        libs ("libsolids4FoamModels.so");
 
         // Optional: specifiy mesh region for multi-region solvers, defaults to
         // region0

--- a/src/solids4FoamModels/functionObjects/volumetricStrain/volumetricStrain.H
+++ b/src/solids4FoamModels/functionObjects/volumetricStrain/volumetricStrain.H
@@ -31,7 +31,7 @@ Description
 
         // Where to load it from (if not already in solver)
         // Note: this is not required if the solver already loads this library.
-        functionObjectLibs ("libsolids4FoamModels.so");
+        libs ("libsolids4FoamModels.so");
 
         // Optional: specifiy mesh region for multi-region solvers, defaults to
         // region0

--- a/tutorials/fluidSolidInteraction-preCICE/3dTube/fluid/constant/polyMesh/blockMeshDict
+++ b/tutorials/fluidSolidInteraction-preCICE/3dTube/fluid/constant/polyMesh/blockMeshDict
@@ -16,7 +16,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/fluidSolidInteraction-preCICE/3dTube/fluid/system/controlDict
+++ b/tutorials/fluidSolidInteraction-preCICE/3dTube/fluid/system/controlDict
@@ -54,8 +54,8 @@ functions
     {
         type                forces;
         "libs|functionObjectLibs" ( "libforces.so" );
-        outputControl       timeStep;
-        outputInterval      1;
+        writeControl        timeStep;
+        writeInterval       1;
         patches             (wall);
         "pName|p"           p;
         "UName|U"           U;

--- a/tutorials/fluidSolidInteraction-preCICE/3dTube/fluid/system/controlDict
+++ b/tutorials/fluidSolidInteraction-preCICE/3dTube/fluid/system/controlDict
@@ -53,7 +53,7 @@ functions
     forces
     {
         type                forces;
-        "libs|functionObjectLibs" ( "libforces.so" );
+        libs                ( "libforces.so" );
         writeControl        timeStep;
         writeInterval       1;
         patches             (wall);

--- a/tutorials/fluidSolidInteraction-preCICE/3dTube/solid/constant/polyMesh/blockMeshDict
+++ b/tutorials/fluidSolidInteraction-preCICE/3dTube/solid/constant/polyMesh/blockMeshDict
@@ -16,7 +16,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/solid/system/blockMeshDict
+++ b/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/solid/system/blockMeshDict
@@ -16,7 +16,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/fluidSolidInteraction/3dTube/constant/fluid/polyMesh/blockMeshDict
+++ b/tutorials/fluidSolidInteraction/3dTube/constant/fluid/polyMesh/blockMeshDict
@@ -16,7 +16,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/fluidSolidInteraction/3dTube/constant/solid/polyMesh/blockMeshDict
+++ b/tutorials/fluidSolidInteraction/3dTube/constant/solid/polyMesh/blockMeshDict
@@ -16,7 +16,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/fluidSolidInteraction/3dTube/system/controlDict
+++ b/tutorials/fluidSolidInteraction/3dTube/system/controlDict
@@ -65,8 +65,8 @@ functions
     {
         type                forces;
         "libs|functionObjectLibs" ( "libforces.so" );
-        outputControl       timeStep;
-        outputInterval      1;
+        writeControl        timeStep;
+        writeInterval       1;
         patches             (wall);
         "pName|p"           p;
         "UName|U"           U;

--- a/tutorials/fluidSolidInteraction/3dTube/system/controlDict
+++ b/tutorials/fluidSolidInteraction/3dTube/system/controlDict
@@ -64,7 +64,7 @@ functions
     forces
     {
         type                forces;
-        "libs|functionObjectLibs" ( "libforces.so" );
+        libs                ( "libforces.so" );
         writeControl        timeStep;
         writeInterval       1;
         patches             (wall);

--- a/tutorials/fluidSolidInteraction/HronTurekFsi3/constant/fluid/polyMesh/blockMeshDict
+++ b/tutorials/fluidSolidInteraction/HronTurekFsi3/constant/fluid/polyMesh/blockMeshDict
@@ -16,7 +16,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 0.001;
+scale 0.001;
 
 vertices
 (

--- a/tutorials/fluidSolidInteraction/HronTurekFsi3/constant/solid/polyMesh/blockMeshDict
+++ b/tutorials/fluidSolidInteraction/HronTurekFsi3/constant/solid/polyMesh/blockMeshDict
@@ -16,7 +16,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 0.001;
+scale 0.001;
 
 vertices
 (

--- a/tutorials/fluidSolidInteraction/HronTurekFsi3/system/functions
+++ b/tutorials/fluidSolidInteraction/HronTurekFsi3/system/functions
@@ -10,8 +10,8 @@ functions
    {
        type                forces;
        functionObjectLibs  ( "libforces.so" );
-       outputControl       timeStep;
-       outputInterval      1;
+       writeControl        timeStep;
+       writeInterval       1;
        patches             (plate);
        "pName|p"           p;
        "UName|U"           U;

--- a/tutorials/fluidSolidInteraction/HronTurekFsi3/system/functions
+++ b/tutorials/fluidSolidInteraction/HronTurekFsi3/system/functions
@@ -9,7 +9,7 @@ functions
    forces
    {
        type                forces;
-       functionObjectLibs  ( "libforces.so" );
+       libs                ( "libforces.so" );
        writeControl        timeStep;
        writeInterval       1;
        patches             (plate);

--- a/tutorials/fluidSolidInteraction/HronTurekFsi3/system/functions.openfoam
+++ b/tutorials/fluidSolidInteraction/HronTurekFsi3/system/functions.openfoam
@@ -10,8 +10,8 @@ functions
    {
        type                forces;
        functionObjectLibs  ( "libforces.so" );
-       outputControl       timeStep;
-       outputInterval      1;
+       writeControl        timeStep;
+       writeInterval       1;
        patches             (plate);
        "pName|p"           p;
        "UName|U"           U;

--- a/tutorials/fluidSolidInteraction/HronTurekFsi3/system/functions.openfoam
+++ b/tutorials/fluidSolidInteraction/HronTurekFsi3/system/functions.openfoam
@@ -9,7 +9,7 @@ functions
    forces
    {
        type                forces;
-       functionObjectLibs  ( "libforces.so" );
+       libs                ( "libforces.so" );
        writeControl        timeStep;
        writeInterval       1;
        patches             (plate);

--- a/tutorials/fluidSolidInteraction/beamInCrossFlow/constant/fluid/polyMesh/blockMeshDict
+++ b/tutorials/fluidSolidInteraction/beamInCrossFlow/constant/fluid/polyMesh/blockMeshDict
@@ -16,7 +16,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/fluidSolidInteraction/beamInCrossFlow/constant/solid/polyMesh/blockMeshDict
+++ b/tutorials/fluidSolidInteraction/beamInCrossFlow/constant/solid/polyMesh/blockMeshDict
@@ -16,7 +16,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/fluidSolidInteraction/beamInCrossFlow/system/functions
+++ b/tutorials/fluidSolidInteraction/beamInCrossFlow/system/functions
@@ -4,7 +4,7 @@ functions
     {
         type                forces;
         region              fluid;
-        functionObjectLibs  ( "libforces.so" );
+        libs                ( "libforces.so" );
         writeControl        timeStep;
         writeInterval       1;
         patches             (interface);

--- a/tutorials/fluidSolidInteraction/beamInCrossFlow/system/functions
+++ b/tutorials/fluidSolidInteraction/beamInCrossFlow/system/functions
@@ -5,8 +5,8 @@ functions
         type                forces;
         region              fluid;
         functionObjectLibs  ( "libforces.so" );
-        outputControl       timeStep;
-        outputInterval      1;
+        writeControl        timeStep;
+        writeInterval       1;
         patches             (interface);
         "pName|p"           p;
         "UName|U"           U;

--- a/tutorials/fluidSolidInteraction/beamInCrossFlow/system/functions.openfoam
+++ b/tutorials/fluidSolidInteraction/beamInCrossFlow/system/functions.openfoam
@@ -5,8 +5,8 @@ functions
         type                forces;
         region              fluid;
         libs                ( "libforces.so" );
-        outputControl       timeStep;
-        outputInterval      1;
+        writeControl        timeStep;
+        writeInterval       1;
         patches             (interface);
         "pName|p"           p;
         "UName|U"           U;

--- a/tutorials/fluidSolidInteraction/flexibleDamBreak/constant/fluid/polyMesh/blockMeshDict
+++ b/tutorials/fluidSolidInteraction/flexibleDamBreak/constant/fluid/polyMesh/blockMeshDict
@@ -16,7 +16,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 0.146;
+scale 0.146;
 
 vertices
 (

--- a/tutorials/fluidSolidInteraction/flexibleDamBreak/constant/solid/polyMesh/blockMeshDict
+++ b/tutorials/fluidSolidInteraction/flexibleDamBreak/constant/solid/polyMesh/blockMeshDict
@@ -16,7 +16,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 0.146;
+scale 0.146;
 
 vertices
 (

--- a/tutorials/fluidSolidInteraction/oneWayCavity/constant/polyMesh/blockMeshDict
+++ b/tutorials/fluidSolidInteraction/oneWayCavity/constant/polyMesh/blockMeshDict
@@ -16,7 +16,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 0.1;
+scale 0.1;
 
 vertices
 (

--- a/tutorials/fluidSolidInteraction/oneWayCavity/constant/solid/polyMesh/blockMeshDict
+++ b/tutorials/fluidSolidInteraction/oneWayCavity/constant/solid/polyMesh/blockMeshDict
@@ -16,7 +16,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 0.1;
+scale 0.1;
 
 vertices
 (

--- a/tutorials/fluidSolidInteraction/perpendicularFlap/constant/solid/polyMesh/blockMeshDict
+++ b/tutorials/fluidSolidInteraction/perpendicularFlap/constant/solid/polyMesh/blockMeshDict
@@ -16,7 +16,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 0.01;
+scale 0.01;
 
 vertices
 (

--- a/tutorials/fluidSolidInteraction/perpendicularFlap/system/functions
+++ b/tutorials/fluidSolidInteraction/perpendicularFlap/system/functions
@@ -4,7 +4,7 @@ functions
     {
         type                forces;
         region              fluid;
-        functionObjectLibs  ( "libforces.so" );
+        libs                ( "libforces.so" );
         writeControl        timeStep;
         writeInterval       1;
         patches             (interface);

--- a/tutorials/fluidSolidInteraction/perpendicularFlap/system/functions
+++ b/tutorials/fluidSolidInteraction/perpendicularFlap/system/functions
@@ -5,8 +5,8 @@ functions
         type                forces;
         region              fluid;
         functionObjectLibs  ( "libforces.so" );
-        outputControl       timeStep;
-        outputInterval      1;
+        writeControl        timeStep;
+        writeInterval       1;
         patches             (interface);
         "pName|p"           p;
         "UName|U"           U;

--- a/tutorials/fluidSolidInteraction/perpendicularFlap/system/functions.openfoam
+++ b/tutorials/fluidSolidInteraction/perpendicularFlap/system/functions.openfoam
@@ -4,7 +4,7 @@ functions
     {
         type                forces;
         region              fluid;
-        functionObjectLibs  ( "libforces.so" );
+        libs                ( "libforces.so" );
         writeControl        timeStep;
         writeInterval       1;
         patches             (interface);

--- a/tutorials/fluidSolidInteraction/perpendicularFlap/system/functions.openfoam
+++ b/tutorials/fluidSolidInteraction/perpendicularFlap/system/functions.openfoam
@@ -5,8 +5,8 @@ functions
         type                forces;
         region              fluid;
         functionObjectLibs  ( "libforces.so" );
-        outputControl       timeStep;
-        outputInterval      1;
+        writeControl        timeStep;
+        writeInterval       1;
         patches             (interface);
         "pName|p"           p;
         "UName|U"           U;

--- a/tutorials/fluidSolidInteraction/wavesOnDam/constant/fluid/polyMesh/blockMeshDict
+++ b/tutorials/fluidSolidInteraction/wavesOnDam/constant/fluid/polyMesh/blockMeshDict
@@ -16,7 +16,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 0.146;
+scale 0.146;
 
 vertices
 (

--- a/tutorials/fluidSolidInteraction/wavesOnDam/constant/solid/polyMesh/blockMeshDict
+++ b/tutorials/fluidSolidInteraction/wavesOnDam/constant/solid/polyMesh/blockMeshDict
@@ -16,7 +16,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 0.146;
+scale 0.146;
 
 vertices
 (

--- a/tutorials/fluids/cylinderInChannel/system/controlDict
+++ b/tutorials/fluids/cylinderInChannel/system/controlDict
@@ -56,7 +56,7 @@ functions
    forces
    {
        type                forces;
-       functionObjectLibs  ( "libforces.so" );
+       libs                ( "libforces.so" );
        writeControl        timeStep;
        writeInterval       1;
        patches             (cylinderWall);

--- a/tutorials/fluids/cylinderInChannel/system/controlDict
+++ b/tutorials/fluids/cylinderInChannel/system/controlDict
@@ -57,8 +57,8 @@ functions
    {
        type                forces;
        functionObjectLibs  ( "libforces.so" );
-       "writeControl|outputControl" timeStep;
-       outputInterval      1;
+       writeControl        timeStep;
+       writeInterval       1;
        patches             (cylinderWall);
        "pName|p"           p;
        "UName|U"           U;

--- a/tutorials/solids/abaqusUMATs/plateHoleTotalDispUMAT/constant/polyMesh/blockMeshDict
+++ b/tutorials/solids/abaqusUMATs/plateHoleTotalDispUMAT/constant/polyMesh/blockMeshDict
@@ -16,7 +16,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/solids/beamsPlatesShells/squarePlate/constant/polyMesh/blockMeshDict
+++ b/tutorials/solids/beamsPlatesShells/squarePlate/constant/polyMesh/blockMeshDict
@@ -17,7 +17,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/solids/elastoplasticity/cooksMembrane/constant/polyMesh/blockMeshDict
+++ b/tutorials/solids/elastoplasticity/cooksMembrane/constant/polyMesh/blockMeshDict
@@ -16,7 +16,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 0.001;
+scale 0.001;
 
 vertices
 (

--- a/tutorials/solids/elastoplasticity/curvedBeams/system/blockMeshDict.m4
+++ b/tutorials/solids/elastoplasticity/curvedBeams/system/blockMeshDict.m4
@@ -43,7 +43,7 @@ m4_define(zB, L)
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 0.001;
+scale 0.001;
 
 vertices
 (

--- a/tutorials/solids/elastoplasticity/cylinderCrush/constant/polyMesh/blockMeshDict
+++ b/tutorials/solids/elastoplasticity/cylinderCrush/constant/polyMesh/blockMeshDict
@@ -16,7 +16,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 40;
+scale 40;
 
 vertices
 (

--- a/tutorials/solids/elastoplasticity/cylinderExpansion/system/blockMeshDict.thickCylinder.m4
+++ b/tutorials/solids/elastoplasticity/cylinderExpansion/system/blockMeshDict.thickCylinder.m4
@@ -41,7 +41,7 @@ define(mr, 10) // number of cells in radial direction
 
 // start of blockMeshDict
 
-convertToMeters 0.001;
+scale 0.001;
 
 vertices
 (

--- a/tutorials/solids/elastoplasticity/impactBar/constant/polyMesh/blockMeshDict
+++ b/tutorials/solids/elastoplasticity/impactBar/constant/polyMesh/blockMeshDict
@@ -39,7 +39,7 @@ FoamFile
 
 // start of blockMeshDict
 
-convertToMeters 0.001;
+scale 0.001;
 
 vertices
 (

--- a/tutorials/solids/elastoplasticity/impactBar/system/blockMeshDict.cylinder.m4
+++ b/tutorials/solids/elastoplasticity/impactBar/system/blockMeshDict.cylinder.m4
@@ -44,7 +44,7 @@ define(mr2, 1) // rigid wall
 
 // start of blockMeshDict
 
-convertToMeters 0.001;
+scale 0.001;
 
 vertices
 (

--- a/tutorials/solids/elastoplasticity/neckingBar/system/blockMeshDict.neckingBar.m4
+++ b/tutorials/solids/elastoplasticity/neckingBar/system/blockMeshDict.neckingBar.m4
@@ -43,7 +43,7 @@ define(lx, calc(0.35*l)) // x-coordinate where refined region ends
 
 // start of blockMeshDict
 
-convertToMeters 0.001;
+scale 0.001;
 
 vertices
 (

--- a/tutorials/solids/elastoplasticity/perforatedPlate/explicitPerforatedPlate/constant/polyMesh/blockMeshDict
+++ b/tutorials/solids/elastoplasticity/perforatedPlate/explicitPerforatedPlate/constant/polyMesh/blockMeshDict
@@ -16,7 +16,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 0.001;
+scale 0.001;
 
 vertices
 (

--- a/tutorials/solids/elastoplasticity/perforatedPlate/perforatedPlate/constant/polyMesh/blockMeshDict
+++ b/tutorials/solids/elastoplasticity/perforatedPlate/perforatedPlate/constant/polyMesh/blockMeshDict
@@ -16,7 +16,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 0.001;
+scale 0.001;
 
 vertices
 (

--- a/tutorials/solids/elastoplasticity/pipeCrush/constant/polyMesh/blockMeshDict
+++ b/tutorials/solids/elastoplasticity/pipeCrush/constant/polyMesh/blockMeshDict
@@ -17,7 +17,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 0.001;
+scale 0.001;
 
 vertices
 (

--- a/tutorials/solids/elastoplasticity/upsetBillet/system/blockMeshDict.cylinder.m4
+++ b/tutorials/solids/elastoplasticity/upsetBillet/system/blockMeshDict.cylinder.m4
@@ -44,7 +44,7 @@ define(mr2, 24)
 
 // start of blockMeshDict
 
-convertToMeters 0.001;
+scale 0.001;
 
 vertices
 (

--- a/tutorials/solids/fracture/crackingBeams/constant/polyMesh/blockMeshDict
+++ b/tutorials/solids/fracture/crackingBeams/constant/polyMesh/blockMeshDict
@@ -41,7 +41,7 @@ FoamFile
 
 // start of blockMeshDict
 
-convertToMeters 0.001;
+scale 0.001;
 
 vertices
 (

--- a/tutorials/solids/fracture/crackingPlateHole/constant/polyMesh/blockMeshDict
+++ b/tutorials/solids/fracture/crackingPlateHole/constant/polyMesh/blockMeshDict
@@ -16,7 +16,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/solids/hyperelasticity/cantileverBeam/constant/polyMesh/blockMeshDict
+++ b/tutorials/solids/hyperelasticity/cantileverBeam/constant/polyMesh/blockMeshDict
@@ -16,7 +16,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/solids/hyperelasticity/cylinderCrush/constant/polyMesh/blockMeshDict
+++ b/tutorials/solids/hyperelasticity/cylinderCrush/constant/polyMesh/blockMeshDict
@@ -16,7 +16,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 40;
+scale 40;
 
 vertices
 (

--- a/tutorials/solids/hyperelasticity/cylindricalPressureVessel/constant/polyMesh/blockMeshDict
+++ b/tutorials/solids/hyperelasticity/cylindricalPressureVessel/constant/polyMesh/blockMeshDict
@@ -16,7 +16,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/solids/hyperelasticity/longWall/constant/polyMesh/blockMeshDict
+++ b/tutorials/solids/hyperelasticity/longWall/constant/polyMesh/blockMeshDict
@@ -16,7 +16,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/solids/hyperelasticity/rigidRotation/rotatingBlock/constant/polyMesh/blockMeshDict
+++ b/tutorials/solids/hyperelasticity/rigidRotation/rotatingBlock/constant/polyMesh/blockMeshDict
@@ -17,7 +17,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/solids/linearElasticity/cantilever2d/coupledCantilever2d/constant/polyMesh/blockMeshDict
+++ b/tutorials/solids/linearElasticity/cantilever2d/coupledCantilever2d/constant/polyMesh/blockMeshDict
@@ -17,7 +17,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/solids/linearElasticity/cantilever2d/explicitCantilever2d/constant/polyMesh/blockMeshDict
+++ b/tutorials/solids/linearElasticity/cantilever2d/explicitCantilever2d/constant/polyMesh/blockMeshDict
@@ -17,7 +17,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/solids/linearElasticity/cantilever2d/segregatedCantilever2d/constant/polyMesh/blockMeshDict
+++ b/tutorials/solids/linearElasticity/cantilever2d/segregatedCantilever2d/constant/polyMesh/blockMeshDict
@@ -17,7 +17,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/solids/linearElasticity/cantilever2d/vertexCentredCantilever2d/constant/polyMesh/blockMeshDict
+++ b/tutorials/solids/linearElasticity/cantilever2d/vertexCentredCantilever2d/constant/polyMesh/blockMeshDict
@@ -17,7 +17,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/solids/linearElasticity/cantilever2d/vertexCentredCantilever2d/constant/polyMesh/blockMeshDict.0
+++ b/tutorials/solids/linearElasticity/cantilever2d/vertexCentredCantilever2d/constant/polyMesh/blockMeshDict.0
@@ -17,7 +17,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/solids/linearElasticity/cantilever2d/vertexCentredCantilever2d/constant/polyMesh/blockMeshDict.1
+++ b/tutorials/solids/linearElasticity/cantilever2d/vertexCentredCantilever2d/constant/polyMesh/blockMeshDict.1
@@ -17,7 +17,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/solids/linearElasticity/cantilever2d/vertexCentredCantilever2d/constant/polyMesh/blockMeshDict.2
+++ b/tutorials/solids/linearElasticity/cantilever2d/vertexCentredCantilever2d/constant/polyMesh/blockMeshDict.2
@@ -17,7 +17,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/solids/linearElasticity/cantilever2d/vertexCentredCantilever2d/constant/polyMesh/blockMeshDict.3
+++ b/tutorials/solids/linearElasticity/cantilever2d/vertexCentredCantilever2d/constant/polyMesh/blockMeshDict.3
@@ -17,7 +17,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/solids/linearElasticity/cantilever2d/vertexCentredCantilever2d/constant/polyMesh/blockMeshDict.4
+++ b/tutorials/solids/linearElasticity/cantilever2d/vertexCentredCantilever2d/constant/polyMesh/blockMeshDict.4
@@ -17,7 +17,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/solids/linearElasticity/cantilever2d/vertexCentredCantilever2d/constant/polyMesh/blockMeshDict.5
+++ b/tutorials/solids/linearElasticity/cantilever2d/vertexCentredCantilever2d/constant/polyMesh/blockMeshDict.5
@@ -17,7 +17,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/solids/linearElasticity/cantilever2d/vertexCentredCantilever2d/constant/polyMesh/blockMeshDict.6
+++ b/tutorials/solids/linearElasticity/cantilever2d/vertexCentredCantilever2d/constant/polyMesh/blockMeshDict.6
@@ -17,7 +17,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/solids/linearElasticity/contactPatchTest/constant/polyMesh/blockMeshDict
+++ b/tutorials/solids/linearElasticity/contactPatchTest/constant/polyMesh/blockMeshDict
@@ -15,7 +15,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/solids/linearElasticity/cooksMembrane/constant/polyMesh/blockMeshDict
+++ b/tutorials/solids/linearElasticity/cooksMembrane/constant/polyMesh/blockMeshDict
@@ -16,7 +16,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 0.001;
+scale 0.001;
 
 vertices
 (

--- a/tutorials/solids/linearElasticity/curvedCantilever/constant/polyMesh/blockMeshDict
+++ b/tutorials/solids/linearElasticity/curvedCantilever/constant/polyMesh/blockMeshDict
@@ -16,7 +16,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 0.01;
+scale 0.01;
 
 vertices
 (

--- a/tutorials/solids/linearElasticity/ellipticPlate/constant/polyMesh/blockMeshDict
+++ b/tutorials/solids/linearElasticity/ellipticPlate/constant/polyMesh/blockMeshDict
@@ -17,7 +17,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/solids/linearElasticity/flatEndedRigidIndenter/Allclean
+++ b/tutorials/solids/linearElasticity/flatEndedRigidIndenter/Allclean
@@ -14,3 +14,10 @@ cleanCase
 # Convert case version to FOAM EXTEND
 solids4Foam::convertCaseFormatFoamExtend .
 
+if [[ "${WM_PROJECT}" == "OpenFOAM" ]]
+then
+    # Convert the new keywords, `point`, and `normal`, back to the old ones
+    # still used in foam-extend: `basePoint` and `normalVector`
+    sed -i -E 's/\bpoint\b/basePoint/' system/mirrorMeshDict
+    sed -i -E 's/\b(normal)\b/\1Vector/' system/mirrorMeshDict
+fi

--- a/tutorials/solids/linearElasticity/flatEndedRigidIndenter/Allrun
+++ b/tutorials/solids/linearElasticity/flatEndedRigidIndenter/Allrun
@@ -19,6 +19,10 @@ then
     mv 0/polyMesh/* constant/polyMesh/
     rm -rf 0/polyMesh
 else
+    # In OpenFOAM-*, `basePoint` and `normalVector` have been deprecated in
+    # favor of `point` and `normal`
+    sed -i -E 's/base(Point)/\L\1/' system/mirrorMeshDict
+    sed -i -E 's/(normal)Vector/\1/' system/mirrorMeshDict
     solids4Foam::runApplication mirrorMesh -overwrite
 fi
 

--- a/tutorials/solids/linearElasticity/flatEndedRigidIndenter/constant/polyMesh/blockMeshDict
+++ b/tutorials/solids/linearElasticity/flatEndedRigidIndenter/constant/polyMesh/blockMeshDict
@@ -17,7 +17,7 @@ FoamFile
 
 // start of blockMeshDict
 
-convertToMeters 0.001;
+scale 0.001;
 
 vertices
 (

--- a/tutorials/solids/linearElasticity/narrowTmember/constant/polyMesh/blockMeshDict
+++ b/tutorials/solids/linearElasticity/narrowTmember/constant/polyMesh/blockMeshDict
@@ -17,7 +17,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 0.001;
+scale 0.001;
 
 vertices
 (

--- a/tutorials/solids/linearElasticity/patchTest/constant/polyMesh/blockMeshDict
+++ b/tutorials/solids/linearElasticity/patchTest/constant/polyMesh/blockMeshDict
@@ -16,7 +16,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/solids/linearElasticity/plateHole/constant/polyMesh/blockMeshDict
+++ b/tutorials/solids/linearElasticity/plateHole/constant/polyMesh/blockMeshDict
@@ -16,7 +16,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/solids/linearElasticity/pressurisedCylinder/constant/polyMesh/blockMeshDict
+++ b/tutorials/solids/linearElasticity/pressurisedCylinder/constant/polyMesh/blockMeshDict
@@ -16,7 +16,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/solids/linearElasticity/rigidCylinderContactBrick/constant/polyMesh/blockMeshDict
+++ b/tutorials/solids/linearElasticity/rigidCylinderContactBrick/constant/polyMesh/blockMeshDict
@@ -16,7 +16,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/solids/linearElasticity/slidingFrictionBall/constant/polyMesh/blockMeshDict
+++ b/tutorials/solids/linearElasticity/slidingFrictionBall/constant/polyMesh/blockMeshDict
@@ -16,7 +16,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 0.01;
+scale 0.01;
 
 vertices
 (

--- a/tutorials/solids/linearElasticity/waveBar/constant/polyMesh/blockMeshDict
+++ b/tutorials/solids/linearElasticity/waveBar/constant/polyMesh/blockMeshDict
@@ -17,7 +17,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/solids/linearElasticity/waveBar/system/controlDict
+++ b/tutorials/solids/linearElasticity/waveBar/system/controlDict
@@ -56,8 +56,8 @@ functions
     probe
     {
         type           probes;
-        outputControl  timeStep;
-        outputInterval 1;
+        writeControl   timeStep;
+        writeInterval  1;
         fields         (D sigma);
         probeLocations ((0.1 0 0));
     }

--- a/tutorials/solids/multiMaterial/layeredPipe/constant/polyMesh/blockMeshDict
+++ b/tutorials/solids/multiMaterial/layeredPipe/constant/polyMesh/blockMeshDict
@@ -16,7 +16,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1e-3;
+scale 1e-3;
 
 vertices
 (

--- a/tutorials/solids/poroelasticity/rodAndSeabed/constant/polyMesh/blockMeshDict
+++ b/tutorials/solids/poroelasticity/rodAndSeabed/constant/polyMesh/blockMeshDict
@@ -16,7 +16,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/solids/poroelasticity/stripFooting/constant/polyMesh/blockMeshDict
+++ b/tutorials/solids/poroelasticity/stripFooting/constant/polyMesh/blockMeshDict
@@ -16,7 +16,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/solids/poroelasticity/stripFooting/system/functions
+++ b/tutorials/solids/poroelasticity/stripFooting/system/functions
@@ -5,8 +5,8 @@ functions
         type           probes;
         functionObjectLibs ("libsampling.so");
         enabled        true;
-        outputControl  outputTime;
-        outputInterval 1;
+        writeControl   outputTime;
+        writeInterval  1;
         probeLocations
         (
             (0.01 0.05 9.98)

--- a/tutorials/solids/poroelasticity/stripFooting/system/functions
+++ b/tutorials/solids/poroelasticity/stripFooting/system/functions
@@ -3,7 +3,7 @@ functions
     probes
     {
         type           probes;
-        functionObjectLibs ("libsampling.so");
+        libs           ("libsampling.so");
         enabled        true;
         writeControl   outputTime;
         writeInterval  1;

--- a/tutorials/solids/poroelasticity/stripFooting/system/functions.openfoam
+++ b/tutorials/solids/poroelasticity/stripFooting/system/functions.openfoam
@@ -5,8 +5,8 @@ functions
         type           probes;
         functionObjectLibs ("libsampling.so");
         enabled        true;
-        outputControl  outputTime;
-        outputInterval 1;
+        writeControl   outputTime;
+        writeInterval  1;
         probeLocations
         (
             (0.01 0.05 9.98)

--- a/tutorials/solids/poroelasticity/stripFooting/system/functions.openfoam
+++ b/tutorials/solids/poroelasticity/stripFooting/system/functions.openfoam
@@ -3,7 +3,7 @@ functions
     probes
     {
         type           probes;
-        functionObjectLibs ("libsampling.so");
+        libs           ("libsampling.so");
         enabled        true;
         writeControl   outputTime;
         writeInterval  1;

--- a/tutorials/solids/poroelasticity/suctionCaission/constant/polyMesh/blockMeshDict
+++ b/tutorials/solids/poroelasticity/suctionCaission/constant/polyMesh/blockMeshDict
@@ -17,7 +17,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/solids/thermoelasticity/hotCylinder/hotCylinder/constant/polyMesh/blockMeshDict
+++ b/tutorials/solids/thermoelasticity/hotCylinder/hotCylinder/constant/polyMesh/blockMeshDict
@@ -17,7 +17,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/solids/thermoelasticity/hotCylinder/hotCylinderPredefinedTFieldMultipleMaterials/constant/polyMesh/blockMeshDict
+++ b/tutorials/solids/thermoelasticity/hotCylinder/hotCylinderPredefinedTFieldMultipleMaterials/constant/polyMesh/blockMeshDict
@@ -17,7 +17,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/solids/thermoelasticity/slabCooling/constant/polyMesh/blockMeshDict
+++ b/tutorials/solids/thermoelasticity/slabCooling/constant/polyMesh/blockMeshDict
@@ -17,7 +17,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/solids/viscoelasticity/viscoTube/constant/polyMesh/blockMeshDict
+++ b/tutorials/solids/viscoelasticity/viscoTube/constant/polyMesh/blockMeshDict
@@ -17,7 +17,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 0.001;
+scale 0.001;
 
 vertices
 (

--- a/tutorials/thermoFluidSolidInteraction/flowOverHeatedPlate/constant/fluid/blockMeshDict.m4
+++ b/tutorials/thermoFluidSolidInteraction/flowOverHeatedPlate/constant/fluid/blockMeshDict.m4
@@ -56,7 +56,7 @@ m4_define(grading, 1 1 1)
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/thermoFluidSolidInteraction/flowOverHeatedPlate/constant/fluid/polyMesh/blockMeshDict
+++ b/tutorials/thermoFluidSolidInteraction/flowOverHeatedPlate/constant/fluid/polyMesh/blockMeshDict
@@ -14,7 +14,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1.0;
+scale 1.0;
 
 vertices
 (

--- a/tutorials/thermoFluidSolidInteraction/flowOverHeatedPlate/constant/solid/polyMesh/blockMeshDict
+++ b/tutorials/thermoFluidSolidInteraction/flowOverHeatedPlate/constant/solid/polyMesh/blockMeshDict
@@ -14,7 +14,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1.0;
+scale 1.0;
 
 vertices
 (

--- a/tutorials/thermoFluidSolidInteraction/hotTJunction/constant/fluid/polyMesh/blockMeshDict
+++ b/tutorials/thermoFluidSolidInteraction/hotTJunction/constant/fluid/polyMesh/blockMeshDict
@@ -14,7 +14,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 0.001;
+scale 0.001;
 
 vertices
 (

--- a/tutorials/thermoFluidSolidInteraction/hotTJunction/constant/solid/polyMesh/blockMeshDict
+++ b/tutorials/thermoFluidSolidInteraction/hotTJunction/constant/solid/polyMesh/blockMeshDict
@@ -17,7 +17,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 0.001;
+scale 0.001;
 
 vertices
 (

--- a/tutorials/thermoFluidSolidInteraction/thermalCavity/constant/fluid/blockMeshDict.m4
+++ b/tutorials/thermoFluidSolidInteraction/thermalCavity/constant/fluid/blockMeshDict.m4
@@ -56,7 +56,7 @@ m4_define(grading, 1 1 1)
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/thermoFluidSolidInteraction/thermalCavity/constant/fluid/polyMesh/blockMeshDict
+++ b/tutorials/thermoFluidSolidInteraction/thermalCavity/constant/fluid/polyMesh/blockMeshDict
@@ -56,7 +56,7 @@ FoamFile
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/thermoFluidSolidInteraction/thermalCavity/constant/solid/blockMeshDict.m4
+++ b/tutorials/thermoFluidSolidInteraction/thermalCavity/constant/solid/blockMeshDict.m4
@@ -56,7 +56,7 @@ m4_define(grading, 1 1 1)
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/tutorials/thermoFluidSolidInteraction/thermalCavity/constant/solid/polyMesh/blockMeshDict
+++ b/tutorials/thermoFluidSolidInteraction/thermalCavity/constant/solid/polyMesh/blockMeshDict
@@ -56,7 +56,7 @@ FoamFile
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (


### PR DESCRIPTION
# `solids4foam` Pull Request

## Pull Request Description 🚀

Please provide a **concise summary** of your changes and the motivation behind
them. For example:

- What issue or feature does this pull request address? It updates old deprecated keywords with newer ones. Also, there are some keywords that have been updated in OpenFOAM-* but not in foam-extend, that needed special treatment.
- Why are these changes necessary? To avoid runtime warnings.

The following keywords have been replaced directly, as they are supported by all
forks:

- `outputControl` -> `writeControl`
- `outputInterval` -> `writeInterval`
- `functionObjectLibs` -> `libs`
- `convertToMeters` -> `scale`

However, for the conversion to `point` and `normal`, I updated the case scripts directly instead of modifying the `solids4FoamScript.sh` script, since only a single replacement was needed in one case.

---

## Related Issues and Discussions 🧩

- This PR addresses  #175
- If this PR fixes a bug, include "Closes #issue-number" to automatically close
  it upon merging.

---

## Changes Made 🛠️

- [ ] **Bug Fix**: Describe the bug and how it was fixed.
- [ ] **New Feature**: Briefly explain the new functionality.
- [x] **Refactoring**: Details of any code improvements.
- [ ] **Documentation**: Updates to docs or comments.
- [ ] **Other**: Explain any additional changes.

### Summary of Changes

- **Files Modified**: Most of the affected files are from the `tutorials/` directory, but there were also some files in `src/` that were modified because their comments included examples using deprecated keywords.
  ```diff
   src/solids4FoamModels/functionObjects/hydrostaticPressure/hydrostaticPressure.H | 2 +-
   src/solids4FoamModels/functionObjects/principalStresses/principalStresses.H     | 2 +-
   src/solids4FoamModels/functionObjects/stressTriaxiality/stressTriaxiality.H     | 2 +-
   src/solids4FoamModels/functionObjects/volumetricStrain/volumetricStrain.H       | 2 +-
   4 files changed, 4 insertions(+), 4 deletions(-)
  ```
- **Behavioural Changes**: Are there any changes in output or performance? There is no impact on performance, but the warnings mentioned in #175 no longer appear in the output.

---

## Checklist ✅

Please ensure the following before submitting your PR:

- [x] Code compiles successfully with **OpenFOAM** or **foam-extend** versions
      (e.g., `v2312`, `4.1`). > Only the comments in the source code was modified.
- [x] I tested the changes with the provided tutorial or relevant test cases.
- [x] Added relevant **comments** or **documentation** for clarity.
- [x] The PR passes existing **GitHub Actions CI checks** (e.g., build and
      test).
- [x] Code follows the project's **coding style** and conventions.

---

## Test Cases and Results 📊

Provide details of any test cases run and their results:

- **Case Name**: e.g., `plateUnderCompression`, `beamBendingFSI`
- **Results**: Brief description (e.g., "Results match the reference solution
  within tolerance").

If applicable, add a **screenshot** or **plot** of the results for visual
confirmation.

---

## Additional Notes 💡

- Highlight any potential **backward compatibility** issues.
- Mention if there are **dependencies** (e.g., specific OpenFOAM versions,
  external libraries).
- Any known limitations or remaining tasks for this PR.

---

## Screenshots (if applicable) 📸

Include relevant screenshots or plots for visualisation.

---

### Final Comments 💬

Thank you for contributing to **solids4foam**! 🎉

If this is your first time contributing, check out the
[CONTRIBUTING.md](link-to-contributing-guide) for more details.
