### PR TITLE
Fix: Removed ANSI escape sequences

### DIFF
--- a/Allwclean
+++ b/Allwclean
@@ -1,5 +1,5 @@
 #!/bin/bash
-1;95;0ccd "${0%/*}" || exit  # Run from this directory
+cd "${0%/*}" || exit  # Run from this directory
 
 # Check if OpenFOAM/FOAM has been sourced
 if [[ -z "${WM_PROJECT}" ]]


### PR DESCRIPTION
I suspect 2nd line in Allwclean was compromised by using a different editor?