### PR TITLE
HronTurekFsi3: loosen regression tolerances

### DIFF
--- a/tutorials/fluidSolidInteraction/HronTurekFsi3/regressionTest.sh
+++ b/tutorials/fluidSolidInteraction/HronTurekFsi3/regressionTest.sh
@@ -16,9 +16,9 @@ CASE_DIR="${REGRESSION_ROOT}/main"
 REG_END_TIME=2.5
 
 # Regression tolerances
-DISP_TOL=1e-5
+DISP_TOL=2e-5
 FX_TOL=1e-4
-FY_TOL=1e-4
+FY_TOL=1e-3
 
 # Reference values at REG_END_TIME
 REF_TIP_UY=-0.00062628


### PR DESCRIPTION
## Summary

- Loosen `DISP_TOL` from `1e-5` to `2e-5` and `FY_TOL` from `1e-4` to `1e-3` in the HronTurekFsi3 regression test script.
- This change is ported directly from `feature-block-coupled-incompressible` (commit `c60f41c5`) to allow it to land on `development` ahead of that larger branch, which may take longer to review and merge.

## Test plan

- [x] Verify `regressionTest.sh` passes for HronTurekFsi3 with the updated tolerances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)