### PR TITLE
Use compatibilityFunctions.H to replace ifdef blocks; bump version to v2.3

### DIFF
--- a/applications/scripts/solidModelDicts/linearGeometryTotalDisplacement.snes/fvSchemes
+++ b/applications/scripts/solidModelDicts/linearGeometryTotalDisplacement.snes/fvSchemes
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/applications/scripts/solidModelDicts/linearGeometryTotalDisplacement.snes/solidProperties
+++ b/applications/scripts/solidModelDicts/linearGeometryTotalDisplacement.snes/solidProperties
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/applications/utilities/perturbMeshPoints/perturbMeshPointsDict
+++ b/applications/utilities/perturbMeshPoints/perturbMeshPointsDict
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |
@@ -46,6 +46,5 @@ fixedPatches
 // Optional: local minimum allow cell volume relative to the initial volume
 // Defaults to 0.1
 //minCellVol 0.1;
-
 
 // ************************************************************************* //

--- a/applications/utilities/smoothlyDistortMeshPoints/smoothlyDistortMeshPointsDict
+++ b/applications/utilities/smoothlyDistortMeshPoints/smoothlyDistortMeshPointsDict
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/applications/utilities/splitPatch/splitPatchDict
+++ b/applications/utilities/splitPatch/splitPatchDict
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/src/solids4FoamModels/fluidModels/fvPatchFields/elasticWallPressure/elasticWallPressureFvPatchScalarField.C
+++ b/src/solids4FoamModels/fluidModels/fvPatchFields/elasticWallPressure/elasticWallPressureFvPatchScalarField.C
@@ -22,6 +22,7 @@ License
 #include "volFields.H"
 #include "surfaceFields.H"
 #include "fluidSolidInterface.H"
+#include "compatibilityFunctions.H"
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
@@ -390,11 +391,7 @@ void elasticWallPressureFvPatchScalarField::patchFlux
         rAU = patch().lookupPatchField<surfaceScalarField, scalar>("rAUf");
     }
 
-#ifdef OPENFOAM_NOT_EXTEND
-    flux.boundaryFieldRef()[patch().index()] = rAU*snGrad()*patch().magSf();
-#else
-    flux.boundaryField()[patch().index()] = rAU*snGrad()*patch().magSf();
-#endif
+    boundaryFieldRef(flux)[patch().index()] = rAU*snGrad()*patch().magSf();
 }
 
 

--- a/src/solids4FoamModels/fluidModels/fvPatchFields/flowRateOutletPressure/flowRateOutletPressureFvPatchScalarField.C
+++ b/src/solids4FoamModels/fluidModels/fvPatchFields/flowRateOutletPressure/flowRateOutletPressureFvPatchScalarField.C
@@ -25,6 +25,7 @@ License
 
 #include "flowRateInletVelocityFvPatchVectorField.H"
 #include "fvc.H"
+#include "compatibilityFunctions.H"
 
 // * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
 
@@ -267,13 +268,8 @@ void Foam::flowRateOutletPressureFvPatchScalarField::updateCoeffs()
 
     scalar reqOutletFlowRate = -inletFlowRate*flowRateFraction_;
 
-#ifdef OPENFOAM_NOT_EXTEND
     scalarField& phip =
-        phi.boundaryFieldRef()[this->patch().index()];
-#else
-    scalarField& phip =
-        phi.boundaryField()[this->patch().index()];
-#endif
+        boundaryFieldRef(phi)[this->patch().index()];
 
     label size = this->patch().size();
     reduce(size, sumOp<label>());

--- a/src/solids4FoamModels/functionObjects/contactPatchTestAnalyticalSolution/contactPatchTestAnalyticalSolution.C
+++ b/src/solids4FoamModels/functionObjects/contactPatchTestAnalyticalSolution/contactPatchTestAnalyticalSolution.C
@@ -23,6 +23,7 @@ License
 #include "pointFields.H"
 #include "coordinateSystem.H"
 #include "symmTensor.H"
+#include "compatibilityFunctions.H"
 
 // * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
 
@@ -100,11 +101,7 @@ bool Foam::contactPatchTestAnalyticalSolution::writeData()
     {
         if (mesh.boundary()[patchI].type() != "empty")
         {
-#ifdef OPENFOAM_NOT_EXTEND
-            symmTensorField& sP = analyticalStress.boundaryFieldRef()[patchI];
-#else
-            symmTensorField& sP = analyticalStress.boundaryField()[patchI];
-#endif
+            symmTensorField& sP = boundaryFieldRef(analyticalStress)[patchI];
             forAll(sP, faceI)
             {
                 sP[faceI] = contactPatchTestStress();
@@ -148,11 +145,7 @@ bool Foam::contactPatchTestAnalyticalSolution::writeData()
         {
             if (mesh.boundary()[patchI].type() != "empty")
             {
-#ifdef OPENFOAM_NOT_EXTEND
-                scalarField& sP = relError.boundaryFieldRef()[patchI];
-#else
-                scalarField& sP = relError.boundaryField()[patchI];
-#endif
+                scalarField& sP = boundaryFieldRef(relError)[patchI];
                 forAll(sP, faceI)
                 {
                     sP[faceI] =

--- a/src/solids4FoamModels/functionObjects/curvedCantileverAnalyticalSolution/curvedCantileverAnalyticalSolution.C
+++ b/src/solids4FoamModels/functionObjects/curvedCantileverAnalyticalSolution/curvedCantileverAnalyticalSolution.C
@@ -23,6 +23,7 @@ License
 #include "pointFields.H"
 #include "coordinateSystem.H"
 #include "symmTensor.H"
+#include "compatibilityFunctions.H"
 
 // * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
 
@@ -159,11 +160,7 @@ bool Foam::curvedCantileverAnalyticalSolution::writeData()
     {
         if (mesh.boundary()[patchI].type() != "empty")
         {
-#ifdef OPENFOAM_NOT_EXTEND
-            symmTensorField& sP = analyticalStress.boundaryFieldRef()[patchI];
-#else
-            symmTensorField& sP = analyticalStress.boundaryField()[patchI];
-#endif
+            symmTensorField& sP = boundaryFieldRef(analyticalStress)[patchI];
             const vectorField& CP = C.boundaryField()[patchI];
 
             forAll(sP, faceI)

--- a/src/solids4FoamModels/functionObjects/plateHoleAnalyticalSolution/plateHoleAnalyticalSolution.C
+++ b/src/solids4FoamModels/functionObjects/plateHoleAnalyticalSolution/plateHoleAnalyticalSolution.C
@@ -22,6 +22,7 @@ License
 #include "volFields.H"
 #include "pointFields.H"
 #include "coordinateSystem.H"
+#include "compatibilityFunctions.H"
 
 // * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
 
@@ -207,13 +208,8 @@ bool Foam::plateHoleAnalyticalSolution::writeData()
         {
             if (mesh.boundary()[patchI].type() != "empty")
             {
-#ifdef OPENFOAM_NOT_EXTEND
-                symmTensorField& sP = analyticalStress.boundaryFieldRef()[patchI];
-                vectorField& aDP = analyticalD.boundaryFieldRef()[patchI];
-#else
-                symmTensorField& sP = analyticalStress.boundaryField()[patchI];
-                vectorField& aDP = analyticalD.boundaryField()[patchI];
-#endif
+                symmTensorField& sP = boundaryFieldRef(analyticalStress)[patchI];
+                vectorField& aDP = boundaryFieldRef(analyticalD)[patchI];
                 const vectorField& CP = C.boundaryField()[patchI];
 
                 forAll(sP, faceI)

--- a/src/solids4FoamModels/functionObjects/principalStresses/principalStressFields.C
+++ b/src/solids4FoamModels/functionObjects/principalStresses/principalStressFields.C
@@ -18,6 +18,7 @@ License
 \*----------------------------------------------------------------------------*/
 
 #include "principalStressFields.H"
+#include "compatibilityFunctions.H"
 
 // * * * * * * * * * * * * * * * * * * Functions * * * * * * * * * * * * * * //
 
@@ -240,23 +241,13 @@ void Foam::writePrincipalStressFields
 
     // References to internalFields for efficiency
     const symmTensorField& sigmaI = sigma.internalField();
-#ifdef OPENFOAM_NOT_EXTEND
-    scalarField& sigmaMaxI = sigmaMax.primitiveFieldRef();
-    scalarField& sigmaMidI = sigmaMid.primitiveFieldRef();
-    scalarField& sigmaMinI = sigmaMin.primitiveFieldRef();
-    vectorField& sigmaMaxDirI = sigmaMaxDir.primitiveFieldRef();
-    vectorField& sigmaMidDirI = sigmaMidDir.primitiveFieldRef();
-    vectorField& sigmaMinDirI = sigmaMinDir.primitiveFieldRef();
-    scalarField& sigmaDiffI = sigmaDiff.primitiveFieldRef();
-#else
-    scalarField& sigmaMaxI = sigmaMax.internalField();
-    scalarField& sigmaMidI = sigmaMid.internalField();
-    scalarField& sigmaMinI = sigmaMin.internalField();
-    vectorField& sigmaMaxDirI = sigmaMaxDir.internalField();
-    vectorField& sigmaMidDirI = sigmaMidDir.internalField();
-    vectorField& sigmaMinDirI = sigmaMinDir.internalField();
-    scalarField& sigmaDiffI = sigmaDiff.internalField();
-#endif
+    scalarField& sigmaMaxI = primitiveFieldRef(sigmaMax);
+    scalarField& sigmaMidI = primitiveFieldRef(sigmaMid);
+    scalarField& sigmaMinI = primitiveFieldRef(sigmaMin);
+    vectorField& sigmaMaxDirI = primitiveFieldRef(sigmaMaxDir);
+    vectorField& sigmaMidDirI = primitiveFieldRef(sigmaMidDir);
+    vectorField& sigmaMinDirI = primitiveFieldRef(sigmaMinDir);
+    scalarField& sigmaDiffI = primitiveFieldRef(sigmaDiff);
 
     forAll (sigmaI, cellI)
     {
@@ -284,23 +275,13 @@ void Foam::writePrincipalStressFields
         )
         {
             const symmTensorField& pSigma = sigma.boundaryField()[patchI];
-#ifdef OPENFOAM_NOT_EXTEND
-            scalarField& pSigmaMax = sigmaMax.boundaryFieldRef()[patchI];
-            scalarField& pSigmaMid = sigmaMid.boundaryFieldRef()[patchI];
-            scalarField& pSigmaMin = sigmaMin.boundaryFieldRef()[patchI];
-            vectorField& pSigmaMaxDir = sigmaMaxDir.boundaryFieldRef()[patchI];
-            vectorField& pSigmaMidDir = sigmaMidDir.boundaryFieldRef()[patchI];
-            vectorField& pSigmaMinDir = sigmaMinDir.boundaryFieldRef()[patchI];
-            scalarField& pSigmaDiff = sigmaDiff.boundaryFieldRef()[patchI];
-#else
-            scalarField& pSigmaMax = sigmaMax.boundaryField()[patchI];
-            scalarField& pSigmaMid = sigmaMid.boundaryField()[patchI];
-            scalarField& pSigmaMin = sigmaMin.boundaryField()[patchI];
-            vectorField& pSigmaMaxDir = sigmaMaxDir.boundaryField()[patchI];
-            vectorField& pSigmaMidDir = sigmaMidDir.boundaryField()[patchI];
-            vectorField& pSigmaMinDir = sigmaMinDir.boundaryField()[patchI];
-            scalarField& pSigmaDiff = sigmaDiff.boundaryField()[patchI];
-#endif
+            scalarField& pSigmaMax = boundaryFieldRef(sigmaMax)[patchI];
+            scalarField& pSigmaMid = boundaryFieldRef(sigmaMid)[patchI];
+            scalarField& pSigmaMin = boundaryFieldRef(sigmaMin)[patchI];
+            vectorField& pSigmaMaxDir = boundaryFieldRef(sigmaMaxDir)[patchI];
+            vectorField& pSigmaMidDir = boundaryFieldRef(sigmaMidDir)[patchI];
+            vectorField& pSigmaMinDir = boundaryFieldRef(sigmaMinDir)[patchI];
+            scalarField& pSigmaDiff = boundaryFieldRef(sigmaDiff)[patchI];
 
             forAll(pSigmaMax, faceI)
             {

--- a/src/solids4FoamModels/functionObjects/solidTractions/solidTractions.C
+++ b/src/solids4FoamModels/functionObjects/solidTractions/solidTractions.C
@@ -21,6 +21,7 @@ License
 #include "addToRunTimeSelectionTable.H"
 #include "volFields.H"
 #include "surfaceFields.H"
+#include "compatibilityFunctions.H"
 
 // * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
 
@@ -90,11 +91,7 @@ bool Foam::solidTractions::writeData()
                 if (!traction.boundaryField()[patchI].coupled())
                 {
                     // It is assumed that sigma is the true (Cauchy) stress
-#ifdef OPENFOAM_NOT_EXTEND
-                    traction.boundaryFieldRef()[patchI] =
-#else
-                    traction.boundaryField()[patchI] =
-#endif
+                    boundaryFieldRef(traction)[patchI] =
                         mesh.boundary()[patchI].nf()
                       & sigma.boundaryField()[patchI];
                 }
@@ -138,11 +135,7 @@ bool Foam::solidTractions::writeData()
                     nCurrent /= mag(nCurrent);
 
                    // It is assumed that sigma is the true (Cauchy) stress
-#ifdef OPENFOAM_NOT_EXTEND
-                   traction.boundaryFieldRef()[patchI] =
-#else
-                   traction.boundaryField()[patchI] =
-#endif
+                   boundaryFieldRef(traction)[patchI] =
                       nCurrent & sigma.boundaryField()[patchI];
                 }
             }
@@ -172,11 +165,7 @@ bool Foam::solidTractions::writeData()
             {
                 if (!traction.boundaryField()[patchI].coupled())
                 {
-#ifdef OPENFOAM_NOT_EXTEND
-                    traction.boundaryFieldRef()[patchI] =
-#else
-                    traction.boundaryField()[patchI] =
-#endif
+                    boundaryFieldRef(traction)[patchI] =
                         mesh.boundary()[patchI].nf()
                       & sigma.boundaryField()[patchI];
                 }

--- a/src/solids4FoamModels/functionObjects/sphericalCavityAnalyticalSolution/sphericalCavityAnalyticalSolution.C
+++ b/src/solids4FoamModels/functionObjects/sphericalCavityAnalyticalSolution/sphericalCavityAnalyticalSolution.C
@@ -23,6 +23,7 @@ License
 #include "pointFields.H"
 #include "sphericalCavityStressDisplacement.H"
 #include "OSspecific.H"
+#include "compatibilityFunctions.H"
 
 // * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
 
@@ -136,13 +137,8 @@ bool Foam::sphericalCavityAnalyticalSolution::writeData()
         {
             if (mesh.boundary()[patchI].type() != "empty")
             {
-#ifdef OPENFOAM_NOT_EXTEND
-                symmTensorField& sP = analyticalStress.boundaryFieldRef()[patchI];
-                vectorField& aDP = analyticalD.boundaryFieldRef()[patchI];
-#else
-                symmTensorField& sP = analyticalStress.boundaryField()[patchI];
-                vectorField& aDP = analyticalD.boundaryField()[patchI];
-#endif
+                symmTensorField& sP = boundaryFieldRef(analyticalStress)[patchI];
+                vectorField& aDP = boundaryFieldRef(analyticalD)[patchI];
                 const vectorField& CP = C.boundaryField()[patchI];
 
                 forAll(sP, faceI)

--- a/src/solids4FoamModels/functionObjects/squarePlateAnalyticalSolution/squarePlateAnalyticalSolution.C
+++ b/src/solids4FoamModels/functionObjects/squarePlateAnalyticalSolution/squarePlateAnalyticalSolution.C
@@ -24,6 +24,7 @@ License
 #include "volFields.H"
 #include "pointFields.H"
 #include "squarePlateStressDisplacement.H"
+#include "compatibilityFunctions.H"
 
 // * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
 
@@ -134,11 +135,7 @@ bool Foam::squarePlateAnalyticalSolution::writeData()
         {
             if (mesh.boundary()[patchI].type() != "empty")
             {
-#ifdef OPENFOAM_NOT_EXTEND
-                scalarField& aDP = analyticalD.boundaryFieldRef()[patchI];
-#else
-                scalarField& aDP = analyticalD.boundaryField()[patchI];
-#endif
+                scalarField& aDP = boundaryFieldRef(analyticalD)[patchI];
                 const vectorField& CP = C.boundaryField()[patchI];
 
                 forAll(aDP, faceI)

--- a/src/solids4FoamModels/functionObjects/transformStressToCylindrical/transformStressToCylindrical.C
+++ b/src/solids4FoamModels/functionObjects/transformStressToCylindrical/transformStressToCylindrical.C
@@ -22,6 +22,7 @@ License
 #include "volFields.H"
 #include "surfaceFields.H"
 #include "coordinateSystem.H"
+#include "compatibilityFunctions.H"
 
 // * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
 
@@ -98,13 +99,8 @@ bool Foam::transformStressToCylindrical::writeData()
 
             const symmTensorField& sigmaP = sigma.boundaryField()[patchI];
 
-#ifdef OPENFOAM_NOT_EXTEND
             symmTensorField& sigmaTP =
-                sigmaTransformed.boundaryFieldRef()[patchI];
-#else
-            symmTensorField& sigmaTP =
-                sigmaTransformed.boundaryField()[patchI];
-#endif
+                boundaryFieldRef(sigmaTransformed)[patchI];
 
             forAll(sigmaTP, faceI)
             {

--- a/src/solids4FoamModels/materialModels/mechanicalModel/solidSubMeshes/solidSubMeshes.C
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/solidSubMeshes/solidSubMeshes.C
@@ -23,6 +23,7 @@ License
 #include "wedgePolyPatch.H"
 #include "ZoneIDs.H"
 #include "demandDrivenData.H"
+#include "compatibilityFunctions.H"
 
 // * * * * * * * * * * * * * Private Member Functions  * * * * * * * * * * * //
 
@@ -170,11 +171,7 @@ void Foam::solidSubMeshes::checkCellZones() const
         baseMesh(),
         dimensionedScalar("zero", dimless, 0.0)
     );
-#ifdef OPENFOAM_NOT_EXTEND
-    scalarField& nCellZonesI = nCellZones.ref();
-#else
-    scalarField& nCellZonesI = nCellZones.internalField();
-#endif
+    scalarField& nCellZonesI = primitiveFieldRef(nCellZones);
 
     forAll(cellZoneNames_, matI)
     {
@@ -1967,11 +1964,7 @@ void Foam::solidSubMeshes::correctBoundarySnGrad
         {
             const polyPatch& ppatch = subMesh.boundaryMesh()[patchI];
             const vectorField n(subMesh.boundary()[patchI].nf());
-#ifdef OPENFOAM_NOT_EXTEND
-            tensorField& patchGradD = subMeshGradD.boundaryFieldRef()[patchI];
-#else
-            tensorField& patchGradD = subMeshGradD.boundaryField()[patchI];
-#endif
+            tensorField& patchGradD = boundaryFieldRef(subMeshGradD)[patchI];
 
             const tensorField patchGradDif
             (
@@ -2056,13 +2049,8 @@ void Foam::solidSubMeshes::correctBoundarySnGradf
         {
             const polyPatch& ppatch = subMesh.boundaryMesh()[patchI];
             const vectorField n(subMesh.boundary()[patchI].nf());
-#ifdef OPENFOAM_NOT_EXTEND
             tensorField& patchGradDf =
-                subMeshGradDf.boundaryFieldRef()[patchI];
-#else
-            tensorField& patchGradDf =
-                subMeshGradDf.boundaryField()[patchI];
-#endif
+                boundaryFieldRef(subMeshGradDf)[patchI];
 
             const tensorField patchGradDif
             (

--- a/src/solids4FoamModels/materialModels/mechanicalModel/solidSubMeshes/solidSubMeshesTemplates.C
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/solidSubMeshes/solidSubMeshesTemplates.C
@@ -20,6 +20,7 @@ License
 #include "solidSubMeshes.H"
 #include "processorFvsPatchField.H"
 #include "processorPointPatchFields.H"
+#include "compatibilityFunctions.H"
 #ifdef FOAMEXTEND
     #include "componentMixedPointPatchFields.H"
 #endif
@@ -61,13 +62,8 @@ void Foam::solidSubMeshes::mapSubMeshVolFields
 
             if (patchMap[patchI] != -1)
             {
-#ifdef OPENFOAM_NOT_EXTEND
                 fvPatchField<Type>& baseMeshFieldP =
-                    baseMeshField.boundaryFieldRef()[patchMap[patchI]];
-#else
-                fvPatchField<Type>& baseMeshFieldP =
-                    baseMeshField.boundaryField()[patchMap[patchI]];
-#endif
+                    boundaryFieldRef(baseMeshField)[patchMap[patchI]];
 
                 if (!baseMeshFieldP.coupled())
                 {
@@ -134,13 +130,8 @@ void Foam::solidSubMeshes::mapSubMeshSurfaceFields
 
             if (patchMap[patchI] != -1)
             {
-#ifdef OPENFOAM_NOT_EXTEND
                 fvsPatchField<Type>& baseMeshFieldP =
-                    baseMeshField.boundaryFieldRef()[patchMap[patchI]];
-#else
-                fvsPatchField<Type>& baseMeshFieldP =
-                    baseMeshField.boundaryField()[patchMap[patchI]];
-#endif
+                    boundaryFieldRef(baseMeshField)[patchMap[patchI]];
 
                 // Note: unlike volFields, we do map on the coupled patches for
                 // surface fields
@@ -180,15 +171,10 @@ void Foam::solidSubMeshes::mapSubMeshSurfaceFields
                             globalGlobalMeshFace
                             - baseMesh().boundaryMesh()[curPatch].start();
 
-#ifdef OPENFOAM_NOT_EXTEND
-                        baseMeshField.boundaryFieldRef()
+                        boundaryFieldRef(baseMeshField)
                         [
                             curPatch
                         ][curPatchFace] = subMeshFieldP[faceI];
-#else
-                        baseMeshField.boundaryField()[curPatch][curPatchFace] =
-                            subMeshFieldP[faceI];
-#endif
                     }
                 }
             }
@@ -229,13 +215,8 @@ void Foam::solidSubMeshes::mapSubMeshSurfaceFields
 
     forAll(baseMeshField.boundaryField(), patchI)
     {
-#ifdef OPENFOAM_NOT_EXTEND
         fvsPatchField<Type>& baseMeshFieldP =
-            baseMeshField.boundaryFieldRef()[patchI];
-#else
-        fvsPatchField<Type>& baseMeshFieldP =
-            baseMeshField.boundaryField()[patchI];
-#endif
+            boundaryFieldRef(baseMeshField)[patchI];
 
         if (baseMeshFieldP.type() == processorFvsPatchField<Type>::typeName)
         {

--- a/src/solids4FoamModels/numerics/fvc/fvcGradf.C
+++ b/src/solids4FoamModels/numerics/fvc/fvcGradf.C
@@ -28,6 +28,7 @@ License
 #include "wedgeFvPatch.H"
 #include "fvc.H"
 #include "zeroGradientFvPatchFields.H"
+#include "compatibilityFunctions.H"
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
@@ -168,11 +169,7 @@ tmp
 
     if (!axisymmetric)
     {
-#ifdef OPENFOAM_NOT_EXTEND
-        Field<GradType>& gradI = tGrad.ref().primitiveFieldRef();
-#else
-        Field<GradType>& gradI = tGrad().internalField();
-#endif
+        Field<GradType>& gradI = primitiveFieldRef(tmpRef(tGrad));
 
         const vectorField& points = mesh.points();
         const faceList& faces = mesh.faces();
@@ -231,11 +228,7 @@ tmp
 
         forAll(tGrad().boundaryField(), patchI)
         {
-#ifdef OPENFOAM_NOT_EXTEND
-            Field<GradType>& patchGrad = tGrad.ref().boundaryFieldRef()[patchI];
-#else
-            Field<GradType>& patchGrad = tGrad().boundaryField()[patchI];
-#endif
+            Field<GradType>& patchGrad = boundaryFieldRef(tmpRef(tGrad))[patchI];
 
             const vectorField& patchN = n.boundaryField()[patchI];
 
@@ -481,11 +474,7 @@ tmp
         )
     );
 
-#ifdef OPENFOAM_NOT_EXTEND
-    Field<GradType>& iGrad = tGrad.ref().primitiveFieldRef();
-#else
-    Field<GradType>& iGrad = tGrad().internalField();
-#endif
+    Field<GradType>& iGrad = primitiveFieldRef(tmpRef(tGrad));
 
     const vectorField& points = mesh.points();
 
@@ -708,13 +697,8 @@ tmp
                 pf.boundaryField()[patchI].patchInternalField()
             );
 
-#ifdef OPENFOAM_NOT_EXTEND
-            tGrad.ref().boundaryFieldRef()[patchI] ==
+            boundaryFieldRef(tmpRef(tGrad))[patchI] ==
                 fGrad(mesh.boundaryMesh()[patchI], ppf);
-#else
-            tGrad().boundaryField()[patchI] ==
-                fGrad(mesh.boundaryMesh()[patchI], ppf);
-#endif
         }
 #ifndef OPENFOAM_NOT_EXTEND
         else if (isA<ggiFvPatch>(mesh.boundary()[patchI]))
@@ -767,11 +751,7 @@ tmp
         {
             const vectorField n(vf.mesh().boundary()[patchi].nf());
 
-#ifdef OPENFOAM_NOT_EXTEND
-            tGrad.ref().boundaryFieldRef()[patchi] +=
-#else
-            tGrad().boundaryField()[patchi] +=
-#endif
+            boundaryFieldRef(tmpRef(tGrad))[patchi] +=
             n
            *(
                 vf.boundaryField()[patchi].snGrad()

--- a/src/solids4FoamModels/numerics/logExpVolFields/eig3Field.C
+++ b/src/solids4FoamModels/numerics/logExpVolFields/eig3Field.C
@@ -18,6 +18,7 @@ License
 \*---------------------------------------------------------------------------*/
 
 #include "eig3Field.H"
+#include "compatibilityFunctions.H"
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
@@ -30,13 +31,8 @@ void eig3Field
 )
 {
     const tensorField& AI = A.internalField();
-#ifdef OPENFOAM_NOT_EXTEND
-    tensorField& VI = V.primitiveFieldRef();
-    vectorField& dI = d.primitiveFieldRef();
-#else
-    tensorField& VI = V.internalField();
-    vectorField& dI = d.internalField();
-#endif
+    tensorField& VI = primitiveFieldRef(V);
+    vectorField& dI = primitiveFieldRef(d);
 
     forAll(AI, cellI)
     {
@@ -48,13 +44,8 @@ void eig3Field
         if (A.boundaryField()[patchI].type() != "empty")
         {
             const tensorField& AB = A.boundaryField()[patchI];
-#ifdef OPENFOAM_NOT_EXTEND
-            tensorField& VB = V.boundaryFieldRef()[patchI];
-            vectorField& dB = d.boundaryFieldRef()[patchI];
-#else
-            tensorField& VB = V.boundaryField()[patchI];
-            vectorField& dB = d.boundaryField()[patchI];
-#endif
+            tensorField& VB = boundaryFieldRef(V)[patchI];
+            vectorField& dB = boundaryFieldRef(d)[patchI];
 
             forAll(AB, faceI)
             {
@@ -71,13 +62,8 @@ void eig3Field
 )
 {
     const symmTensorField& AI = A.internalField();
-#ifdef OPENFOAM_NOT_EXTEND
-    tensorField& VI = V.primitiveFieldRef();
-    vectorField& dI = d.primitiveFieldRef();
-#else
-    tensorField& VI = V.internalField();
-    vectorField& dI = d.internalField();
-#endif
+    tensorField& VI = primitiveFieldRef(V);
+    vectorField& dI = primitiveFieldRef(d);
 
     forAll(AI, cellI)
     {
@@ -89,13 +75,8 @@ void eig3Field
         if (A.boundaryField()[patchI].type() != "empty")
         {
             const symmTensorField& AB = A.boundaryField()[patchI];
-#ifdef OPENFOAM_NOT_EXTEND
-            tensorField& VB = V.boundaryFieldRef()[patchI];
-            vectorField& dB = d.boundaryFieldRef()[patchI];
-#else
-            tensorField& VB = V.boundaryField()[patchI];
-            vectorField& dB = d.boundaryField()[patchI];
-#endif
+            tensorField& VB = boundaryFieldRef(V)[patchI];
+            vectorField& dB = boundaryFieldRef(d)[patchI];
 
             forAll(AB, faceI)
             {

--- a/src/solids4FoamModels/numerics/logExpVolFields/expVolFields.C
+++ b/src/solids4FoamModels/numerics/logExpVolFields/expVolFields.C
@@ -29,6 +29,7 @@ Author
 
 #include "expVolFields.H"
 #include "emptyFvPatchFields.H"
+#include "compatibilityFunctions.H"
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
@@ -142,11 +143,7 @@ tmp<volSymmTensorField> exp(const volSymmTensorField& vf)
         {
             const vectorField& eigenValB = eigenVal.boundaryField()[patchI];
             const tensorField& eigenVecB = eigenVec.boundaryField()[patchI];
-#ifdef OPENFOAM_NOT_EXTEND
-            symmTensorField& resultB = result.boundaryFieldRef()[patchI];
-#else
-            symmTensorField& resultB = result.boundaryField()[patchI];
-#endif
+            symmTensorField& resultB = boundaryFieldRef(result)[patchI];
 
             forAll(eigenValB, faceI)
             {

--- a/src/solids4FoamModels/numerics/logExpVolFields/logVolFields.C
+++ b/src/solids4FoamModels/numerics/logExpVolFields/logVolFields.C
@@ -28,6 +28,7 @@ Author
 
 #include "logVolFields.H"
 #include "emptyFvPatchFields.H"
+#include "compatibilityFunctions.H"
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
@@ -142,11 +143,7 @@ tmp<volSymmTensorField> log(const volSymmTensorField& vf)
             // Take references
             const vectorField& eigenValB = eigenVal.boundaryField()[patchI];
             const tensorField& eigenVecB = eigenVec.boundaryField()[patchI];
-#ifdef OPENFOAM_NOT_EXTEND
-            symmTensorField& resultB = result.boundaryFieldRef()[patchI];
-#else
-            symmTensorField& resultB = result.boundaryField()[patchI];
-#endif
+            symmTensorField& resultB = boundaryFieldRef(result)[patchI];
 
             forAll(eigenValB, faceI)
             {

--- a/src/solids4FoamModels/solidModels/fvPatchFields/fixedDisplacement/fixedDisplacementFvPatchVectorField.C
+++ b/src/solids4FoamModels/solidModels/fvPatchFields/fixedDisplacement/fixedDisplacementFvPatchVectorField.C
@@ -27,6 +27,7 @@ License
 #include "fixedValuePointPatchFields.H"
 #include "patchCorrectionVectors.H"
 #include "lookupSolidModel.H"
+#include "compatibilityFunctions.H"
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
@@ -102,14 +103,10 @@ void fixedDisplacementFvPatchVectorField::setPointDisplacement
             fixedValuePointPatchVectorField& patchPointD =
                 refCast<fixedValuePointPatchVectorField>
                 (
-                    const_cast<pointVectorField&>
+                    boundaryFieldRef
                     (
-                        pointD
-#ifdef OPENFOAM_NOT_EXTEND
-                    ).boundaryFieldRef()[patch().index()]
-#else
-                    ).boundaryField()[patch().index()]
-#endif
+                        const_cast<pointVectorField&>(pointD)
+                    )[patch().index()]
                 );
 
             // Interpolate face values to the points

--- a/src/solids4FoamModels/solidModels/fvPatchFields/fixedRotation/fixedRotationFvPatchVectorField.C
+++ b/src/solids4FoamModels/solidModels/fvPatchFields/fixedRotation/fixedRotationFvPatchVectorField.C
@@ -25,6 +25,7 @@ License
 #include "RodriguesRotation.H"
 #include "fixedValuePointPatchFields.H"
 #include "patchCorrectionVectors.H"
+#include "compatibilityFunctions.H"
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
@@ -321,11 +322,7 @@ void fixedRotationFvPatchVectorField::updateCoeffs()
             fixedValuePointPatchVectorField& pointD =
                 refCast<fixedValuePointPatchVectorField>
                 (
-#ifdef OPENFOAM_NOT_EXTEND
-                    pointDField.boundaryFieldRef()[patch().index()]
-#else
-                    pointDField.boundaryField()[patch().index()]
-#endif
+                    boundaryFieldRef(pointDField)[patch().index()]
                 );
 
             const vectorField newPatchPoints

--- a/src/solids4FoamModels/solidModels/kirchhoffPlateSolid/kirchhoffPlateSolidTemplates.C
+++ b/src/solids4FoamModels/solidModels/kirchhoffPlateSolid/kirchhoffPlateSolidTemplates.C
@@ -21,6 +21,7 @@ License
 
 #include "kirchhoffPlateSolid.H"
 #include "GeometricFields.H"
+#include "compatibilityFunctions.H"
 
 // * * * * * * * * * * * * * Private Member Functions  * * * * * * * * * * * //
 
@@ -39,11 +40,7 @@ mapAreaFieldToSingleLayerVolumeField
     const label areaPatchID = areaPatch().index();
     const label pMeshNFaces = pMesh.nFaces();
     const Field<Type> afI = af.internalField();
-#ifdef OPENFOAM_NOT_EXTEND
-    FieldField<fvPatchField, Type>& bf = vf.boundaryFieldRef();
-#else
-    FieldField<fvPatchField, Type>& bf = vf.boundaryField();
-#endif
+    FieldField<fvPatchField, Type>& bf = boundaryFieldRef(vf);
 
     // Check that bf area patch is not of type empty
     if (bf[areaPatchID].type() == "empty")
@@ -86,13 +83,8 @@ mapAreaFieldToSingleLayerVolumeField
 
     {
         const unallocLabelList& faceCells = areaShadowPatch().faceCells();
-#ifdef OPENFOAM_NOT_EXTEND
         Field<Type>& patchField =
-            vf.boundaryFieldRef()[areaShadowPatch().index()];
-#else
-        Field<Type>& patchField =
-            vf.boundaryField()[areaShadowPatch().index()];
-#endif
+            boundaryFieldRef(vf)[areaShadowPatch().index()];
 
         forAll(faceCells, faceI)
         {

--- a/src/solids4FoamModels/solidModels/nonLinGeomTotalLagTotalDispSolid/nonLinGeomTotalLagTotalDispSolid.C
+++ b/src/solids4FoamModels/solidModels/nonLinGeomTotalLagTotalDispSolid/nonLinGeomTotalLagTotalDispSolid.C
@@ -100,11 +100,7 @@ void nonLinGeomTotalLagTotalDispSolid::enforceTractionBoundaries
     // Enforce traction conditions
     forAll(D.boundaryField(), patchI)
     {
-#ifdef OPENFOAM_NOT_EXTEND
-        vectorField& forceP = force.boundaryFieldRef()[patchI];
-#else
-        vectorField& forceP = force.boundaryField()[patchI];
-#endif
+        vectorField& forceP = boundaryFieldRef(force)[patchI];
 
         if
         (
@@ -392,11 +388,7 @@ bool nonLinGeomTotalLagTotalDispSolid::evolveSnes()
         // Map the D field to the SNES solution vector
         foamPetscSnesHelper::InsertFieldComponents<vector>
         (
-#ifdef OPENFOAM_NOT_EXTEND
-            D().primitiveFieldRef(),
-#else
-            D().internalField(),
-#endif
+            primitiveFieldRef(D()),
             foamPetscSnesHelper::solution(),
             0, // Location of first component
             solidModel::twoD()
@@ -698,11 +690,7 @@ nonLinGeomTotalLagTotalDispSolid::nonLinGeomTotalLagTotalDispSolid
                 solidTractionFvPatchVectorField& tracPatch =
                     refCast<solidTractionFvPatchVectorField>
                     (
-#ifdef OPENFOAM_NOT_EXTEND
-                        D().boundaryFieldRef()[patchI]
-#else
-                        D().boundaryField()[patchI]
-#endif
+                        boundaryFieldRef(D())[patchI]
                     );
 
                 tracPatch.extrapolateValue() = true;

--- a/src/solids4FoamModels/solidModels/nonLinGeomUpdatedLagSolid/nonLinGeomUpdatedLagSolid.C
+++ b/src/solids4FoamModels/solidModels/nonLinGeomUpdatedLagSolid/nonLinGeomUpdatedLagSolid.C
@@ -94,11 +94,7 @@ void nonLinGeomUpdatedLagSolid::enforceTractionBoundaries
     // Enforce traction conditions
     forAll(D.boundaryField(), patchI)
     {
-#ifdef OPENFOAM_NOT_EXTEND
-        vectorField& forceP = force.boundaryFieldRef()[patchI];
-#else
-        vectorField& forceP = force.boundaryField()[patchI];
-#endif
+        vectorField& forceP = boundaryFieldRef(force)[patchI];
 
         if
         (
@@ -345,11 +341,7 @@ bool nonLinGeomUpdatedLagSolid::evolveSnes()
         // Map the D field to the SNES solution vector
         foamPetscSnesHelper::InsertFieldComponents<vector>
         (
-#ifdef OPENFOAM_NOT_EXTEND
-            DD().primitiveFieldRef(),
-#else
-            DD().internalField(),
-#endif
+            primitiveFieldRef(DD()),
             foamPetscSnesHelper::solution(),
             0, // Location of first component
             solidModel::twoD()
@@ -366,11 +358,7 @@ bool nonLinGeomUpdatedLagSolid::evolveSnes()
     foamPetscSnesHelper::ExtractFieldComponents<vector>
     (
         foamPetscSnesHelper::solution(),
-#ifdef OPENFOAM_NOT_EXTEND
-        DD().primitiveFieldRef(),
-#else
-        DD().internalField(),
-#endif
+        primitiveFieldRef(DD()),
         0, // Location of first component
         solidModel::twoD()
       ? makeList<label>({0,1})
@@ -638,11 +626,7 @@ nonLinGeomUpdatedLagSolid::nonLinGeomUpdatedLagSolid
                 solidTractionFvPatchVectorField& tracPatch =
                     refCast<solidTractionFvPatchVectorField>
                     (
-#ifdef OPENFOAM_NOT_EXTEND
-                        DD().boundaryFieldRef()[patchI]
-#else
-                        DD().boundaryField()[patchI]
-#endif
+                        boundaryFieldRef(DD())[patchI]
                     );
 
                 tracPatch.extrapolateValue() = true;

--- a/src/solids4FoamModels/solidModels/solidModel/solidModel.C
+++ b/src/solids4FoamModels/solidModels/solidModel/solidModel.C
@@ -32,6 +32,7 @@ License
 #include "wedgePolyPatch.H"
 #include "meshTools.H"
 #include "addToRunTimeSelectionTable.H"
+#include "compatibilityFunctions.H"
 
 // * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
 
@@ -1855,11 +1856,7 @@ void Foam::solidModel::setTraction
         globalPatches()[interfaceI].globalFaceToPatch(faceZoneTraction)
     );
 
-#ifdef OPENFOAM_NOT_EXTEND
-    setTraction(solutionD().boundaryFieldRef()[patchID], patchTraction);
-#else
-    setTraction(solutionD().boundaryField()[patchID], patchTraction);
-#endif
+    setTraction(boundaryFieldRef(solutionD())[patchID], patchTraction);
 }
 
 
@@ -1923,11 +1920,7 @@ void Foam::solidModel::setPressure
         globalPatches()[interfaceI].globalFaceToPatch(faceZonePressure)
     );
 
-#ifdef OPENFOAM_NOT_EXTEND
-    setPressure(solutionD().boundaryFieldRef()[patchID], patchPressure);
-#else
-    setPressure(solutionD().boundaryField()[patchID], patchPressure);
-#endif
+    setPressure(boundaryFieldRef(solutionD())[patchID], patchPressure);
 }
 
 

--- a/tutorials/fluidSolidInteraction-preCICE/3dTube/fluid/0/U
+++ b/tutorials/fluidSolidInteraction-preCICE/3dTube/fluid/0/U
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/3dTube/fluid/0/p
+++ b/tutorials/fluidSolidInteraction-preCICE/3dTube/fluid/0/p
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/3dTube/fluid/0/pointDisplacement
+++ b/tutorials/fluidSolidInteraction-preCICE/3dTube/fluid/0/pointDisplacement
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/3dTube/fluid/constant/dynamicMeshDict
+++ b/tutorials/fluidSolidInteraction-preCICE/3dTube/fluid/constant/dynamicMeshDict
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/3dTube/fluid/constant/fluidProperties
+++ b/tutorials/fluidSolidInteraction-preCICE/3dTube/fluid/constant/fluidProperties
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/3dTube/fluid/constant/polyMesh/blockMeshDict
+++ b/tutorials/fluidSolidInteraction-preCICE/3dTube/fluid/constant/polyMesh/blockMeshDict
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/3dTube/fluid/constant/thermodynamicProperties
+++ b/tutorials/fluidSolidInteraction-preCICE/3dTube/fluid/constant/thermodynamicProperties
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/3dTube/fluid/constant/transportProperties
+++ b/tutorials/fluidSolidInteraction-preCICE/3dTube/fluid/constant/transportProperties
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/3dTube/fluid/constant/turbulenceProperties
+++ b/tutorials/fluidSolidInteraction-preCICE/3dTube/fluid/constant/turbulenceProperties
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/3dTube/fluid/system/controlDict
+++ b/tutorials/fluidSolidInteraction-preCICE/3dTube/fluid/system/controlDict
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/3dTube/fluid/system/decomposeParDict
+++ b/tutorials/fluidSolidInteraction-preCICE/3dTube/fluid/system/decomposeParDict
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/3dTube/fluid/system/fvSchemes
+++ b/tutorials/fluidSolidInteraction-preCICE/3dTube/fluid/system/fvSchemes
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/3dTube/fluid/system/fvSolution
+++ b/tutorials/fluidSolidInteraction-preCICE/3dTube/fluid/system/fvSolution
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/3dTube/solid/0/DD
+++ b/tutorials/fluidSolidInteraction-preCICE/3dTube/solid/0/DD
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/3dTube/solid/0/pointDD
+++ b/tutorials/fluidSolidInteraction-preCICE/3dTube/solid/0/pointDD
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/3dTube/solid/0/solidForce
+++ b/tutorials/fluidSolidInteraction-preCICE/3dTube/solid/0/solidForce
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/3dTube/solid/constant/dynamicMeshDict
+++ b/tutorials/fluidSolidInteraction-preCICE/3dTube/solid/constant/dynamicMeshDict
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/3dTube/solid/constant/g
+++ b/tutorials/fluidSolidInteraction-preCICE/3dTube/solid/constant/g
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/3dTube/solid/constant/mechanicalProperties
+++ b/tutorials/fluidSolidInteraction-preCICE/3dTube/solid/constant/mechanicalProperties
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/3dTube/solid/constant/physicsProperties
+++ b/tutorials/fluidSolidInteraction-preCICE/3dTube/solid/constant/physicsProperties
@@ -1,11 +1,11 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |
-|              www.openfoam.com](https://www.openfoam.com), and owner of the  |
-|              OPENFOAM® and OpenCFD® trade marks.                            |
+|              www.openfoam.com, and owner of the OPENFOAM® and OpenCFD®      |
+|              trade marks.                                                   |
 \*---------------------------------------------------------------------------*/
 FoamFile
 {

--- a/tutorials/fluidSolidInteraction-preCICE/3dTube/solid/constant/polyMesh/blockMeshDict
+++ b/tutorials/fluidSolidInteraction-preCICE/3dTube/solid/constant/polyMesh/blockMeshDict
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/3dTube/solid/constant/solidProperties
+++ b/tutorials/fluidSolidInteraction-preCICE/3dTube/solid/constant/solidProperties
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/3dTube/solid/system/controlDict
+++ b/tutorials/fluidSolidInteraction-preCICE/3dTube/solid/system/controlDict
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/3dTube/solid/system/decomposeParDict
+++ b/tutorials/fluidSolidInteraction-preCICE/3dTube/solid/system/decomposeParDict
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/3dTube/solid/system/fvSchemes
+++ b/tutorials/fluidSolidInteraction-preCICE/3dTube/solid/system/fvSchemes
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/3dTube/solid/system/fvSolution
+++ b/tutorials/fluidSolidInteraction-preCICE/3dTube/solid/system/fvSolution
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderAndBackground/0.orig/U
+++ b/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderAndBackground/0.orig/U
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderAndBackground/0.orig/epsilon
+++ b/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderAndBackground/0.orig/epsilon
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderAndBackground/0.orig/k
+++ b/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderAndBackground/0.orig/k
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderAndBackground/0.orig/nut
+++ b/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderAndBackground/0.orig/nut
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderAndBackground/0.orig/p
+++ b/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderAndBackground/0.orig/p
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderAndBackground/0.orig/pointDisplacement
+++ b/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderAndBackground/0.orig/pointDisplacement
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderAndBackground/0.orig/zoneID
+++ b/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderAndBackground/0.orig/zoneID
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderAndBackground/constant/dynamicMeshDict
+++ b/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderAndBackground/constant/dynamicMeshDict
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderAndBackground/constant/transportProperties
+++ b/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderAndBackground/constant/transportProperties
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderAndBackground/constant/turbulenceProperties
+++ b/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderAndBackground/constant/turbulenceProperties
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderAndBackground/system/blockMeshDict
+++ b/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderAndBackground/system/blockMeshDict
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderAndBackground/system/controlDict
+++ b/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderAndBackground/system/controlDict
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderAndBackground/system/fvSchemes
+++ b/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderAndBackground/system/fvSchemes
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderAndBackground/system/fvSolution
+++ b/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderAndBackground/system/fvSolution
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderAndBackground/system/preciceDict
+++ b/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderAndBackground/system/preciceDict
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderAndBackground/system/setFieldsDict
+++ b/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderAndBackground/system/setFieldsDict
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderAndBackground/system/topoSetDict
+++ b/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderAndBackground/system/topoSetDict
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderMesh/system/controlDict
+++ b/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderMesh/system/controlDict
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderMesh/system/createPatchDict
+++ b/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderMesh/system/createPatchDict
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderMesh/system/extrudeMeshDict
+++ b/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderMesh/system/extrudeMeshDict
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderMesh/system/fvSchemes
+++ b/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderMesh/system/fvSchemes
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderMesh/system/fvSolution
+++ b/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/fluid/cylinderMesh/system/fvSolution
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/solid/0/D
+++ b/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/solid/0/D
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/solid/0/solidForce
+++ b/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/solid/0/solidForce
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/solid/constant/dynamicMeshDict
+++ b/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/solid/constant/dynamicMeshDict
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/solid/constant/g
+++ b/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/solid/constant/g
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/solid/constant/mechanicalProperties
+++ b/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/solid/constant/mechanicalProperties
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/solid/constant/physicsProperties
+++ b/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/solid/constant/physicsProperties
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/solid/constant/solidProperties
+++ b/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/solid/constant/solidProperties
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/solid/system/blockMeshDict
+++ b/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/solid/system/blockMeshDict
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/solid/system/controlDict
+++ b/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/solid/system/controlDict
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/solid/system/fvSchemes
+++ b/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/solid/system/fvSchemes
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/solid/system/fvSolution
+++ b/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/solid/system/fvSolution
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |

--- a/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/solid/system/preciceDict
+++ b/tutorials/fluidSolidInteraction-preCICE/flexibleOversetCylinder/solid/system/preciceDict
@@ -1,6 +1,6 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | solids4foam: solid mechanics and fluid-solid interaction simulations        |
-| Version:     v2.0                                                           |
+| Version:     v2.3                                                           |
 | Web:         https://solids4foam.github.io                                  |
 | Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
 |              producer and distributor of the OpenFOAM software via          |


### PR DESCRIPTION
## Summary

- Replace scattered `#ifdef OPENFOAM_NOT_EXTEND` / `#else` / `#endif` guards for `boundaryFieldRef()`, `primitiveFieldRef()`, and related cross-variant API differences with the corresponding helpers from `compatibilityFunctions.H`, reducing preprocessor noise and improving readability.
- Bump the solids4foam version string in 65 tutorial and utility case-file headers from `v2.0` to `v2.3`.

### C++ files updated (compat-function cleanups only)

| File | Change |
|------|--------|
| `elasticWallPressureFvPatchScalarField.C` | `boundaryFieldRef` |
| `flowRateOutletPressureFvPatchScalarField.C` | `boundaryFieldRef` |
| `principalStressFields.C` | `primitiveFieldRef`, `boundaryFieldRef` |
| `solidTractions.C` | `boundaryFieldRef` |
| `solidSubMeshes.C` / `solidSubMeshesTemplates.C` | `primitiveFieldRef`, `boundaryFieldRef` |
| `fvcGradf.C` | `primitiveFieldRef`, `boundaryFieldRef` |
| `eig3Field.C`, `expVolFields.C`, `logVolFields.C` | `primitiveFieldRef`, `boundaryFieldRef` |
| analytical-solution function objects (6 files) | `primitiveFieldRef`, `boundaryFieldRef` |
| `fixedRotationFvPatchVectorField.C` | `boundaryFieldRef` |
| `kirchhoffPlateSolidTemplates.C` | `primitiveFieldRef` |
| `fixedDisplacementFvPatchVectorField.C` | `boundaryFieldRef` in `setPointDisplacement` |
| `solidModel.C` | `boundaryFieldRef` in `setTraction` / `setPressure` |
| `nonLinGeomTotalLagTotalDispSolid.C` | `boundaryFieldRef`, `primitiveFieldRef` (3 sites) |
| `nonLinGeomUpdatedLagSolid.C` | `boundaryFieldRef`, `primitiveFieldRef` (4 sites) |

### Files excluded from this PR (kept for PR #233)

New classes (`newtonQuasiMonolithicCouplingInterface`, `nonLinGeomTotalLagVelocitySolid`) and all other feature changes from PR #233 are **not** included here.

## Test plan

- [x] Build with OpenFOAM-v2412 (`wmake` in `src/`)
- [x] Existing regression suite passes (`tutorials/Alltest-regression`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)