### PR TITLE
Remove redundant reassignment of bulk modulus in `linearElastic.C`

### DIFF
--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElastic/linearElastic.C
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElastic/linearElastic.C
@@ -74,14 +74,14 @@ Foam::linearElastic::linearElastic
         // Set the bulk modulus
         if (nu_.value() < 0.5)
         {
-	    if (planeStress())
+            if (planeStress())
             {
                 K_ = (nu_*E_/((1.0 + nu_)*(1.0 - nu_))) + (2.0/3.0)*mu_;
-	    }
-	    else
-	    {
+            }
+            else
+            {
                 K_ = (nu_*E_/((1.0 + nu_)*(1.0 - 2.0*nu_))) + (2.0/3.0)*mu_;
-	    }
+            }
         }
         else
         {
@@ -117,7 +117,6 @@ Foam::linearElastic::linearElastic
         if (planeStress())
         {
             lambda_ = nu_*E_/((1.0 + nu_)*(1.0 - nu_));
-            K_ = E_/(3.0*(1.0 - nu_));
 
             if (solvePressureEqn())
             {
@@ -131,7 +130,6 @@ Foam::linearElastic::linearElastic
         else
         {
             lambda_ = nu_*E_/((1.0 + nu_)*(1.0 - 2.0*nu_));
-            K_ = E_/(3.0*(1.0 - 2.0*nu_));
         }
     }
     else


### PR DESCRIPTION
## Pull Request Description 🚀

This PR removes the second reassignment of the bulk modulus `K_` in the `linearElastic.C` constructor.

Currently, `K_` is computed consistently during the initial parameter setup (either from (E, nu) or directly from (mu, K)). However, it is later reassigned in the Lamé parameter block, which introduces inconsistency in the plane stress case.
By removing these lines we are reverting to the prior code.

---

## Changes Made 🛠️

- [x] **Bug Fix**: Wrong bulk modulus in the plane stress case

### Summary of Changes

- **Files Modified**: `linearElastic.C`

---

## Checklist ✅

Please ensure the following before submitting your PR:

- [x] Code compiles successfully with **OpenFOAM** or **foam-extend** versions
      (e.g., `v2312`, `4.1`).
- [x] The PR passes existing **GitHub Actions CI checks** (e.g., build and
      test).
- [x] Code follows the project's **coding style** and conventions.
