### PR TITLE
Make point-patch enforcement optional in fixedDisplacement BC

### DIFF
--- a/src/solids4FoamModels/solidModels/fvPatchFields/fixedDisplacement/fixedDisplacementFvPatchVectorField.C
+++ b/src/solids4FoamModels/solidModels/fvPatchFields/fixedDisplacement/fixedDisplacementFvPatchVectorField.C
@@ -27,6 +27,7 @@ License
 #include "fixedValuePointPatchFields.H"
 #include "patchCorrectionVectors.H"
 #include "lookupSolidModel.H"
+#include "compatibilityFunctions.H"
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
@@ -67,6 +68,11 @@ void fixedDisplacementFvPatchVectorField::setPointDisplacement
     const vectorField& faceDisp
 )
 {
+    if (!enforcePointPatchField_)
+    {
+        return;
+    }
+
     const fvMesh& mesh = patch().boundaryMesh().mesh();
 
     if
@@ -102,14 +108,10 @@ void fixedDisplacementFvPatchVectorField::setPointDisplacement
             fixedValuePointPatchVectorField& patchPointD =
                 refCast<fixedValuePointPatchVectorField>
                 (
-                    const_cast<pointVectorField&>
+                    boundaryFieldRef
                     (
-                        pointD
-#ifdef OPENFOAM_NOT_EXTEND
-                    ).boundaryFieldRef()[patch().index()]
-#else
-                    ).boundaryField()[patch().index()]
-#endif
+                        const_cast<pointVectorField&>(pointD)
+                    )[patch().index()]
                 );
 
             // Interpolate face values to the points
@@ -131,6 +133,7 @@ fixedDisplacementFvPatchVectorField::fixedDisplacementFvPatchVectorField
     nonOrthogonalCorrections_(true),
     totalDisp_(p.size(), vector::zero),
     dispSeries_(),
+    enforcePointPatchField_(true),
     interpPtr_()
 {}
 
@@ -151,6 +154,7 @@ fixedDisplacementFvPatchVectorField::fixedDisplacementFvPatchVectorField
     totalDisp_(pvf.totalDisp_, mapper),
 #endif
     dispSeries_(pvf.dispSeries_),
+    enforcePointPatchField_(true),
     interpPtr_()
 {}
 
@@ -169,6 +173,10 @@ fixedDisplacementFvPatchVectorField::fixedDisplacementFvPatchVectorField
     ),
     totalDisp_(*this),
     dispSeries_(),
+    enforcePointPatchField_
+    (
+        dict.lookupOrDefault<Switch>("enforcePointPatchField", true)
+    ),
     interpPtr_()
 {
     Info<< "Creating " << type() << " boundary condition" << endl;
@@ -197,6 +205,7 @@ fixedDisplacementFvPatchVectorField::fixedDisplacementFvPatchVectorField
     nonOrthogonalCorrections_(pvf.nonOrthogonalCorrections_),
     totalDisp_(pvf.totalDisp_),
     dispSeries_(pvf.dispSeries_),
+    enforcePointPatchField_(pvf.enforcePointPatchField_),
     interpPtr_()
 {}
 #endif
@@ -211,6 +220,7 @@ fixedDisplacementFvPatchVectorField::fixedDisplacementFvPatchVectorField
     nonOrthogonalCorrections_(pvf.nonOrthogonalCorrections_),
     totalDisp_(pvf.totalDisp_),
     dispSeries_(pvf.dispSeries_),
+    enforcePointPatchField_(pvf.enforcePointPatchField_),
     interpPtr_()
 {}
 

--- a/src/solids4FoamModels/solidModels/fvPatchFields/fixedDisplacement/fixedDisplacementFvPatchVectorField.H
+++ b/src/solids4FoamModels/solidModels/fvPatchFields/fixedDisplacement/fixedDisplacementFvPatchVectorField.H
@@ -65,6 +65,9 @@ class fixedDisplacementFvPatchVectorField
         //- Displacement time series
         interpolationTable<vector> dispSeries_;
 
+        //- Optionally, set point patch displacement field if it exists
+        const Switch enforcePointPatchField_;
+
         //- Patch interpolator to interpolate face values to the points
         mutable autoPtr<primitivePatchInterpolation> interpPtr_;
 


### PR DESCRIPTION
## Summary

Add a `enforcePointPatchField` switch (default `true`, backward compatible) to `fixedDisplacementFvPatchVectorField`. When set to `false` in the boundary-condition dictionary, `setPointDisplacement()` returns immediately without updating the point-displacement field. This is needed by the quasi-monolithic FSI solver, where point-field updates are handled differently.

Also replaces the `#ifdef OPENFOAM_NOT_EXTEND` guard for `boundaryFieldRef` access with the `boundaryFieldRef()` helper from `compatibilityFunctions.H` (the same change is in PR #250 for this file; the two PRs can be merged in either order — if #250 goes first the `compatibilityFunctions.H` hunk will apply cleanly as a no-op).

**Files changed:**
- `fixedDisplacementFvPatchVectorField.H` — add `enforcePointPatchField_` member
- `fixedDisplacementFvPatchVectorField.C` — early return guard + compat helper + constructor updates

Extracted from PR #233.

## Test plan

- [x] Build with `wmake libso` in `src/solids4FoamModels/`
- [x] Run an existing tutorial using `fixedDisplacement` BC and confirm default behaviour is unchanged
- [x] Set `enforcePointPatchField false` in the dict and confirm the point field is no longer updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)