### PR TITLE
Improve boundary condition enforcement in diffusionElastic law

### DIFF
--- a/src/solids4FoamModels/Make/files.openfoam
+++ b/src/solids4FoamModels/Make/files.openfoam
@@ -55,6 +55,7 @@ $(mechanicalLaws)/mechanicalLaw/newMechanicalLaw.C
 
 linGeomLaws = $(mechanicalLaws)/linearGeometryLaws
 $(linGeomLaws)/anisotropicBiotElastic/anisotropicBiotElastic.C
+$(linGeomLaws)/diffusionElastic/diffusionElastic.C
 $(linGeomLaws)/linearElastic/linearElastic.C
 $(linGeomLaws)/linearElasticFromFile/linearElasticFromFile.C
 $(linGeomLaws)/linearElasticMisesPlastic/linearElasticMisesPlastic.C

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/diffusionElastic/diffusionElastic.C
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/diffusionElastic/diffusionElastic.C
@@ -47,6 +47,9 @@ void Foam::diffusionElastic::updateD() const
     df_ = min(maxFactor_*avDf, max(minFactor_*avDf, df_));
     df_ /= avDf;
     d_ = fvc::average(df_);
+
+    // Enforce zero gradient boundaries
+    d_.correctBoundaryConditions();
 }
 
 
@@ -64,11 +67,23 @@ Foam::diffusionElastic::diffusionElastic
     mechanicalLaw(name, mesh, dict, nonLinGeom),
     mu_(dict.lookup("mu")),
     kappa_(dict.lookup("kappa")),
-    maxFactor_(dict.lookupOrDefault<scalar>("maxFactor", 10)),
+    maxFactor_(dict.lookupOrDefault<scalar>("maxFactor", 100)),
     minFactor_(dict.lookupOrDefault<scalar>("minFactor", 0.1)),
     motionDiffPtr_(motionDiffusivity::New(mesh, dict.lookup("diffusivity"))),
     df_("distf", motionDiffPtr_()()),
-    d_("dist", fvc::average(df_))
+    d_
+    (
+        IOobject
+        (
+            "stiffnessScaleFactor",
+            mesh.time().timeName(),
+            mesh,
+            IOobject::NO_READ,
+            IOobject::NO_WRITE
+        ),
+        fvc::average(df_),
+        "zeroGradient"
+    )
 {
     // Store old times
     epsilon().storeOldTime();
@@ -81,6 +96,11 @@ Foam::diffusionElastic::diffusionElastic
     }
 
     updateD();
+
+    if (Switch(dict.lookup("writeStiffScaleFactor")))
+    {
+        d_.writeOpt() = IOobject::AUTO_WRITE;
+    }
 }
 
 

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/diffusionElastic/diffusionElastic.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/diffusionElastic/diffusionElastic.H
@@ -67,7 +67,7 @@ class diffusionElastic
 
         //- Maximum factor
         //  The max value of d is limit to maxFactor*average(d)
-        //  Defaults to 10
+        //  Defaults to 100
         const scalar maxFactor_;
 
         //- Minimum factor

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/diffusionElastic/diffusionElastic.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/diffusionElastic/diffusionElastic.H
@@ -21,7 +21,7 @@ Class
 Description
     Linear elasticity where the stress is given as:
 
-        sigma = K*I*tr(gradD) + mu*dev(symm(gradD))
+        sigma = d*(mu*dev(symm(gradD)) K*I*tr(gradD))
 
     and mu and K are user-defined scalar stiffness parameters and d is a
     diffusivity field specified by the "diffusivity" user setting, e.g. inverse

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/diffusionElastic/diffusionElastic.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/diffusionElastic/diffusionElastic.H
@@ -1,0 +1,149 @@
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    diffusionElastic
+
+Description
+    Linear elasticity where the stress is given as:
+
+        sigma = K*I*tr(gradD) + mu*dev(symm(gradD))
+
+    and mu and K are user-defined scalar stiffness parameters and d is a
+    diffusivity field specified by the "diffusivity" user setting, e.g. inverse
+    distance from the wall.
+
+    This law is useful as a mesh motion solver.
+
+SourceFiles
+    diffusionElastic.C
+
+Author
+    Philip Cardiff, UCD. All rights reserved
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef diffusionElastic_H
+#define diffusionElastic_H
+
+#include "mechanicalLaw.H"
+#include "surfaceMesh.H"
+#include "motionDiffusivity.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+/*---------------------------------------------------------------------------*\
+                         Class diffusionElastic Declaration
+\*---------------------------------------------------------------------------*/
+
+class diffusionElastic
+:
+    public mechanicalLaw
+{
+    // Private data
+
+        //- Shear modulus type stiffness parameter
+        const dimensionedScalar mu_;
+
+        //- Bulk modulus type stiffness parameter
+        const dimensionedScalar kappa_;
+
+        //- Maximum factor
+        //  The max value of d is limit to maxFactor*average(d)
+        //  Defaults to 10
+        const scalar maxFactor_;
+
+        //- Minimum factor
+        //  The min value of d is limit to minFactor*average(d)
+        //  Defaults to 0.1
+        const scalar minFactor_;
+
+        //- Stiffness calculator, which calculates d
+        mutable autoPtr<motionDiffusivity> motionDiffPtr_;
+
+        //- d surface field
+        mutable surfaceScalarField df_;
+
+        //- d vol field
+        mutable volScalarField d_;
+
+    // Private Member Functions
+
+        //- Update the d fields
+        void updateD() const;
+
+        //- Disallow default bitwise copy construct
+        diffusionElastic(const diffusionElastic&);
+
+        //- Disallow default bitwise assignment
+        void operator=(const diffusionElastic&);
+
+public:
+
+    //- Runtime type information
+    TypeName("diffusionElastic");
+
+    // Constructors
+
+        //- Construct from dictionary
+        diffusionElastic
+        (
+            const word& name,
+            const fvMesh& mesh,
+            const dictionary& dict,
+            const nonLinearGeometry::nonLinearType& nonLinGeom
+        );
+
+
+    // Destructor
+
+        virtual ~diffusionElastic()
+        {}
+
+
+    // Member Functions
+
+        //- Return bulk modulus
+        virtual tmp<volScalarField> bulkModulus() const;
+
+        //- Return shear modulus
+        virtual tmp<volScalarField> shearModulus() const;
+
+        //- Return the implicit stiffness
+        //  This is the diffusivity for the Laplacian term
+        virtual tmp<volScalarField> impK() const;
+
+        //- Calculate the stress
+        virtual void correct(volSymmTensorField& sigma);
+
+        //- Calculate the stress
+        virtual void correct(surfaceSymmTensorField& sigma);
+};
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //


### PR DESCRIPTION
## Summary

Improvements to the `diffusionElastic` mechanical law:

- **BC enforcement**: call `d_.correctBoundaryConditions()` after each update so zero-gradient boundary conditions are correctly enforced.
- **Named field**: construct the stiffness scale factor field `d_` via a proper `IOobject` with name `"stiffnessScaleFactor"` and explicit `zeroGradient` BC type.
- **Raised default**: increase `maxFactor` default from `10` to `100` for better handling of highly distorted meshes.
- **Optional output**: add `writeStiffScaleFactor` switch — when `true`, `d_` is written to disk at each output time for post-processing.
- **New header**: add `diffusionElastic.H` class header (the class was previously header-less).
- **Build fix**: add `diffusionElastic.C` to `Make/files.openfoam` so the class is compiled.

Extracted from PR #233. Self-contained; no other changes required.

## Test plan

- [x] Build with `wmake libso` in `src/solids4FoamModels/`
- [x] Run a tutorial using `diffusionElastic` and confirm correct field evolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)