### PR TITLE
Add solidPressureMinMax function object

### DIFF
--- a/src/solids4FoamModels/Make/files.foamextend
+++ b/src/solids4FoamModels/Make/files.foamextend
@@ -187,6 +187,7 @@ functionObjects/solidPointDisplacement/solidPointDisplacement.C
 functionObjects/solidPointStress/solidPointStress.C
 functionObjects/solidPointTemperature/solidPointTemperature.C
 functionObjects/solidPotentialEnergy/solidPotentialEnergy.C
+functionObjects/solidPressureMinMax/solidPressureMinMax.C
 functionObjects/solidStresses/solidStresses.C
 functionObjects/solidTorque/solidTorque.C
 functionObjects/solidTractions/solidTractions.C

--- a/src/solids4FoamModels/Make/files.openfoam
+++ b/src/solids4FoamModels/Make/files.openfoam
@@ -188,6 +188,7 @@ functionObjects/solidPointDisplacementAlongLine/solidPointDisplacementAlongLine.
 functionObjects/solidPointStress/solidPointStress.C
 functionObjects/solidPointTemperature/solidPointTemperature.C
 functionObjects/solidPotentialEnergy/solidPotentialEnergy.C
+functionObjects/solidPressureMinMax/solidPressureMinMax.C
 functionObjects/solidStresses/solidStresses.C
 functionObjects/solidTorque/solidTorque.C
 functionObjects/solidTractions/solidTractions.C

--- a/src/solids4FoamModels/functionObjects/README.md
+++ b/src/solids4FoamModels/functionObjects/README.md
@@ -749,6 +749,55 @@ equal to $$3-4\nu$$.
 
 ---
 
+## `solidPressureMinMax`
+
+- **Function object purpose**
+  Reports the minimum and maximum values of the solid hydrostatic pressure:
+
+  $$
+  p = -\frac{1}{3}\text{tr}(\boldsymbol{\sigma}).
+  $$
+
+  where $$\boldsymbol{\sigma}$$ is the Cauchy stress tensor field `sigma`.
+
+- **Example of usage**
+
+  ```c++
+  functions
+  {
+      pressureMinMax
+      {
+          type    solidPressureMinMax;
+      }
+  }
+  ```
+
+- **Arguments**
+
+  - None.
+
+- **Optional arguments**
+
+  - None.
+
+- **Outputs**
+
+  - Output file: `postProcessing/0/solidPressureMinMax.dat` ;
+
+  - Output file format:
+
+      ```c++
+      # Time  p_min  p_max  trSigma_min  trSigma_max
+      1 150 500 -1500 -450
+      2 160 510 -1530 -480
+      ...
+      ```
+
+- **Tutorial case in which it is used:**
+  None
+
+---
+
 ## `solidPointDisplacement`
 
 - **Function object purpose**

--- a/src/solids4FoamModels/functionObjects/solidPressureMinMax/solidPressureMinMax.C
+++ b/src/solids4FoamModels/functionObjects/solidPressureMinMax/solidPressureMinMax.C
@@ -1,0 +1,184 @@
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+\*----------------------------------------------------------------------------*/
+
+#include "solidPressureMinMax.H"
+#include "addToRunTimeSelectionTable.H"
+#include "volFields.H"
+#include "OSspecific.H"
+
+// * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
+
+namespace Foam
+{
+    defineTypeNameAndDebug(solidPressureMinMax, 0);
+
+    addToRunTimeSelectionTable
+    (
+        functionObject,
+        solidPressureMinMax,
+        dictionary
+    );
+}
+
+
+// * * * * * * * * * * * * * Private Member Functions  * * * * * * * * * * * //
+
+bool Foam::solidPressureMinMax::writeData()
+{
+    // Lookup the solid mesh
+    const fvMesh* meshPtr = NULL;
+    if (time_.foundObject<fvMesh>("solid"))
+    {
+        meshPtr = &(time_.lookupObject<fvMesh>("solid"));
+    }
+    else
+    {
+        meshPtr = &(time_.lookupObject<fvMesh>("region0"));
+    }
+    const fvMesh& mesh = *meshPtr;
+
+    if (mesh.foundObject<volSymmTensorField>("sigma"))
+    {
+        const volSymmTensorField& sigma =
+            mesh.lookupObject<volSymmTensorField>("sigma");
+
+        // tr(sigma) = sigmaXX + sigmaYY + sigmaZZ
+        const scalarField trSigma(tr(sigma.internalField()));
+
+        const scalar trMin = gMin(trSigma);
+        const scalar trMax = gMax(trSigma);
+
+        // Hydrostatic pressure p = -tr(sigma)/3
+        const scalar pMin = -trMax / 3.0;
+        const scalar pMax = -trMin / 3.0;
+
+        if (Pstream::master())
+        {
+            historyFilePtr_()
+                << time_.time().value()
+                << " " << pMin
+                << " " << pMax
+                << " " << trMin
+                << " " << trMax
+                << endl;
+        }
+    }
+    else
+    {
+        InfoIn(this->name() + " function object writeData()")
+            << "volSymmTensorField sigma not found" << endl;
+    }
+
+    return true;
+}
+
+
+// * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
+
+Foam::solidPressureMinMax::solidPressureMinMax
+(
+    const word& name,
+    const Time& t,
+    const dictionary& dict
+)
+:
+    functionObject(name),
+    name_(name),
+    time_(t),
+    historyFilePtr_()
+{
+    Info<< "Creating " << this->name() << " function object" << endl;
+
+    if (Pstream::master())
+    {
+        fileName historyDir;
+
+        const fvMesh* meshPtr = NULL;
+        if (time_.foundObject<fvMesh>("solid"))
+        {
+            meshPtr = &(time_.lookupObject<fvMesh>("solid"));
+        }
+        else if (time_.foundObject<fvMesh>("region0"))
+        {
+            meshPtr = &(time_.lookupObject<fvMesh>("region0"));
+        }
+
+        const word startTimeName =
+            (meshPtr != NULL)
+          ? time_.timeName(meshPtr->time().startTime().value())
+          : "0";
+
+        if (Pstream::parRun())
+        {
+            historyDir =
+                time_.path()/".."/"postProcessing"/startTimeName;
+        }
+        else
+        {
+            historyDir = time_.path()/"postProcessing"/startTimeName;
+        }
+
+        mkDir(historyDir);
+
+        historyFilePtr_.reset
+        (
+            new OFstream(historyDir/"solidPressureMinMax.dat")
+        );
+
+        if (historyFilePtr_.valid())
+        {
+            historyFilePtr_()
+                << "# Time  p_min  p_max  trSigma_min  trSigma_max" << endl;
+        }
+    }
+}
+
+
+// * * * * * * * * * * * * * * * Member Functions  * * * * * * * * * * * * * //
+
+bool Foam::solidPressureMinMax::start()
+{
+    return false;
+}
+
+
+#if FOAMEXTEND
+bool Foam::solidPressureMinMax::execute(const bool forceWrite)
+#else
+bool Foam::solidPressureMinMax::execute()
+#endif
+{
+    return writeData();
+}
+
+
+bool Foam::solidPressureMinMax::read(const dictionary& dict)
+{
+    return true;
+}
+
+
+#ifdef OPENFOAM_NOT_EXTEND
+bool Foam::solidPressureMinMax::write()
+{
+    return false;
+}
+#endif
+
+// ************************************************************************* //

--- a/src/solids4FoamModels/functionObjects/solidPressureMinMax/solidPressureMinMax.H
+++ b/src/solids4FoamModels/functionObjects/solidPressureMinMax/solidPressureMinMax.H
@@ -1,0 +1,160 @@
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    solidPressureMinMax
+
+Description
+    FunctionObject that writes the global min and max of the hydrostatic
+    pressure in the solid at every time step.
+
+    The hydrostatic pressure is defined as
+
+        p = -tr(sigma) / 3
+
+    where sigma is the Cauchy stress tensor.  Both min and max are written to
+    a plain text data file:
+
+        postProcessing/<startTime>/solidPressureMinMax.dat
+
+    File columns:
+        Time  p_min  p_max  trSigma_min  trSigma_max
+
+    Dictionary example:
+
+        pressureMinMax
+        {
+            type    solidPressureMinMax;
+        }
+
+Author
+    Philip Cardiff, UCD.  All rights reserved.
+
+SourceFiles
+    solidPressureMinMax.C
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef solidPressureMinMax_H
+#define solidPressureMinMax_H
+
+#include "functionObject.H"
+#include "dictionary.H"
+#include "fvMesh.H"
+#include "OFstream.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+/*---------------------------------------------------------------------------*\
+                     Class solidPressureMinMax Declaration
+\*---------------------------------------------------------------------------*/
+
+class solidPressureMinMax
+:
+    public functionObject
+{
+    // Private data
+
+        //- Name
+        const word name_;
+
+        //- Reference to main object registry
+        const Time& time_;
+
+        //- History file ptr
+        autoPtr<OFstream> historyFilePtr_;
+
+
+    // Private Member Functions
+
+        //- Write data
+        bool writeData();
+
+        //- Disallow default bitwise copy construct
+        solidPressureMinMax(const solidPressureMinMax&);
+
+        //- Disallow default bitwise assignment
+        void operator=(const solidPressureMinMax&);
+
+
+public:
+
+    //- Runtime type information
+    TypeName("solidPressureMinMax");
+
+
+    // Constructors
+
+        //- Construct from components
+        solidPressureMinMax
+        (
+            const word& name,
+            const Time&,
+            const dictionary&
+        );
+
+
+    // Member Functions
+
+        //- start is called at the start of the time-loop
+        virtual bool start();
+
+        //- execute is called at each ++ or += of the time-loop
+#if FOAMEXTEND
+        virtual bool execute(const bool forceWrite);
+#else
+        virtual bool execute();
+#endif
+
+        //- Called when time was set at the end of the Time::operator++
+        virtual bool timeSet()
+        {
+            return true;
+        }
+
+        //- Read and set the function object if its data has changed
+        virtual bool read(const dictionary& dict);
+
+#ifdef OPENFOAM_NOT_EXTEND
+        //- Write
+        virtual bool write();
+#endif
+
+#ifndef OPENFOAM_NOT_EXTEND
+        //- Update for changes of mesh
+        virtual void updateMesh(const mapPolyMesh&)
+        {}
+
+        //- Update for changes of mesh
+        virtual void movePoints(const pointField&)
+        {}
+#endif
+};
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //


### PR DESCRIPTION
## Summary

New `solidPressureMinMax` function object that computes and logs the minimum and maximum hydrostatic pressure

$$p = -\frac{\text{tr}(\boldsymbol{\sigma})}{3}$$

from the Cauchy stress field at each write interval. Useful for monitoring pressure in nearly-incompressible or mixed-formulation solid models.

**Files added:**
- `src/solids4FoamModels/functionObjects/solidPressureMinMax/solidPressureMinMax.C` (184 lines)
- `src/solids4FoamModels/functionObjects/solidPressureMinMax/solidPressureMinMax.H` (160 lines)
- `Make/files.openfoam` and `Make/files.foamextend`: add compilation entry

Extracted from PR #233. Self-contained; no dependency on other branch changes.

## Test plan

- [ ] Build with `wmake libso` in `src/solids4FoamModels/`
- [ ] Add `solidPressureMinMax` to `functions {}` in `controlDict` of a solid tutorial and confirm min/max pressure is written to log

🤖 Generated with [Claude Code](https://claude.com/claude-code)