### PR TITLE
Bugfix: Mismatch between the size of `label`, `PetscInt`, and `int` (`feature-petsc-snes-pressure`)

### DIFF
--- a/src/solids4FoamModels/fluidSolidInterfaces/newtonMonolithicCouplingInterface/newtonMonolithicCouplingInterface.C
+++ b/src/solids4FoamModels/fluidSolidInterfaces/newtonMonolithicCouplingInterface/newtonMonolithicCouplingInterface.C
@@ -243,8 +243,8 @@ label newtonMonolithicCouplingInterface::initialiseAfm
     // Allocate per-scalar-row nonzeros
     // d is initialised to 1 to count the diagonal
     // while o is initialised to 0
-    std::vector<int> d_nnz(scalarRowN, fluidBlockSize);
-    std::vector<int> o_nnz(scalarRowN, 0);
+    std::vector<label> d_nnz(scalarRowN, fluidBlockSize);
+    std::vector<label> o_nnz(scalarRowN, 0);
 
     // Count neighbours sharing an internal face
     const Foam::labelUList& own = fluidMesh.owner();
@@ -368,8 +368,8 @@ label newtonMonolithicCouplingInterface::initialiseAms
     const label scalarRowN = fluidMesh.nCells()*motionBlockSize;
 
     // Allocate per-scalar-row nonzeros, initialised to 0
-    std::vector<int> d_nnz(scalarRowN, 0);
-    std::vector<int> o_nnz(scalarRowN, 0);
+    std::vector<label> d_nnz(scalarRowN, 0);
+    std::vector<label> o_nnz(scalarRowN, 0);
 
     // Set non-zeros for each interface fluid cells
     const labelList& fluidFaceMap = interfaceMap.zoneBToZoneAFaceMap();
@@ -455,8 +455,8 @@ label newtonMonolithicCouplingInterface::initialiseAsf
     const label scalarRowN = solidMesh.nCells()*solidBlockSize;
 
     // Allocate per-scalar-row nonzeros, initialised to 0
-    std::vector<int> d_nnz(scalarRowN, 0);
-    std::vector<int> o_nnz(scalarRowN, 0);
+    std::vector<label> d_nnz(scalarRowN, 0);
+    std::vector<label> o_nnz(scalarRowN, 0);
 
     // Set non-zeros for each interface solid cells
     const labelList& solidFaceMap = interfaceMap.zoneAToZoneBFaceMap();

--- a/src/solids4FoamModels/numerics/sparseMatrix/sparseMatrixTools.C
+++ b/src/solids4FoamModels/numerics/sparseMatrix/sparseMatrixTools.C
@@ -476,8 +476,8 @@ Foam::sparseMatrixTools::solveLinearSystemPETSc
     // off-core). For now, we will just use the max on-core non-zeros to
     // initialise not-owned values
 
-    int* d_nnz = (int*)malloc(n*sizeof(int));
-    int* o_nnz = (int*)malloc(n*sizeof(int));
+    label* d_nnz = (label*)malloc(n*sizeof(*d_nnz));
+    label* o_nnz = (label*)malloc(n*sizeof(*o_nnz));
     // label d_nnz[n];
     // label o_nnz[n];
     label d_nz = 0;
@@ -1061,8 +1061,8 @@ Foam::sparseMatrixTools::solveLinearSystemPETSc
     // off-core). For now, we will just use the max on-core non-zeros to
     // initialise not-owned values
 
-    int* d_nnz = (int*)malloc(n*sizeof(int));
-    int* o_nnz = (int*)malloc(n*sizeof(int));
+    label* d_nnz = (label*)malloc(n*sizeof(*d_nnz));
+    label* o_nnz = (label*)malloc(n*sizeof(*o_nnz));
     // label d_nnz[n];
     // label o_nnz[n];
     label d_nz = 0;

--- a/src/solids4FoamModels/solidModels/pointPatchFields/pointSolidContact/solidContactPointPatchVectorField.C
+++ b/src/solids4FoamModels/solidModels/pointPatchFields/pointSolidContact/solidContactPointPatchVectorField.C
@@ -24,6 +24,7 @@ License
 #include "pointBoundaryMesh.H"
 #include "pointMesh.H"
 #include "lookupSolidModel.H"
+#include "demandDrivenData.H"
 #ifdef OPENFOAM_NOT_EXTEND
     #include "Time.H"
 #endif

--- a/src/solids4FoamModels/solidModels/solidModel/foamPetscSnesHelper/foamPetscSnesHelper.C
+++ b/src/solids4FoamModels/solidModels/solidModel/foamPetscSnesHelper/foamPetscSnesHelper.C
@@ -190,10 +190,10 @@ Foam::label Foam::initialiseJacobian
     // Note: we assume a compact stencil, i.e. face only face neighbours
 
     // Number of on-processor non-zeros per row
-    int* d_nnz = (int*)malloc(blockn*sizeof(int));
+    label* d_nnz = (label*)malloc(blockn*sizeof(*d_nnz));
 
     // Number of off-processor non-zeros per row
-    int* o_nnz = (int*)malloc(blockn*sizeof(int));
+    label* o_nnz = (label*)malloc(blockn*sizeof(*o_nnz));
 
     // Initialise d_nnz to one and o_nnz to zero
     for (int i = 0; i < blockn; ++i)

--- a/src/solids4FoamModels/solidModels/vertexCentredLinGeomSolid/vertexCentredLinGeomSolid.C
+++ b/src/solids4FoamModels/solidModels/vertexCentredLinGeomSolid/vertexCentredLinGeomSolid.C
@@ -221,8 +221,8 @@ PetscErrorCode formJacobian
     for (auto iter = data.begin(); iter != data.end(); ++iter)
     {
         const Foam::tensor& coeff = iter();
-        const int blockRowI = localToGlobalPointMap[iter.key()[0]];
-        const int blockColI = localToGlobalPointMap[iter.key()[1]];
+        const Foam::label blockRowI = localToGlobalPointMap[iter.key()[0]];
+        const Foam::label blockColI = localToGlobalPointMap[iter.key()[1]];
 
         if (twoD)
         {
@@ -998,11 +998,11 @@ bool vertexCentredLinGeomSolid::evolveSnes()
 
     // Count the number of non-zeros
     // TODO: fix for parallel
-    int* d_nnz = (int*)malloc(n*sizeof(int));
-    int* o_nnz = (int*)malloc(n*sizeof(int));
+    label* d_nnz = (label*)malloc(n*sizeof(*d_nnz));
+    label* o_nnz = (label*)malloc(n*sizeof(*o_nnz));
     // label d_nnz[n];
     // label o_nnz[n];
-    int d_nz = 0;
+    label d_nz = 0;
     Foam::sparseMatrixTools::setNonZerosPerRow
     (
         d_nnz,


### PR DESCRIPTION
# `solids4foam` Pull Request

## Pull Request Description 🚀

Please provide a **concise summary** of your changes and the motivation behind
them. For example:

- What issue or feature does this pull request address? 
  - Build fails because of difference in index size
  - Build fails because a header file is missing (`demandDrivenData.H`)
- Why are these changes necessary? Because size of `int` is OS-dependent and not customizable. If the user decides to use OpenFOAM with 64-bit label or PETSC with 64-bit index size, then the use of `int` will cause compilation errors.

---

## Related Issues and Discussions 🧩

- Link to any related **issues** (e.g., #123) or **discussions**. None
- If this PR fixes a bug, include "Closes #issue-number" to automatically close
  it upon merging.

---

## Changes Made 🛠️

- [x] **Bug Fix**: Describe the bug and how it was fixed.

  In short: this fix will replace occurrences of `int` with `label`.

  OpenFOAM and PETSC are by default compiled with 32 bit index size

  ```c++
  sizeof(label) == sizeof(PetscInt) == 4
  ```

  When the user customizes the index size via

  ```sh
  export WM_LABEL_SIZE=4

  ./configure ... -with-64-bit-indices
  ```

  any mismatch between the two software can introduce compilation errors
  such as:

  ```console
  ...

  note: candidate function not viable: no known conversion from 'const
        label *' (aka 'const long long *') to 'const PetscInt *' (aka
        'const int *') for 3rd argument
  ...
  ```

  If, however, both are the same, no error will be emitted.

  However, in a few places there were variables and pointer's of type
  `int`. Since it is something OS-dependent, the user cannot configure and
  change its size. Therefore, this will only work when

  ```c++
  sizeof(label) == sizeof(PetscInt) == sizeof(int)
  ```

  To fix this issue, instances of `int` are replaced with `label`, which
  the user can manage its size.

- [ ] **New Feature**: Briefly explain the new functionality.
- [ ] **Refactoring**: Details of any code improvements.
- [ ] **Documentation**: Updates to docs or comments.
- [ ] **Other**: Explain any additional changes.


### Summary of Changes

- **Files Modified**: List the key files affected (e.g., `solidsModel.C`,
  `solverFoam.H`).
  
  ```console
  $ git diff --stat upstream/feature-petsc-snes-pressure
   .../fluidSolidInterfaces/newtonMonolithicCouplingInterface/newtonMonolithicCouplingInterface.C            | 12 ++++++------
   src/solids4FoamModels/numerics/sparseMatrix/sparseMatrixTools.C                                           |  8 ++++----
   src/solids4FoamModels/solidModels/pointPatchFields/pointSolidContact/solidContactPointPatchVectorField.C  |  1 +
   src/solids4FoamModels/solidModels/solidModel/foamPetscSnesHelper/foamPetscSnesHelper.C                    |  4 ++--
   src/solids4FoamModels/solidModels/vertexCentredLinGeomSolid/vertexCentredLinGeomSolid.C                   | 10 +++++-----
  ```

- **Behavioural Changes**: Are there any changes in output or performance? No

---

## Checklist ✅

Please ensure the following before submitting your PR:

- [x] Code compiles successfully with **OpenFOAM** or **foam-extend** versions
      (e.g., `v2312`, `4.1`).
  - I tested with OpenFOAM (OpenFOAM-v2412)
- [x] I tested the changes with the provided tutorial or relevant test cases.
  - Some tutorial tests were failed locally. GitHub workflows ran without any
  failure.

  ```console
  Application solids4Foam - case 3dTube: ** FOAM FATAL ERROR **
  Application solids4Foam - case flexibleDamBreak: ** FOAM FATAL ERROR **
  Application solids4Foam - case oneWayCavity: ** FOAM FATAL ERROR **
  Application solids4Foam - case perpendicularFlap: ** FOAM FATAL ERROR **
  Application solids4Foam - case 3dTube/solid: ** FOAM FATAL ERROR **
  Application solids4Foam - case flexibleOversetCylinder/solid: ** FOAM FATAL ERROR **
  Application solids4Foam - case elastoplasticity/cooksMembrane: ** FOAM FATAL ERROR **
  Application solids4Foam - case elastoplasticity/perforatedPlate/explicitPerforatedPlate: ** FOAM FATAL ERROR **
  Application solids4Foam - case hyperelasticity/rigidRotation/rotatingBlock: ** FOAM FATAL ERROR **
  Application solids4Foam - case hyperelasticity/rigidRotation/rotatingCylinder: ** FOAM FATAL ERROR **
  Application solids4Foam - case hyperelasticity/rigidRotation/rotatingSphere: ** FOAM FATAL ERROR **
  Application solids4Foam - case linearElasticity/cantilever2d/explicitCantilever2d: ** FOAM FATAL ERROR **
  Application solids4Foam - case linearElasticity/cantilever2d/segregatedCantilever2d: ** FOAM FATAL ERROR **
  Application solids4Foam - case linearElasticity/contactPatchTest: ** FOAM FATAL ERROR **
  Application solids4Foam - case linearElasticity/cooksMembrane: ** FOAM FATAL ERROR **
  Application solids4Foam - case linearElasticity/flatEndedRigidIndenter: ** FOAM FATAL ERROR **
  Application solids4Foam - case linearElasticity/patchTest: ** FOAM FATAL ERROR **
  Application solids4Foam - case linearElasticity/plateHole: ** FOAM FATAL ERROR **
  Application solids4Foam - case linearElasticity/pressurisedCylinder: ** FOAM FATAL ERROR **
  Application solids4Foam - case linearElasticity/rigidCylinderContactBrick: ** FOAM FATAL ERROR **
  Application solids4Foam - case linearElasticity/slidingFrictionBall: ** FOAM FATAL ERROR **
  Application solids4Foam - case linearElasticity/waveBar: ** FOAM FATAL ERROR **
  Application solids4Foam - case multiMaterial/layeredPipe: ** FOAM FATAL ERROR **
  Application solids4Foam - case thermoelasticity/hotCylinder/hotCylinderPredefinedTFieldMultipleMaterials: ** FOAM FATAL ERROR **
  Application solids4Foam - case viscoelasticity/viscoTube: ** FOAM FATAL ERROR **
  ```

  I am not sure whether these failures have existed before the introduction of
  my changes. I cannot be sure because the changes enable the compilation of the
  `feature-petsc-snes-pressure` in the first place.

- [ ] Added relevant **comments** or **documentation** for clarity.
- [x] The PR passes existing **GitHub Actions CI checks** (e.g., build and
      test).
- [x] Code follows the project's **coding style** and conventions.

---

## Test Cases and Results 📊

Provide details of any test cases run and their results:

- **Case Name**: e.g., `plateUnderCompression`, `beamBendingFSI`
- **Results**: Brief description (e.g., "Results match the reference solution
  within tolerance").

If applicable, add a **screenshot** or **plot** of the results for visual
confirmation.

---

## Additional Notes 💡

- Highlight any potential **backward compatibility** issues.
- Mention if there are **dependencies** (e.g., specific OpenFOAM versions,
  external libraries).
- Any known limitations or remaining tasks for this PR.

To handle any mismatch between `label` and `PetscInt`, proper type casting
should be implemented. However, it is always preferable and recommended by many
style guides, including the C++ style guide, to avoid type casts as much as
possible. Also, it is fairly easy to rebuild both OpenFOAM and PETSC from source
with the desired index size.

---

## Screenshots (if applicable) 📸

Include relevant screenshots or plots for visualisation.

---

### Final Comments 💬

Thank you for contributing to **solids4foam**! 🎉

If this is your first time contributing, check out the
[CONTRIBUTING.md](link-to-contributing-guide) for more details.