### PR TITLE
Make fluidProperties() accessors public in fluidModel

### DIFF
--- a/src/solids4FoamModels/fluidModels/fluidModel/fluidModel.H
+++ b/src/solids4FoamModels/fluidModels/fluidModel/fluidModel.H
@@ -212,18 +212,6 @@ protected:
 
     // Protected member functions
 
-        //- Return fluid properties dictionary
-        dictionary& fluidProperties()
-        {
-            return fluidProperties_;
-        }
-
-        //- Return fluid properties dictionary
-        const dictionary& fluidProperties() const
-        {
-            return fluidProperties_;
-        }
-
         //- Update Robin boundary conditions, if found
         void updateRobinFsiInterface
         (
@@ -315,6 +303,18 @@ public:
     // Member Functions
 
         // Access
+
+            //- Return fluid properties dictionary
+            dictionary& fluidProperties()
+            {
+                return fluidProperties_;
+            }
+
+            //- Return fluid properties dictionary
+            const dictionary& fluidProperties() const
+            {
+                return fluidProperties_;
+            }
 
             //- Return reference to the mesh
             dynamicFvMesh& mesh()


### PR DESCRIPTION
## Summary

Move the `fluidProperties()` const and non-const accessors from the `protected` section to the `public` Access section of `fluidModel.H`.

- Zero logic change — purely a visibility refactor.
- Required so that coupling interfaces outside the `fluidModel` class hierarchy can read/write the fluid properties dictionary.

Extracted from PR #233. One file changed, 12 lines moved.

## Test plan

- [ ] Build with `wmake libso` in `src/solids4FoamModels/`
- [ ] Existing regression suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)