### PR TITLE
Include missing demandDrivenData.H in solidContactPointPatchVectorFie…

### DIFF
--- a/src/solids4FoamModels/solidModels/pointPatchFields/pointSolidContact/solidContactPointPatchVectorField.C
+++ b/src/solids4FoamModels/solidModels/pointPatchFields/pointSolidContact/solidContactPointPatchVectorField.C
@@ -24,6 +24,7 @@ License
 #include "pointBoundaryMesh.H"
 #include "pointMesh.H"
 #include "lookupSolidModel.H"
+#include "demandDrivenData.H"
 #ifdef OPENFOAM_NOT_EXTEND
     #include "Time.H"
 #endif


### PR DESCRIPTION
…ld.C

#include "demandDrivenData.H" is not present in the feature-petsc-snes branch, leading to compilation error. This commit add the required inclusion statement.

# `solids4foam` Pull Request

## Pull Request Description 🚀

Add #include "demandDrivenData.H" in solids4FoamModels/solidModels/pointPatchFields/pointSolidContact/solidContactPointPatchVectorField.C

## Changes Made 🛠️

The inclusion, already present in the master branch, fix a compilation error.
