### PR TITLE
Refactor FSI region selection

### DIFF
--- a/src/solids4FoamModels/fluidModels/fluidModel/fluidModel.C
+++ b/src/solids4FoamModels/fluidModels/fluidModel/fluidModel.C
@@ -35,6 +35,15 @@ namespace Foam
     defineTypeNameAndDebug(fluidModel, 0);
     defineRunTimeSelectionTable(fluidModel, dictionary);
     addToRunTimeSelectionTable(physicsModel, fluidModel, physicsModel);
+
+    namespace
+    {
+        word resolvedFluidRegion(const Time& runTime, const word& region)
+        {
+            return runTime.controlDict().subOrEmptyDict("fluid")
+                .lookupOrDefault<word>("region", region);
+        }
+    }
 }
 
 // * * * * * * * * * * * * * Private Member Functions  * * * * * * * * * * * //
@@ -490,7 +499,7 @@ Foam::fluidModel::fluidModel
     const bool constructNull
 )
 :
-    physicsModel(type, runTime),
+    physicsModel(type, runTime, region),
     IOdictionary
     (
         // If region == "region0" then read from the main case
@@ -997,6 +1006,8 @@ Foam::autoPtr<Foam::fluidModel> Foam::fluidModel::New
     const word& region
 )
 {
+    const word runRegion(resolvedFluidRegion(runTime, region));
+
     // NB: dictionary must be unregistered to avoid adding to the database
 
     IOdictionary props
@@ -1004,9 +1015,9 @@ Foam::autoPtr<Foam::fluidModel> Foam::fluidModel::New
         IOobject
         (
             "fluidProperties",
-            bool(region == dynamicFvMesh::defaultRegion)
+            bool(runRegion == dynamicFvMesh::defaultRegion)
           ? fileName(runTime.caseConstant())
-          : fileName(runTime.caseConstant()/region),
+          : fileName(runTime.caseConstant()/runRegion),
             runTime,
             IOobject::MUST_READ,
             IOobject::NO_WRITE,
@@ -1051,7 +1062,7 @@ Foam::autoPtr<Foam::fluidModel> Foam::fluidModel::New
     auto* ctorPtr = cstrIter();
 #endif
 
-    return autoPtr<fluidModel>(ctorPtr(runTime, region));
+    return autoPtr<fluidModel>(ctorPtr(runTime, runRegion));
 }
 
 

--- a/src/solids4FoamModels/fluidModels/newtonIcoFluid/newtonIcoFluid.C
+++ b/src/solids4FoamModels/fluidModels/newtonIcoFluid/newtonIcoFluid.C
@@ -358,6 +358,7 @@ tmp<vectorField> newtonIcoFluid::patchViscousForce
 
 void newtonIcoFluid::setDeltaT(Time& runTime)
 {
+#ifdef USE_PETSC
     if
     (
         runTime.controlDict().lookupOrDefault("adjustTimeStep", false)
@@ -446,6 +447,21 @@ void newtonIcoFluid::setDeltaT(Time& runTime)
                 << reason << endl;
         }
     }
+#else
+    if (runTime.controlDict().lookupOrDefault("adjustTimeStep", false))
+    {
+        static bool warned = false;
+
+        if (!warned)
+        {
+            WarningInFunction
+                << "Ignoring adjustTimeStep because PETSc support is not "
+                << "enabled" << endl;
+
+            warned = true;
+        }
+    }
+#endif
 }
 
 

--- a/src/solids4FoamModels/fluidSolidInterfaces/fluidSolidInterface/fluidSolidInterface.C
+++ b/src/solids4FoamModels/fluidSolidInterfaces/fluidSolidInterface/fluidSolidInterface.C
@@ -45,6 +45,64 @@ namespace Foam
     defineTypeNameAndDebug(fluidSolidInterface, 0);
     defineRunTimeSelectionTable(fluidSolidInterface, dictionary);
     addToRunTimeSelectionTable(physicsModel, fluidSolidInterface, physicsModel);
+
+    namespace
+    {
+        word resolvedRegion
+        (
+            const Time& runTime,
+            const dictionary& fsiProperties,
+            const word& modelName,
+            const word& defaultRegion
+        )
+        {
+            const word controlDictRegion
+            (
+                runTime.controlDict().subOrEmptyDict(modelName)
+                    .lookupOrDefault<word>("region", defaultRegion)
+            );
+
+            return fsiProperties.lookupOrDefault<word>
+            (
+                modelName + "Region",
+                controlDictRegion
+            );
+        }
+
+
+        void warnOnConflictingRegion
+        (
+            const Time& runTime,
+            const dictionary& fsiProperties,
+            const word& modelName,
+            const word& resolvedRegionName,
+            const word& defaultRegion
+        )
+        {
+            if
+            (
+                fsiProperties.found(modelName + "Region")
+             && runTime.controlDict().subOrEmptyDict(modelName).found("region")
+            )
+            {
+                const word controlDictRegion
+                (
+                    runTime.controlDict().subOrEmptyDict(modelName)
+                        .lookupOrDefault<word>("region", defaultRegion)
+                );
+
+                if (controlDictRegion != resolvedRegionName)
+                {
+                    WarningInFunction
+                        << "Conflicting " << modelName << " region settings: "
+                        << "using '" << resolvedRegionName << "' from "
+                        << "fsiProperties and ignoring '" << controlDictRegion
+                        << "' from controlDict/" << modelName
+                        << "/region" << endl;
+                }
+            }
+        }
+    }
 }
 
 // * * * * * * * * * * * * * Private Member Functions  * * * * * * * * * * * //
@@ -271,7 +329,7 @@ Foam::fluidSolidInterface::fluidSolidInterface
     const word& region
 )
 :
-    physicsModel(type, runTime),
+    physicsModel(type, runTime, region),
     IOdictionary
     (
         IOobject
@@ -284,8 +342,8 @@ Foam::fluidSolidInterface::fluidSolidInterface
         )
     ),
     fsiProperties_(subDict(type + "Coeffs")),
-    fluid_(fluidModel::New(runTime, "fluid")),
-    solid_(solidModel::New(runTime, "solid")),
+    fluid_(),
+    solid_(),
     solidPatchNames_(),
     fluidPatchNames_(),
     solidPatchIndices_(),
@@ -362,6 +420,37 @@ Foam::fluidSolidInterface::fluidSolidInterface
     ),
     accumulatedFluidInterfacesDisplacementsList_()
 {
+    const word fluidRegion
+    (
+        resolvedRegion(runTime, fsiProperties_, "fluid", "fluid")
+    );
+
+    const word solidRegion
+    (
+        resolvedRegion(runTime, fsiProperties_, "solid", "solid")
+    );
+
+    warnOnConflictingRegion
+    (
+        runTime,
+        fsiProperties_,
+        "fluid",
+        fluidRegion,
+        "fluid"
+    );
+
+    warnOnConflictingRegion
+    (
+        runTime,
+        fsiProperties_,
+        "solid",
+        solidRegion,
+        "solid"
+    );
+
+    fluid_ = fluidModel::New(runTime, fluidRegion);
+    solid_ = solidModel::New(runTime, solidRegion);
+
     Info<< "additionalMeshCorrection: " << additionalMeshCorrection_ << endl;
 
     // Check if couplingStartTime is specified

--- a/src/solids4FoamModels/physicsModel/physicsModel.C
+++ b/src/solids4FoamModels/physicsModel/physicsModel.C
@@ -28,6 +28,36 @@ namespace Foam
 {
     defineTypeNameAndDebug(physicsModel, 0);
     defineRunTimeSelectionTable(physicsModel, physicsModel);
+
+    namespace
+    {
+        fileName physicsPropertiesPath(Time& runTime, const word& region)
+        {
+            if (region != dynamicFvMesh::defaultRegion)
+            {
+                IOobject regionHeader
+                (
+                    "physicsProperties",
+                    runTime.caseConstant()/region,
+                    runTime,
+                    IOobject::READ_IF_PRESENT,
+                    IOobject::NO_WRITE,
+                    false
+                );
+
+#ifdef OPENFOAM_NOT_EXTEND
+                if (regionHeader.typeHeaderOk<IOdictionary>(true))
+#else
+                if (regionHeader.headerOk())
+#endif
+                {
+                    return fileName(runTime.caseConstant()/region);
+                }
+            }
+
+            return fileName(runTime.caseConstant());
+        }
+    }
 }
 
 // * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
@@ -44,9 +74,7 @@ Foam::physicsModel::physicsModel
         IOobject
         (
             "physicsProperties",
-            bool(region == dynamicFvMesh::defaultRegion)
-          ? fileName(runTime.caseConstant())
-          : fileName(runTime.caseConstant()/region),
+            physicsPropertiesPath(runTime, region),
             runTime,
             IOobject::MUST_READ,
             IOobject::NO_WRITE
@@ -77,9 +105,7 @@ Foam::autoPtr<Foam::physicsModel> Foam::physicsModel::New
         IOobject
         (
             "physicsProperties",
-            bool(region == dynamicFvMesh::defaultRegion)
-          ? fileName(runTime.caseConstant())
-          : fileName(runTime.caseConstant()/region),
+            physicsPropertiesPath(runTime, region),
             runTime,
             IOobject::MUST_READ,
             IOobject::NO_WRITE,

--- a/src/solids4FoamModels/physicsModel/physicsModel.C
+++ b/src/solids4FoamModels/physicsModel/physicsModel.C
@@ -53,8 +53,6 @@ Foam::physicsModel::physicsModel
         )
     ),
     runTime_(runTime),
-    fluidMeshPtr_(),
-    solidMeshPtr_(),
     printInfo_(true)
 {}
 

--- a/src/solids4FoamModels/physicsModel/physicsModel.H
+++ b/src/solids4FoamModels/physicsModel/physicsModel.H
@@ -59,12 +59,6 @@ class physicsModel
         //- Reference to the master time object
         Time& runTime_;
 
-        //- Fluid mesh pointer
-        autoPtr<dynamicFvMesh> fluidMeshPtr_;
-
-        //- Solid mesh pointer
-        autoPtr<dynamicFvMesh> solidMeshPtr_;
-
         //- Flag to indicate whether info statements should be printed to
         //  std out or not. Defaults to true but can be modified by the
         //  printInfo() access function

--- a/src/solids4FoamModels/solidModels/solidModel/solidModel.C
+++ b/src/solids4FoamModels/solidModels/solidModel/solidModel.C
@@ -609,7 +609,7 @@ Foam::solidModel::solidModel
     const word& region
 )
 :
-    physicsModel(type, runTime),
+    physicsModel(type, runTime, region),
     regIOobject // ZT, Jul18: allow for multiple solid regions
     (
         IOobject


### PR DESCRIPTION
## Summary
- remove the unused `physicsModel` mesh pointers
- make `fluidSolidInterface` resolve `fluidRegion` and `solidRegion` from `fsiProperties` with `controlDict` fallback
- pass the selected region through the `physicsModel` base constructor while preserving fallback to global `physicsProperties`

## Validation
- `./Allwclean && ./Allwmake -j 20`
- `./tutorials/Alltest`
- `./tutorials/Alltest-regression -j 20`

## act preflight
- local `act` startup is working on this machine
- a full local `act` completion is being rerun now
