### PR TITLE
Updated K value for plane stress

### DIFF
--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElastic/linearElastic.C
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElastic/linearElastic.C
@@ -73,7 +73,14 @@ Foam::linearElastic::linearElastic
         // Set the bulk modulus
         if (nu_.value() < 0.5)
         {
-            K_ = (nu_*E_/((1.0 + nu_)*(1.0 - 2.0*nu_))) + (2.0/3.0)*mu_;
+	    if (planeStress())
+            {
+                K_ = (nu_*E_/((1.0 + nu_)*(1.0 - nu_))) + (2.0/3.0)*mu_;
+	    }
+	    else
+	    {
+                K_ = (nu_*E_/((1.0 + nu_)*(1.0 - 2.0*nu_))) + (2.0/3.0)*mu_;
+	    }
         }
         else
         {

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticMisesPlastic/linearElasticMisesPlastic.C
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticMisesPlastic/linearElasticMisesPlastic.C
@@ -610,7 +610,14 @@ Foam::linearElasticMisesPlastic::linearElasticMisesPlastic
         mu_ = E_/(2.0*(1.0 + nu_));
 
         // Set the bulk modulus
-        K_ = (nu_*E_/((1.0 + nu_)*(1.0 - 2.0*nu_))) + (2.0/3.0)*mu_;
+	if (planeStress())
+        {
+            K_ = (nu_*E_/((1.0 + nu_)*(1.0 - nu_))) + (2.0/3.0)*mu_;
+	}
+	else
+	{
+            K_ = (nu_*E_/((1.0 + nu_)*(1.0 - 2.0*nu_))) + (2.0/3.0)*mu_;
+	}
     }
     else if (dict.found("mu") && dict.found("K"))
     {


### PR DESCRIPTION
# `solids4foam` Pull Request

## Pull Request Description 🚀

In our solvers, the implicit stiffness is calculated as:
```
impK = 2*mu + lambda = (4/3) * mu + K
```

The Lamé parameters is possible to calculate using the `mechanicalModel`, which stores only `K` and `impK`, as follows:
```
mu = (impK_ - K) * (3.0 / 4.0);
lambda = impK_ - 2.0 * mu;
```
Regardless of whether we are in a plane stress or plane strain condition, the shear modulus mu should remain the same.

However, if we attempt to compute mu using the code above, we end up with different values under plane stress conditions. This led me to conclude that we need to update the calculation of the bulk modulus `K` specifically for plane stress. We are already calculating `K` differently for plane stress in the `neoHookeanElastic` material model.

I believe this went unnoticed earlier because in `neoHookeanElastic`, the form `(4/3) * mu + K` is used for `impK`, whereas in the linear elastic model, the form `2 * mu + lambda` is used.
   
---



