### PR TITLE
adding the sign convention into the m==0 case for the even order lapl…

### DIFF
--- a/src/solids4FoamModels/numerics/stabilisationModels/generalisedEvenOrderLaplacianStab/generalisedEvenOrderLaplacianStabTemplates.H
+++ b/src/solids4FoamModels/numerics/stabilisationModels/generalisedEvenOrderLaplacianStab/generalisedEvenOrderLaplacianStabTemplates.H
@@ -52,7 +52,7 @@ void Foam::generalisedEvenOrderLaplacianStab::computeDiffStencil
 
         const dimensionedScalar one("one", dimless/sqr(dimLength), 1.0);
 
-        faceFlux = -scaleFactor*one*h2f*op.snGrad(field);
+        faceFlux = scaleFactor*one*h2f*op.snGrad(field);
 
         return;
     }


### PR DESCRIPTION
When updating the sign convention the m==0 case for the generalised laplacian was not update
- this is fixed now by changing the sign in:
generalisedEvenOrderLaplacianStabTemplates.H


