### PR TITLE
Add decomposeParMonolithic utility for coupled mesh decomposition

### DIFF
--- a/applications/utilities/decomposeParMonolithic/Make/files
+++ b/applications/utilities/decomposeParMonolithic/Make/files
@@ -1,0 +1,3 @@
+decomposeParMonolithic.C
+
+EXE = $(FOAM_USER_APPBIN)/decomposeParMonolithic

--- a/applications/utilities/decomposeParMonolithic/Make/options
+++ b/applications/utilities/decomposeParMonolithic/Make/options
@@ -1,0 +1,20 @@
+SOLIDS4FOAM_ROOT := ../../..
+
+sinclude $(SOLIDS4FOAM_ROOT)/etc/wmake-options
+sinclude $(SOLIDS4FOAM_ROOT)/../etc/wmake-options
+
+EXE_INC = \
+    $(VERSION_SPECIFIC_INC) \
+    -I$(LIB_SRC)/finiteVolume/lnInclude \
+    -I$(LIB_SRC)/meshTools/lnInclude \
+    -I$(LIB_SRC)/parallel/decompose/decompositionMethods/lnInclude \
+    -I$(LIB_SRC)/parallel/decompose/decompose/lnInclude
+
+EXE_LIBS = \
+    -lfiniteVolume \
+    -lmeshTools \
+    -ldecompositionMethods \
+    -ldecompose \
+    -lscotchDecomp \
+    -L$(FOAM_LIBBIN)/dummy \
+    -lmetisDecomp -lkahipDecomp

--- a/applications/utilities/decomposeParMonolithic/Make/options
+++ b/applications/utilities/decomposeParMonolithic/Make/options
@@ -17,4 +17,8 @@ EXE_LIBS = \
     -ldecompose \
     -lscotchDecomp \
     -L$(FOAM_LIBBIN)/dummy \
-    -lmetisDecomp -lkahipDecomp
+    -lmetisDecomp
+
+ifneq (,$(findstring -DOPENFOAM_COM, $(VERSION_SPECIFIC_INC)))
+    EXE_LIBS += -lkahipDecomp
+endif

--- a/applications/utilities/decomposeParMonolithic/Make/options
+++ b/applications/utilities/decomposeParMonolithic/Make/options
@@ -22,3 +22,18 @@ EXE_LIBS = \
 ifneq (,$(findstring -DOPENFOAM_COM, $(VERSION_SPECIFIC_INC)))
     EXE_LIBS += -lkahipDecomp
 endif
+
+ifneq (,$(findstring -DFOAMEXTEND, $(VERSION_SPECIFIC_INC)))
+    EXE_INC = \
+        $(VERSION_SPECIFIC_INC) \
+        -I$(LIB_SRC)/finiteVolume/lnInclude \
+        -I$(LIB_SRC)/meshTools/lnInclude \
+        -I$(LIB_SRC)/decompositionMethods/decompositionMethods/lnInclude \
+        -I$(LIB_SRC)/decompositionMethods/decomposeReconstruct/lnInclude
+
+    EXE_LIBS = \
+        -lfiniteVolume \
+        -lmeshTools \
+        -ldecompositionMethods \
+        -ldecomposeReconstruct
+endif

--- a/applications/utilities/decomposeParMonolithic/README.md
+++ b/applications/utilities/decomposeParMonolithic/README.md
@@ -1,0 +1,148 @@
+# `decomposeParMonolithic`
+
+Coupled multi-region decomposition utility for monolithic FSI cases.
+
+## Purpose
+
+`decomposeParMonolithic` partitions multiple volume regions as one graph and
+then runs the standard `decomposePar` utility internally with `method manual`
+so that a single command produces the normal OpenFOAM processor directory tree
+for each region.
+
+This is useful for monolithic FSI cases where one region is much smaller than
+the other. Instead of forcing every rank to own both fluid and solid cells, the
+combined decomposition can assign some ranks only fluid cells, some only solid
+cells, and some both.
+
+## Current workflow
+
+The utility:
+
+1. Reads `system/decomposeParDict` by default, or the file supplied with
+   `-decomposeParDict`.
+2. Reads the coupled region list and interface definitions from the
+   `monolithicCoeffs` sub-dictionary.
+3. Loads all listed `fvMesh` regions.
+4. Builds one combined graph from:
+   - each region's internal cell adjacency
+   - extra cross-region edges across the declared FSI interface pairs
+5. Runs the selected OpenFOAM decomposition method once on the combined graph.
+6. Splits the result back into one `cellDecomposition` list per region.
+7. By default, runs `decomposePar` internally for each region using
+   `method manual`.
+
+## Dictionary format
+
+Example:
+
+```foam
+numberOfSubdomains 4;
+
+method scotch;
+
+monolithicCoeffs
+{
+    regions (fluid solid);
+
+    regionWeights
+    {
+        fluid 4;
+        solid 3;
+    }
+
+    interfaces
+    (
+        {
+            regionA fluid;
+            patchA  flag;
+            regionB solid;
+            patchB  interface;
+        }
+    );
+}
+```
+
+### Entries
+
+- `numberOfSubdomains`
+  Total MPI ranks for the coupled decomposition.
+- `method`
+  Standard OpenFOAM decomposition method, for example `scotch`.
+- `monolithicCoeffs.regions`
+  Volume regions to decompose together.
+- `monolithicCoeffs.regionWeights`
+  Optional scalar weight per region. The current implementation applies these
+  as per-cell weights in the combined graph.
+- `monolithicCoeffs.interfaces`
+  List of cross-region interfaces used to connect the region graphs.
+
+## Region selection
+
+Region selection is currently dictionary-driven only:
+
+- the coupled region list is read from `monolithicCoeffs.regions`
+- command-line `-region` and `-regions` overrides are not currently supported
+
+## Interface assumptions in v1
+
+The current implementation is intentionally narrow:
+
+- it expects conformal interface patches
+- it requires the paired patches to have the same number of faces
+- it matches the two patches by nearest face centre
+- it does not read or interpret a separate mapping mode from the dictionary
+
+In practice, this utility is best suited to direct-map style interfaces such as
+the conformal `flag`/`interface` pair in `foilInWind`.
+
+## Command-line options
+
+```bash
+decomposeParMonolithic
+decomposeParMonolithic -decomposeParDict system/decomposeParDict.monolithic
+decomposeParMonolithic -cellDist
+decomposeParMonolithic -decompose-only
+decomposeParMonolithic -force
+decomposeParMonolithic -copy-zero
+decomposeParMonolithic -no-fields
+```
+
+### Supported options
+
+- `-decomposeParDict <file>`
+  Use an alternative decompose dictionary.
+- `-cellDist`
+  Also write `cellDist` fields for visualisation.
+- `-decompose-only`
+  Only write `cellDecomposition` files and stop before the internal
+  `decomposePar` calls.
+- `-force`
+  Pass `-force` to the internal `decomposePar` calls.
+- `-copy-zero`
+  Pass `-copyZero` to the internal `decomposePar` calls.
+- `-no-fields`
+  Pass `-no-fields` to the internal `decomposePar` calls.
+
+## `-decompose-only` mode
+
+`-decompose-only` writes:
+
+- `constant/<region>/cellDecomposition`
+
+for each region and prints the equivalent manual `decomposePar` workflow.
+
+If you complete the decomposition manually afterwards, ensure that your manual
+`decomposeParDict` uses the same `numberOfSubdomains` as the monolithic
+decomposition that produced the `cellDecomposition` files.
+
+## Output
+
+During the run, the utility prints:
+
+- total cells per region
+- matched interface face count per coupled interface
+- per-rank cell counts per region
+- zero-cell rank counts per region
+
+These statistics are useful for checking whether the coupled decomposition is
+doing what you intended.

--- a/applications/utilities/decomposeParMonolithic/README.md
+++ b/applications/utilities/decomposeParMonolithic/README.md
@@ -14,6 +14,11 @@ the other. Instead of forcing every rank to own both fluid and solid cells, the
 combined decomposition can assign some ranks only fluid cells, some only solid
 cells, and some both.
 
+The name reflects this target monolithic FSI workflow, but the utility is not
+tied to a specific solver class. The generated per-region decomposition can be
+used by other multi-region solvers if they support processor ranks with zero
+cells in some regions.
+
 ## Current workflow
 
 The utility:
@@ -89,11 +94,14 @@ The current implementation is intentionally narrow:
 
 - it expects conformal interface patches
 - it requires the paired patches to have the same number of faces
-- it matches the two patches by nearest face centre
+- it matches the two patches by nearest face centre using an O(n^2) search
 - it does not read or interpret a separate mapping mode from the dictionary
 
 In practice, this utility is best suited to direct-map style interfaces such as
 the conformal `flag`/`interface` pair in `foilInWind`.
+
+If multiple interface face pairs connect the same two owner cells, the duplicate
+cell-cell graph edges are collapsed before decomposition.
 
 ## Command-line options
 

--- a/applications/utilities/decomposeParMonolithic/decomposeParMonolithic.C
+++ b/applications/utilities/decomposeParMonolithic/decomposeParMonolithic.C
@@ -70,6 +70,41 @@ using namespace Foam;
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
+static bool optionFound(const argList& args, const word& opt)
+{
+#ifdef OPENFOAM_ORG
+    return args.optionFound(opt);
+#else
+    return args.found(opt);
+#endif
+}
+
+
+static bool optionReadIfPresent
+(
+    const argList& args,
+    const word& opt,
+    fileName& value
+)
+{
+#ifdef OPENFOAM_ORG
+    return args.optionReadIfPresent(opt, value);
+#else
+    return args.readIfPresent(opt, value);
+#endif
+}
+
+
+static label regionIndex(const wordList& names, const word& name)
+{
+#ifdef OPENFOAM_ORG
+    return findIndex(names, name);
+#else
+    return names.find(name);
+#endif
+}
+
+
 // Build face-centre matching between two conformal patches.
 // Returns list of (ownerCellA, ownerCellB) pairs.
 List<labelPair> matchConformalInterface
@@ -230,11 +265,11 @@ int main(int argc, char *argv[])
     #include "setRootCase.H"
     #include "createTime.H"
 
-    const bool writeCellDist = args.found("cellDist");
-    const bool decomposeOnly = args.found("decompose-only");
-    const bool forceOverwrite = args.found("force");
-    const bool copyZero = args.found("copy-zero");
-    const bool noFields = args.found("no-fields");
+    const bool writeCellDist = optionFound(args, "cellDist");
+    const bool decomposeOnly = optionFound(args, "decompose-only");
+    const bool forceOverwrite = optionFound(args, "force");
+    const bool copyZero = optionFound(args, "copy-zero");
+    const bool noFields = optionFound(args, "no-fields");
 
     // -----------------------------------------------------------------------
     // Read dictionary
@@ -243,7 +278,7 @@ int main(int argc, char *argv[])
     fileName decompDictFile;
     if
     (
-        args.readIfPresent("decomposeParDict", decompDictFile)
+        optionReadIfPresent(args, "decomposeParDict", decompDictFile)
      && !decompDictFile.empty() && !decompDictFile.isAbsolute()
     )
     {
@@ -253,28 +288,34 @@ int main(int argc, char *argv[])
     // Find the dictionary
     IOdictionary decompDict
     (
-        IOobject::selectIO
+        decompDictFile.empty()
+      ? IOobject
         (
-            IOobject
-            (
-                "decomposeParDict",
-                runTime.system(),
-                runTime,
-                IOobject::MUST_READ,
-                IOobject::NO_WRITE,
-                IOobject::NO_REGISTER
-            ),
-            decompDictFile
+            "decomposeParDict",
+            runTime.system(),
+            runTime,
+            IOobject::MUST_READ,
+            IOobject::NO_WRITE,
+            false
+        )
+      : IOobject
+        (
+            decompDictFile,
+            runTime,
+            IOobject::MUST_READ,
+            IOobject::NO_WRITE,
+            false
         )
     );
 
-    const label nDomains = decompDict.get<label>("numberOfSubdomains");
+    const label nDomains =
+        readLabel(decompDict.lookup("numberOfSubdomains"));
 
     Info<< "Number of subdomains: " << nDomains << nl << endl;
 
     // Read monolithicCoeffs
     const dictionary& monoDict = decompDict.subDict("monolithicCoeffs");
-    const wordList regionNames(monoDict.get<wordList>("regions"));
+    const wordList regionNames(monoDict.lookup("regions"));
 
     if (regionNames.size() < 2)
     {
@@ -370,14 +411,14 @@ int main(int argc, char *argv[])
     {
         const dictionary& ifDict = interfaceDicts[ii];
 
-        const word regionAName = ifDict.get<word>("regionA");
-        const word patchAName = ifDict.get<word>("patchA");
-        const word regionBName = ifDict.get<word>("regionB");
-        const word patchBName = ifDict.get<word>("patchB");
+        const word regionAName(ifDict.lookup("regionA"));
+        const word patchAName(ifDict.lookup("patchA"));
+        const word regionBName(ifDict.lookup("regionB"));
+        const word patchBName(ifDict.lookup("patchB"));
 
         // Find region indices
-        const label riA = regionNames.find(regionAName);
-        const label riB = regionNames.find(regionBName);
+        const label riA = regionIndex(regionNames, regionAName);
+        const label riB = regionIndex(regionNames, regionBName);
 
         if (riA < 0)
         {
@@ -493,7 +534,7 @@ int main(int argc, char *argv[])
                 mesh,
                 IOobject::NO_READ,
                 IOobject::NO_WRITE,
-                IOobject::NO_REGISTER
+                false
             ),
             regionCellToProc
         );
@@ -501,7 +542,7 @@ int main(int argc, char *argv[])
         cellDecomposition.write();
 
         Info<< "  Region " << regionNames[ri] << ": wrote "
-            << cellDecomposition.objectRelPath() << endl;
+            << cellDecomposition.objectPath() << endl;
 
         // Optional: write as volScalarField
         if (writeCellDist)
@@ -515,7 +556,7 @@ int main(int argc, char *argv[])
                     mesh,
                     IOobject::NO_READ,
                     IOobject::AUTO_WRITE,
-                    IOobject::NO_REGISTER
+                    false
                 ),
                 mesh,
                 dimensionedScalar("cellDist", dimless, 0)
@@ -529,7 +570,7 @@ int main(int argc, char *argv[])
             cellDist.write();
 
             Info<< "  Region " << regionNames[ri] << ": wrote "
-                << cellDist.objectRelPath() << endl;
+                << cellDist.objectPath() << endl;
         }
     }
 

--- a/applications/utilities/decomposeParMonolithic/decomposeParMonolithic.C
+++ b/applications/utilities/decomposeParMonolithic/decomposeParMonolithic.C
@@ -20,9 +20,11 @@ Application
 
 Description
     Decomposes multiple volume regions as one coupled graph for monolithic
-    FSI solvers.  By default it also runs the standard decomposePar utility
+    FSI cases. By default it also runs the standard decomposePar utility
     internally (via method manual) so that a single command produces the
-    full processor directory tree for every region.
+    full processor directory tree for every region. The generated
+    per-region decomposition can be used by other multi-region solvers that
+    support processor ranks with zero cells in some regions.
 
     This avoids the inefficiency of independent per-region decomposition
     when one region is much smaller than the other. With a coupled
@@ -104,6 +106,22 @@ static label regionIndex(const wordList& names, const word& name)
 }
 
 
+static bool appendIfAbsent(labelList& labels, const label value)
+{
+    forAll(labels, i)
+    {
+        if (labels[i] == value)
+        {
+            return false;
+        }
+    }
+
+    labels.append(value);
+
+    return true;
+}
+
+
 // Build face-centre matching between two conformal patches.
 // Returns list of (ownerCellA, ownerCellB) pairs.
 List<labelPair> matchConformalInterface
@@ -169,8 +187,9 @@ List<labelPair> matchConformalInterface
 
     List<labelPair> pairs(cfA.size());
 
-    // For each face in patchA, find the matching face in patchB
-    // by nearest face centre. For conformal meshes this should be exact.
+    // For each face in patchA, find the matching face in patchB by nearest
+    // face centre. For conformal meshes this should be exact. This is an
+    // O(n^2) search and can be revisited if it becomes a bottleneck.
     labelList usedB(cfB.size(), -1);
 
     forAll(cfA, faceI)
@@ -448,7 +467,10 @@ int main(int argc, char *argv[])
         const label offsetA = regionOffset[riA];
         const label offsetB = regionOffset[riB];
 
-        // Add bidirectional edges
+        label nDuplicateEdges = 0;
+
+        // Add bidirectional edges. Multiple matching boundary faces may
+        // connect the same cell pair, so collapse duplicates in the graph.
         forAll(pairs, pi)
         {
             const label globalA = pairs[pi].first() + offsetA;
@@ -456,11 +478,20 @@ int main(int argc, char *argv[])
 
             // Add B to A's neighbours
             labelList& nbrsA = globalCellCells[globalA];
-            nbrsA.append(globalB);
+            if (!appendIfAbsent(nbrsA, globalB))
+            {
+                nDuplicateEdges++;
+            }
 
             // Add A to B's neighbours
             labelList& nbrsB = globalCellCells[globalB];
-            nbrsB.append(globalA);
+            appendIfAbsent(nbrsB, globalA);
+        }
+
+        if (nDuplicateEdges > 0)
+        {
+            Info<< "  Collapsed " << nDuplicateEdges
+                << " duplicate interface graph edges" << endl;
         }
     }
 

--- a/applications/utilities/decomposeParMonolithic/decomposeParMonolithic.C
+++ b/applications/utilities/decomposeParMonolithic/decomposeParMonolithic.C
@@ -1,0 +1,737 @@
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+Application
+    decomposeParMonolithic
+
+Description
+    Decomposes multiple volume regions as one coupled graph for monolithic
+    FSI solvers.  By default it also runs the standard decomposePar utility
+    internally (via method manual) so that a single command produces the
+    full processor directory tree for every region.
+
+    This avoids the inefficiency of independent per-region decomposition
+    when one region is much smaller than the other. With a coupled
+    decomposition some ranks may have zero cells in one region, which the
+    monolithic solver already supports.
+
+Usage
+    \b decomposeParMonolithic [OPTIONS]
+
+    Options:
+      - \par -decomposeParDict \<file\>
+        Alternative decomposeParDict file with monolithicCoeffs section.
+
+      - \par -cellDist
+        Write cell distribution as a volScalarField for visualisation.
+
+      - \par -decompose-only
+        Only compute and write cellDecomposition files; do not run
+        decomposePar to create processor directories.
+
+      - \par -force
+        Remove existing processor subdirectories before decomposing.
+
+      - \par -copy-zero
+        Copy 0 directory to processor directories rather than decompose
+        the fields.
+
+      - \par -no-fields
+        Suppress conversion of fields.
+
+\*---------------------------------------------------------------------------*/
+
+#include "argList.H"
+#include "Time.H"
+#include "fvMesh.H"
+#include "IOdictionary.H"
+#include "labelIOList.H"
+#include "decompositionMethod.H"
+#include "CompactListList.H"
+#include "volFields.H"
+#include "OFstream.H"
+#include "OSspecific.H"
+
+using namespace Foam;
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+// Build face-centre matching between two conformal patches.
+// Returns list of (ownerCellA, ownerCellB) pairs.
+List<labelPair> matchConformalInterface
+(
+    const fvMesh& meshA,
+    const word& patchNameA,
+    const fvMesh& meshB,
+    const word& patchNameB
+)
+{
+    const label patchIA = meshA.boundaryMesh().findPatchID(patchNameA);
+    if (patchIA < 0)
+    {
+        FatalErrorInFunction
+            << "Patch " << patchNameA << " not found in region "
+            << meshA.name()
+            << exit(FatalError);
+    }
+
+    const label patchIB = meshB.boundaryMesh().findPatchID(patchNameB);
+    if (patchIB < 0)
+    {
+        FatalErrorInFunction
+            << "Patch " << patchNameB << " not found in region "
+            << meshB.name()
+            << exit(FatalError);
+    }
+
+    const polyPatch& ppA = meshA.boundaryMesh()[patchIA];
+    const polyPatch& ppB = meshB.boundaryMesh()[patchIB];
+
+    const vectorField cfA(ppA.faceCentres());
+    const vectorField cfB(ppB.faceCentres());
+
+    if (cfA.size() != cfB.size())
+    {
+        FatalErrorInFunction
+            << "Interface patches have different sizes: "
+            << patchNameA << " (" << cfA.size() << ") vs "
+            << patchNameB << " (" << cfB.size() << ")" << nl
+            << "Non-conformal interfaces are not supported in v1."
+            << exit(FatalError);
+    }
+
+    // Compute a length scale for tolerance
+    scalar tolSq = 0;
+    if (cfA.size() > 0)
+    {
+        // Use a fraction of the mesh bounding box diagonal
+        const boundBox bbA(cfA);
+        const boundBox bbB(cfB);
+        const scalar diagA = bbA.mag();
+        const scalar diagB = bbB.mag();
+        const scalar charLen = max(diagA, diagB);
+        // Tolerance: 1e-6 of characteristic length
+        tolSq = sqr(1e-6*charLen);
+
+        if (tolSq < SMALL)
+        {
+            tolSq = SMALL;
+        }
+    }
+
+    List<labelPair> pairs(cfA.size());
+
+    // For each face in patchA, find the matching face in patchB
+    // by nearest face centre. For conformal meshes this should be exact.
+    labelList usedB(cfB.size(), -1);
+
+    forAll(cfA, faceI)
+    {
+        const point& ptA = cfA[faceI];
+        label bestJ = -1;
+        scalar bestDistSq = GREAT;
+
+        forAll(cfB, faceJ)
+        {
+            if (usedB[faceJ] >= 0) continue;
+
+            const scalar dSq = magSqr(ptA - cfB[faceJ]);
+            if (dSq < bestDistSq)
+            {
+                bestDistSq = dSq;
+                bestJ = faceJ;
+            }
+        }
+
+        if (bestJ < 0 || bestDistSq > tolSq)
+        {
+            FatalErrorInFunction
+                << "Could not find matching face for face " << faceI
+                << " of patch " << patchNameA
+                << " at " << ptA << nl
+                << "Best distance: " << Foam::sqrt(bestDistSq)
+                << ", tolerance: " << Foam::sqrt(tolSq)
+                << exit(FatalError);
+        }
+
+        usedB[bestJ] = faceI;
+
+        // Get owner cells
+        const label cellA = ppA.faceCells()[faceI];
+        const label cellB = ppB.faceCells()[bestJ];
+
+        pairs[faceI] = labelPair(cellA, cellB);
+    }
+
+    return pairs;
+}
+
+
+int main(int argc, char *argv[])
+{
+    argList::addNote
+    (
+        "Decompose multiple regions as one coupled graph for monolithic FSI"
+    );
+
+    argList::noParallel();
+
+    argList::addOption
+    (
+        "decomposeParDict",
+        "file",
+        "Alternative decomposeParDict file with monolithicCoeffs"
+    );
+
+    argList::addBoolOption
+    (
+        "cellDist",
+        "Write cell distribution as volScalarField for visualisation"
+    );
+
+    argList::addBoolOption
+    (
+        "decompose-only",
+        "Only write cellDecomposition files; skip decomposePar"
+    );
+
+    argList::addBoolOption
+    (
+        "force",
+        "Remove existing processor*/ subdirs before decomposing"
+    );
+
+    argList::addBoolOption
+    (
+        "copy-zero",
+        "Copy 0/ directory to processor*/ rather than decompose fields"
+    );
+
+    argList::addBoolOption
+    (
+        "no-fields",
+        "Suppress conversion of fields"
+    );
+
+    #include "setRootCase.H"
+    #include "createTime.H"
+
+    const bool writeCellDist = args.found("cellDist");
+    const bool decomposeOnly = args.found("decompose-only");
+    const bool forceOverwrite = args.found("force");
+    const bool copyZero = args.found("copy-zero");
+    const bool noFields = args.found("no-fields");
+
+    // -----------------------------------------------------------------------
+    // Read dictionary
+    // -----------------------------------------------------------------------
+
+    fileName decompDictFile;
+    if
+    (
+        args.readIfPresent("decomposeParDict", decompDictFile)
+     && !decompDictFile.empty() && !decompDictFile.isAbsolute()
+    )
+    {
+        decompDictFile = runTime.globalPath()/decompDictFile;
+    }
+
+    // Find the dictionary
+    IOdictionary decompDict
+    (
+        IOobject::selectIO
+        (
+            IOobject
+            (
+                "decomposeParDict",
+                runTime.system(),
+                runTime,
+                IOobject::MUST_READ,
+                IOobject::NO_WRITE,
+                IOobject::NO_REGISTER
+            ),
+            decompDictFile
+        )
+    );
+
+    const label nDomains = decompDict.get<label>("numberOfSubdomains");
+
+    Info<< "Number of subdomains: " << nDomains << nl << endl;
+
+    // Read monolithicCoeffs
+    const dictionary& monoDict = decompDict.subDict("monolithicCoeffs");
+    const wordList regionNames(monoDict.get<wordList>("regions"));
+
+    if (regionNames.size() < 2)
+    {
+        FatalErrorInFunction
+            << "monolithicCoeffs::regions must list at least 2 regions, got "
+            << regionNames.size()
+            << exit(FatalError);
+    }
+
+    Info<< "Regions: " << regionNames << nl << endl;
+
+    // Optional region weights
+    dictionary regionWeightsDict;
+    if (monoDict.found("regionWeights"))
+    {
+        regionWeightsDict = monoDict.subDict("regionWeights");
+    }
+
+    // Read interface definitions
+    const List<dictionary> interfaceDicts
+    (
+        monoDict.lookup("interfaces")
+    );
+
+    // -----------------------------------------------------------------------
+    // Load region meshes
+    // -----------------------------------------------------------------------
+
+    PtrList<fvMesh> regionMeshes(regionNames.size());
+
+    labelList regionOffset(regionNames.size(), 0);
+    label nTotalCells = 0;
+
+    forAll(regionNames, ri)
+    {
+        Info<< "Loading mesh for region: " << regionNames[ri] << endl;
+
+        regionMeshes.set
+        (
+            ri,
+            new fvMesh
+            (
+                IOobject
+                (
+                    regionNames[ri],
+                    runTime.timeName(),
+                    runTime,
+                    IOobject::MUST_READ
+                )
+            )
+        );
+
+        regionOffset[ri] = nTotalCells;
+        nTotalCells += regionMeshes[ri].nCells();
+
+        Info<< "  Cells: " << regionMeshes[ri].nCells()
+            << "  (global offset: " << regionOffset[ri] << ")" << endl;
+    }
+
+    Info<< nl << "Total cells across all regions: " << nTotalCells << nl
+        << endl;
+
+    // -----------------------------------------------------------------------
+    // Build combined adjacency graph
+    // -----------------------------------------------------------------------
+
+    Info<< "Building combined adjacency graph" << endl;
+
+    // Start with internal adjacency per region
+    labelListList globalCellCells(nTotalCells);
+
+    forAll(regionMeshes, ri)
+    {
+        const fvMesh& mesh = regionMeshes[ri];
+        const label offset = regionOffset[ri];
+        const labelListList& cc = mesh.cellCells();
+
+        forAll(cc, cellI)
+        {
+            const labelList& nbrs = cc[cellI];
+            labelList& globalNbrs = globalCellCells[offset + cellI];
+            globalNbrs.setSize(nbrs.size());
+
+            forAll(nbrs, ni)
+            {
+                globalNbrs[ni] = nbrs[ni] + offset;
+            }
+        }
+    }
+
+    // Add cross-region interface edges
+    forAll(interfaceDicts, ii)
+    {
+        const dictionary& ifDict = interfaceDicts[ii];
+
+        const word regionAName = ifDict.get<word>("regionA");
+        const word patchAName = ifDict.get<word>("patchA");
+        const word regionBName = ifDict.get<word>("regionB");
+        const word patchBName = ifDict.get<word>("patchB");
+
+        // Find region indices
+        const label riA = regionNames.find(regionAName);
+        const label riB = regionNames.find(regionBName);
+
+        if (riA < 0)
+        {
+            FatalErrorInFunction
+                << "Interface regionA '" << regionAName
+                << "' not found in regions list"
+                << exit(FatalError);
+        }
+        if (riB < 0)
+        {
+            FatalErrorInFunction
+                << "Interface regionB '" << regionBName
+                << "' not found in regions list"
+                << exit(FatalError);
+        }
+
+        Info<< "Matching interface: " << regionAName << "/" << patchAName
+            << " <-> " << regionBName << "/" << patchBName << endl;
+
+        const List<labelPair> pairs = matchConformalInterface
+        (
+            regionMeshes[riA], patchAName,
+            regionMeshes[riB], patchBName
+        );
+
+        Info<< "  Matched " << pairs.size() << " face pairs" << endl;
+
+        const label offsetA = regionOffset[riA];
+        const label offsetB = regionOffset[riB];
+
+        // Add bidirectional edges
+        forAll(pairs, pi)
+        {
+            const label globalA = pairs[pi].first() + offsetA;
+            const label globalB = pairs[pi].second() + offsetB;
+
+            // Add B to A's neighbours
+            labelList& nbrsA = globalCellCells[globalA];
+            nbrsA.append(globalB);
+
+            // Add A to B's neighbours
+            labelList& nbrsB = globalCellCells[globalB];
+            nbrsB.append(globalA);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Build combined cell centres and weights
+    // -----------------------------------------------------------------------
+
+    pointField combinedCC(nTotalCells);
+    scalarField combinedWeights(nTotalCells, 1.0);
+
+    forAll(regionMeshes, ri)
+    {
+        const fvMesh& mesh = regionMeshes[ri];
+        const label offset = regionOffset[ri];
+        const vectorField& cc = mesh.cellCentres();
+
+        // Optionally apply region weight
+        scalar regionWeight = 1.0;
+        if (regionWeightsDict.size() > 0)
+        {
+            regionWeightsDict.readIfPresent(regionNames[ri], regionWeight);
+        }
+
+        forAll(cc, cellI)
+        {
+            combinedCC[offset + cellI] = cc[cellI];
+            combinedWeights[offset + cellI] = regionWeight;
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Call decomposition method
+    // -----------------------------------------------------------------------
+
+    Info<< nl << "Performing coupled decomposition" << endl;
+
+    autoPtr<decompositionMethod> methodPtr =
+        decompositionMethod::New(decompDict);
+
+    const labelList cellToProc = methodPtr->decompose
+    (
+        globalCellCells,
+        combinedCC,
+        combinedWeights
+    );
+
+    // -----------------------------------------------------------------------
+    // Split result per region and write cellDecomposition
+    // -----------------------------------------------------------------------
+
+    Info<< nl << "Writing per-region cellDecomposition files" << nl << endl;
+
+    forAll(regionMeshes, ri)
+    {
+        const fvMesh& mesh = regionMeshes[ri];
+        const label offset = regionOffset[ri];
+        const label nCells = mesh.nCells();
+
+        labelList regionCellToProc
+        (
+            SubList<label>(cellToProc, nCells, offset)
+        );
+
+        labelIOList cellDecomposition
+        (
+            IOobject
+            (
+                "cellDecomposition",
+                mesh.facesInstance(),
+                mesh,
+                IOobject::NO_READ,
+                IOobject::NO_WRITE,
+                IOobject::NO_REGISTER
+            ),
+            regionCellToProc
+        );
+
+        cellDecomposition.write();
+
+        Info<< "  Region " << regionNames[ri] << ": wrote "
+            << cellDecomposition.objectRelPath() << endl;
+
+        // Optional: write as volScalarField
+        if (writeCellDist)
+        {
+            volScalarField cellDist
+            (
+                IOobject
+                (
+                    "cellDist",
+                    runTime.timeName(),
+                    mesh,
+                    IOobject::NO_READ,
+                    IOobject::AUTO_WRITE,
+                    IOobject::NO_REGISTER
+                ),
+                mesh,
+                dimensionedScalar("cellDist", dimless, 0)
+            );
+
+            forAll(regionCellToProc, cellI)
+            {
+                cellDist[cellI] = regionCellToProc[cellI];
+            }
+
+            cellDist.write();
+
+            Info<< "  Region " << regionNames[ri] << ": wrote "
+                << cellDist.objectRelPath() << endl;
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Print statistics
+    // -----------------------------------------------------------------------
+
+    Info<< nl << "Decomposition statistics:" << nl << endl;
+
+    // Per-processor per-region cell counts
+    labelListList procRegionCells(nDomains);
+    forAll(procRegionCells, pi)
+    {
+        procRegionCells[pi].setSize(regionNames.size(), 0);
+    }
+
+    forAll(regionMeshes, ri)
+    {
+        const label offset = regionOffset[ri];
+        const label nCells = regionMeshes[ri].nCells();
+
+        for (label ci = 0; ci < nCells; ++ci)
+        {
+            const label proc = cellToProc[offset + ci];
+            procRegionCells[proc][ri]++;
+        }
+    }
+
+    // Print table header
+    Info<< "    Proc";
+    forAll(regionNames, ri)
+    {
+        Info<< "\t" << regionNames[ri];
+    }
+    Info<< "\tTotal" << nl;
+
+    Info<< "    ----";
+    forAll(regionNames, ri)
+    {
+        Info<< "\t----";
+    }
+    Info<< "\t-----" << nl;
+
+    labelList maxCellsPerRegion(regionNames.size(), 0);
+    labelList totalCellsPerRegion(regionNames.size(), 0);
+
+    forAll(procRegionCells, pi)
+    {
+        Info<< "    " << pi;
+
+        label procTotal = 0;
+
+        forAll(regionNames, ri)
+        {
+            const label n = procRegionCells[pi][ri];
+            Info<< "\t" << n;
+            procTotal += n;
+            maxCellsPerRegion[ri] = max(maxCellsPerRegion[ri], n);
+            totalCellsPerRegion[ri] += n;
+        }
+
+        Info<< "\t" << procTotal << nl;
+    }
+
+    // Zero-cell rank counts
+    Info<< nl;
+    forAll(regionNames, ri)
+    {
+        label nZeroRanks = 0;
+        forAll(procRegionCells, pi)
+        {
+            if (procRegionCells[pi][ri] == 0)
+            {
+                nZeroRanks++;
+            }
+        }
+
+        const scalar avgCells =
+            scalar(totalCellsPerRegion[ri]) / nDomains;
+
+        Info<< "  Region " << regionNames[ri] << ":"
+            << "  total=" << totalCellsPerRegion[ri]
+            << "  avg=" << avgCells
+            << "  max=" << maxCellsPerRegion[ri];
+
+        if (avgCells > SMALL)
+        {
+            Info<< " (" << 100.0*(maxCellsPerRegion[ri]-avgCells)/avgCells
+                << "% above avg)";
+        }
+
+        Info<< "  zero-cell ranks=" << nZeroRanks << nl;
+    }
+
+    // -----------------------------------------------------------------------
+    // Run decomposePar for each region (unless -decompose-only)
+    // -----------------------------------------------------------------------
+
+    if (decomposeOnly)
+    {
+        Info<< nl
+            << "Decompose-only mode: skipping processor mesh generation."
+            << nl
+            << "To complete the decomposition, run decomposePar for each"
+            << " region with method=manual, e.g.:" << nl << nl;
+
+        forAll(regionNames, ri)
+        {
+            Info<< "  decomposePar -region " << regionNames[ri]
+                << " -decomposeParDict system/decomposeParDict.manual"
+                << nl;
+        }
+
+        Info<< nl
+            << "where system/decomposeParDict.manual contains:" << nl
+            << "  numberOfSubdomains " << nDomains << ";" << nl
+            << "  method manual;" << nl
+            << "  manualCoeffs { dataFile \"cellDecomposition\"; }" << nl
+            << endl;
+    }
+    else
+    {
+        // Write a temporary manual decomposeParDict
+        const fileName tmpDictPath =
+            runTime.path()/"system"/"decomposeParDict.monolithic_tmp_";
+
+        {
+            OFstream os(tmpDictPath);
+
+            os  << "FoamFile" << nl
+                << "{" << nl
+                << "    version     2.0;" << nl
+                << "    format      ascii;" << nl
+                << "    class       dictionary;" << nl
+                << "    object      decomposeParDict;" << nl
+                << "}" << nl << nl
+                << "numberOfSubdomains " << nDomains << ";" << nl << nl
+                << "method          manual;" << nl << nl
+                << "manualCoeffs" << nl
+                << "{" << nl
+                << "    dataFile    \"cellDecomposition\";" << nl
+                << "}" << nl;
+        }
+
+        Info<< nl
+            << "Running decomposePar for each region" << nl << endl;
+
+        forAll(regionNames, ri)
+        {
+            Info<< "--- Decomposing region: " << regionNames[ri]
+                << " ---" << nl << endl;
+
+            std::string cmd = "decomposePar"
+                " -region " + regionNames[ri]
+                + " -decomposeParDict " + tmpDictPath;
+
+            if (forceOverwrite)
+            {
+                cmd += " -force";
+            }
+            if (copyZero)
+            {
+                cmd += " -copyZero";
+            }
+            if (noFields)
+            {
+                cmd += " -no-fields";
+            }
+
+            const int ret = Foam::system(cmd);
+
+            if (ret != 0)
+            {
+                FatalErrorInFunction
+                    << "decomposePar failed for region "
+                    << regionNames[ri]
+                    << " (exit code " << ret << ")"
+                    << exit(FatalError);
+            }
+        }
+
+        // Clean up temporary dict
+        Foam::rm(tmpDictPath);
+
+        // Clean up cellDecomposition files
+        forAll(regionMeshes, ri)
+        {
+            const fvMesh& mesh = regionMeshes[ri];
+            const fileName cellDecompPath =
+                mesh.time().path()
+              / mesh.facesInstance()
+              / mesh.dbDir()
+              / "cellDecomposition";
+
+            Foam::rm(cellDecompPath);
+        }
+    }
+
+    Info<< "\nEnd\n" << endl;
+
+    return 0;
+}
+
+
+// ************************************************************************* //

--- a/applications/utilities/decomposeParMonolithic/decomposeParMonolithic.C
+++ b/applications/utilities/decomposeParMonolithic/decomposeParMonolithic.C
@@ -56,7 +56,6 @@ Usage
 \*---------------------------------------------------------------------------*/
 
 #include "argList.H"
-#include "Time.H"
 #include "fvMesh.H"
 #include "IOdictionary.H"
 #include "labelIOList.H"
@@ -72,10 +71,10 @@ using namespace Foam;
 
 static bool optionFound(const argList& args, const word& opt)
 {
-#ifdef OPENFOAM_ORG
-    return args.optionFound(opt);
-#else
+#ifdef OPENFOAM_COM
     return args.found(opt);
+#else
+    return args.optionFound(opt);
 #endif
 }
 
@@ -87,20 +86,20 @@ static bool optionReadIfPresent
     fileName& value
 )
 {
-#ifdef OPENFOAM_ORG
-    return args.optionReadIfPresent(opt, value);
-#else
+#ifdef OPENFOAM_COM
     return args.readIfPresent(opt, value);
+#else
+    return args.optionReadIfPresent(opt, value);
 #endif
 }
 
 
 static label regionIndex(const wordList& names, const word& name)
 {
-#ifdef OPENFOAM_ORG
-    return findIndex(names, name);
-#else
+#ifdef OPENFOAM_COM
     return names.find(name);
+#else
+    return findIndex(names, name);
 #endif
 }
 
@@ -282,7 +281,7 @@ int main(int argc, char *argv[])
      && !decompDictFile.empty() && !decompDictFile.isAbsolute()
     )
     {
-        decompDictFile = runTime.globalPath()/decompDictFile;
+        decompDictFile = runTime.path()/decompDictFile;
     }
 
     // Find the dictionary


### PR DESCRIPTION
## Summary

New `decomposeParMonolithic` utility that decomposes multiple mesh regions (e.g. fluid + solid) as a single coupled graph rather than independently per region. This ensures balanced parallel rank distribution when one region is much smaller than the other — a common issue in FSI simulations.

**How it works:**
1. Reads a list of coupled regions from `monolithicCoeffs` in `decomposeParDict`
2. Builds a single combined adjacency graph from all regions, adding cross-region edges at the FSI interface
3. Partitions the combined graph using the specified decomposition method
4. Splits the result back to per-region `cellDecomposition` lists
5. Calls standard `decomposePar` for each region

**No dependency on PETSc or the new FSI solver classes** — uses only standard OpenFOAM infrastructure (`decompositionMethod`, `fvMesh`, `labelIOList`, etc.).

**Files added:**
- `applications/utilities/decomposeParMonolithic/decomposeParMonolithic.C` (737 lines)
- `applications/utilities/decomposeParMonolithic/Make/files`
- `applications/utilities/decomposeParMonolithic/Make/options`
- `applications/utilities/decomposeParMonolithic/README.md`

Extracted from PR #233.

## Test plan

- [x] `wmake` in `applications/utilities/decomposeParMonolithic/` — should produce `decomposeParMonolithic` executable
- [x] Run on a coupled FSI case and verify per-region decompositions are balanced

🤖 Generated with [Claude Code](https://claude.com/claude-code)