### PR TITLE
[codex] Update solids4foam skill guidance

### DIFF
--- a/.agents/skills/solids4foam/SKILL.md
+++ b/.agents/skills/solids4foam/SKILL.md
@@ -19,13 +19,20 @@ This document defines how automated coding changes should be made in this reposi
 - Prefer consistency with nearby code over introducing new style variants.
 - Avoid broad refactors unless explicitly requested.
 - Keep compatibility across supported OpenFOAM variants in mind.
+- State assumptions before implementation when behavior, target OpenFOAM
+  variant, or expected numerical result is unclear.
+- If multiple interpretations are plausible, ask or present the tradeoff instead
+  of silently choosing.
+- Push back on requests that would cause unnecessary redesign, broad
+  compatibility risk, or speculative behavior.
 
 ## 2) Coding Style Rules
 
 ### C++ style
 
 - Follow existing OpenFOAM/solids4foam style in surrounding files.
-- Use the same indentation, brace style, comment style, and naming conventions as local code.
+- Use the same indentation, brace style, comment style, and naming conventions
+  as local code.
 - Keep lines and expressions readable; avoid clever/condensed code.
 - Prefer explicit, local, maintainable changes over abstraction-heavy rewrites.
 - Add comments only when behavior is non-obvious; do not add redundant comments.
@@ -94,6 +101,12 @@ Rules when adding new runtime-selectable classes:
 - Do not rename symbols/files unless required.
 - Do not alter behavior outside requested scope.
 - Prefer targeted edits over cleanup passes.
+- Every changed line should trace directly to the user's request, a required
+  build fix, or a test/documentation update needed to verify the change.
+- If unrelated dead code or cleanup is noticed, mention it separately; do not
+  remove it unless asked.
+- Remove only unused code, imports, includes, or variables introduced by the
+  current change.
 
 Before finalizing, verify:
 
@@ -101,27 +114,30 @@ Before finalizing, verify:
 - No unrelated files changed.
 - No compatibility regressions introduced by style-only edits.
 
-## 6) Change Delivery Format (Mandatory)
+## 6) Change Delivery Format
 
-All code changes must be returned as **git patches**.
-
-- Provide changes in patch form (`git diff`/unified diff) suitable for application.
+- Keep changes patch-oriented and reviewable.
+- When asked for a patch, provide unified diff output suitable for application.
+- When editing directly in the workspace, summarize changed files and
+  verification performed.
 - Keep patches focused and reviewable.
 - If multiple concerns are required, split into logical commits/patches.
-- Do not provide only prose summaries when code edits were requested.
 
 ## 7) Practical Workflow for Codex
 
-1. Read nearby code and follow local patterns.
-2. Implement minimal patch.
-3. Update runtime registration/build lists if adding a new class.
-4. Run or describe relevant checks/tests.
-5. Return changes as patch-oriented output.
+1. Define the concrete success criteria for the request.
+2. Read nearby code and follow local patterns.
+3. Implement the minimal patch.
+4. Update runtime registration/build lists if adding a new class.
+5. Verify with the narrowest relevant build/test/check.
+6. Report what was verified and what was not.
 
 ## 8) What to Avoid
 
 - Large-scale refactors without explicit request.
 - API redesigns when a local fix is sufficient.
+- New dictionary options, runtime switches, fallback behavior, or
+  configurability unless requested or required by existing repository patterns.
 - Introducing new style conventions inconsistent with repository norms.
 - Silent behavioral changes not documented in the patch summary.
 

--- a/.claude/skills/solids4foam/SKILL.md
+++ b/.claude/skills/solids4foam/SKILL.md
@@ -19,13 +19,20 @@ This document defines how automated coding changes should be made in this reposi
 - Prefer consistency with nearby code over introducing new style variants.
 - Avoid broad refactors unless explicitly requested.
 - Keep compatibility across supported OpenFOAM variants in mind.
+- State assumptions before implementation when behavior, target OpenFOAM
+  variant, or expected numerical result is unclear.
+- If multiple interpretations are plausible, ask or present the tradeoff instead
+  of silently choosing.
+- Push back on requests that would cause unnecessary redesign, broad
+  compatibility risk, or speculative behavior.
 
 ## 2) Coding Style Rules
 
 ### C++ style
 
 - Follow existing OpenFOAM/solids4foam style in surrounding files.
-- Use the same indentation, brace style, comment style, and naming conventions as local code.
+- Use the same indentation, brace style, comment style, and naming conventions
+  as local code.
 - Keep lines and expressions readable; avoid clever/condensed code.
 - Prefer explicit, local, maintainable changes over abstraction-heavy rewrites.
 - Add comments only when behavior is non-obvious; do not add redundant comments.
@@ -94,6 +101,12 @@ Rules when adding new runtime-selectable classes:
 - Do not rename symbols/files unless required.
 - Do not alter behavior outside requested scope.
 - Prefer targeted edits over cleanup passes.
+- Every changed line should trace directly to the user's request, a required
+  build fix, or a test/documentation update needed to verify the change.
+- If unrelated dead code or cleanup is noticed, mention it separately; do not
+  remove it unless asked.
+- Remove only unused code, imports, includes, or variables introduced by the
+  current change.
 
 Before finalizing, verify:
 
@@ -101,27 +114,30 @@ Before finalizing, verify:
 - No unrelated files changed.
 - No compatibility regressions introduced by style-only edits.
 
-## 6) Change Delivery Format (Mandatory)
+## 6) Change Delivery Format
 
-All code changes must be returned as **git patches**.
-
-- Provide changes in patch form (`git diff`/unified diff) suitable for application.
+- Keep changes patch-oriented and reviewable.
+- When asked for a patch, provide unified diff output suitable for application.
+- When editing directly in the workspace, summarize changed files and
+  verification performed.
 - Keep patches focused and reviewable.
 - If multiple concerns are required, split into logical commits/patches.
-- Do not provide only prose summaries when code edits were requested.
 
 ## 7) Practical Workflow for Codex
 
-1. Read nearby code and follow local patterns.
-2. Implement minimal patch.
-3. Update runtime registration/build lists if adding a new class.
-4. Run or describe relevant checks/tests.
-5. Return changes as patch-oriented output.
+1. Define the concrete success criteria for the request.
+2. Read nearby code and follow local patterns.
+3. Implement the minimal patch.
+4. Update runtime registration/build lists if adding a new class.
+5. Verify with the narrowest relevant build/test/check.
+6. Report what was verified and what was not.
 
 ## 8) What to Avoid
 
 - Large-scale refactors without explicit request.
 - API redesigns when a local fix is sufficient.
+- New dictionary options, runtime switches, fallback behavior, or
+  configurability unless requested or required by existing repository patterns.
 - Introducing new style conventions inconsistent with repository norms.
 - Silent behavioral changes not documented in the patch summary.
 


### PR DESCRIPTION
## Summary

This PR updates both solids4foam skill guidance files with behaviour rules adapted from the reviewed CLAUDE.md guidance (at https://github.com/forrestchang/andrej-karpathy-skills):

- Adds explicit assumptions, ambiguity, and pushback guidance before implementation.
- Strengthens surgical-change expectations with a changed-line traceability rule.
- Clarifies patch-oriented delivery for both direct workspace edits and requested unified diffs.
- Adds concrete success criteria and verification steps to the practical workflow.
- Warns against speculative dictionary options, runtime switches, fallback behaviour, and configurability.

## Impact

These changes should make automated edits in this repository more conservative, easier to review, and clearer about verification expectations while preserving the existing OpenFOAM/solids4foam-specific guidance.

## Validation

- markdownlint .agents/skills/solids4foam/SKILL.md .claude/skills/solids4foam/SKILL.md
- git diff --check

Note: npx markdownlint-cli2-action was attempted first, but npm reported that it could not determine an executable to run. The locally installed markdownlint command passed.