### PR TITLE
Clarify RBF library license

### DIFF
--- a/src/RBFMeshMotionSolver/RBFCoarsening.C
+++ b/src/RBFMeshMotionSolver/RBFCoarsening.C
@@ -1,11 +1,22 @@
 
-/*
- * Author
- *   David Blom, TU Delft. All rights reserved.
- *   NOTE: This file is distributed under the GNU General Public License (GPL).
- *   The phrase "All rights reserved" above is retained from the original source
- *   but does not limit the permissions granted by the GPL.
- */
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
 
 #include "RBFCoarsening.H"
 #include "WendlandC2Function.H"

--- a/src/RBFMeshMotionSolver/RBFCoarsening.C
+++ b/src/RBFMeshMotionSolver/RBFCoarsening.C
@@ -2,6 +2,9 @@
 /*
  * Author
  *   David Blom, TU Delft. All rights reserved.
+ *   NOTE: This file is distributed under the GNU General Public License (GPL).
+ *   The phrase "All rights reserved" above is retained from the original source
+ *   but does not limit the permissions granted by the GPL.
  */
 
 #include "RBFCoarsening.H"

--- a/src/RBFMeshMotionSolver/RBFCoarsening.H
+++ b/src/RBFMeshMotionSolver/RBFCoarsening.H
@@ -2,6 +2,9 @@
 /*
  * Author
  *   David Blom, TU Delft. All rights reserved.
+ *   NOTE: This file is distributed under the GNU General Public License (GPL).
+ *   The phrase "All rights reserved" above is retained from the original source
+ *   but does not limit the permissions granted by the GPL.
  */
 
 #ifndef RBFCoarsening_H

--- a/src/RBFMeshMotionSolver/RBFCoarsening.H
+++ b/src/RBFMeshMotionSolver/RBFCoarsening.H
@@ -1,11 +1,37 @@
 
-/*
- * Author
- *   David Blom, TU Delft. All rights reserved.
- *   NOTE: This file is distributed under the GNU General Public License (GPL).
- *   The phrase "All rights reserved" above is retained from the original source
- *   but does not limit the permissions granted by the GPL.
- */
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    RBFCoarsening
+
+Description
+    Radial basis function coarsening utilities.
+
+Author
+    David Blom, TU Delft. All rights reserved.
+    NOTE: This file is distributed under the GNU General Public License (GPL).
+    The phrase "All rights reserved" above is retained from the original
+    source but does not limit the permissions granted by the GPL.
+
+SourceFiles
+    RBFCoarsening.C
+
+\*---------------------------------------------------------------------------*/
 
 #ifndef RBFCoarsening_H
 #define RBFCoarsening_H

--- a/src/RBFMeshMotionSolver/RBFFunctionInterface.H
+++ b/src/RBFMeshMotionSolver/RBFFunctionInterface.H
@@ -1,11 +1,34 @@
 
-/*
- * Author
- *   David Blom, TU Delft. All rights reserved.
- *   NOTE: This file is distributed under the GNU General Public License (GPL).
- *   The phrase "All rights reserved" above is retained from the original source
- *   but does not limit the permissions granted by the GPL.
- */
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    RBFFunctionInterface
+
+Description
+    Abstract interface for radial basis functions.
+
+Author
+    David Blom, TU Delft. All rights reserved.
+    NOTE: This file is distributed under the GNU General Public License (GPL).
+    The phrase "All rights reserved" above is retained from the original
+    source but does not limit the permissions granted by the GPL.
+
+\*---------------------------------------------------------------------------*/
 
 #ifndef RBFFunctionInterface_H
 #define RBFFunctionInterface_H

--- a/src/RBFMeshMotionSolver/RBFFunctionInterface.H
+++ b/src/RBFMeshMotionSolver/RBFFunctionInterface.H
@@ -2,6 +2,9 @@
 /*
  * Author
  *   David Blom, TU Delft. All rights reserved.
+ *   NOTE: This file is distributed under the GNU General Public License (GPL).
+ *   The phrase "All rights reserved" above is retained from the original source
+ *   but does not limit the permissions granted by the GPL.
  */
 
 #ifndef RBFFunctionInterface_H

--- a/src/RBFMeshMotionSolver/RBFFunctions/LinearFunction.C
+++ b/src/RBFMeshMotionSolver/RBFFunctions/LinearFunction.C
@@ -2,6 +2,9 @@
 /*
  * Author
  *   David Blom, TU Delft. All rights reserved.
+ *   NOTE: This file is distributed under the GNU General Public License (GPL).
+ *   The phrase "All rights reserved" above is retained from the original source
+ *   but does not limit the permissions granted by the GPL.
  */
 
 #include "LinearFunction.H"

--- a/src/RBFMeshMotionSolver/RBFFunctions/LinearFunction.C
+++ b/src/RBFMeshMotionSolver/RBFFunctions/LinearFunction.C
@@ -1,11 +1,22 @@
 
-/*
- * Author
- *   David Blom, TU Delft. All rights reserved.
- *   NOTE: This file is distributed under the GNU General Public License (GPL).
- *   The phrase "All rights reserved" above is retained from the original source
- *   but does not limit the permissions granted by the GPL.
- */
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
 
 #include "LinearFunction.H"
 

--- a/src/RBFMeshMotionSolver/RBFFunctions/LinearFunction.H
+++ b/src/RBFMeshMotionSolver/RBFFunctions/LinearFunction.H
@@ -2,6 +2,9 @@
 /*
  * Author
  *   David Blom, TU Delft. All rights reserved.
+ *   NOTE: This file is distributed under the GNU General Public License (GPL).
+ *   The phrase "All rights reserved" above is retained from the original source
+ *   but does not limit the permissions granted by the GPL.
  */
 
 #ifndef LinearFunction_H

--- a/src/RBFMeshMotionSolver/RBFFunctions/LinearFunction.H
+++ b/src/RBFMeshMotionSolver/RBFFunctions/LinearFunction.H
@@ -1,11 +1,34 @@
 
-/*
- * Author
- *   David Blom, TU Delft. All rights reserved.
- *   NOTE: This file is distributed under the GNU General Public License (GPL).
- *   The phrase "All rights reserved" above is retained from the original source
- *   but does not limit the permissions granted by the GPL.
- */
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    LinearFunction
+
+Description
+    Linear radial basis function.
+
+Author
+    David Blom, TU Delft. All rights reserved.
+    NOTE: This file is distributed under the GNU General Public License (GPL).
+    The phrase "All rights reserved" above is retained from the original
+    source but does not limit the permissions granted by the GPL.
+
+\*---------------------------------------------------------------------------*/
 
 #ifndef LinearFunction_H
 #define LinearFunction_H

--- a/src/RBFMeshMotionSolver/RBFFunctions/TPSFunction.C
+++ b/src/RBFMeshMotionSolver/RBFFunctions/TPSFunction.C
@@ -1,11 +1,22 @@
 
-/*
- * Author
- *   David Blom, TU Delft. All rights reserved.
- *   NOTE: This file is distributed under the GNU General Public License (GPL).
- *   The phrase "All rights reserved" above is retained from the original source
- *   but does not limit the permissions granted by the GPL.
- */
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
 
 #include "TPSFunction.H"
 

--- a/src/RBFMeshMotionSolver/RBFFunctions/TPSFunction.C
+++ b/src/RBFMeshMotionSolver/RBFFunctions/TPSFunction.C
@@ -2,6 +2,9 @@
 /*
  * Author
  *   David Blom, TU Delft. All rights reserved.
+ *   NOTE: This file is distributed under the GNU General Public License (GPL).
+ *   The phrase "All rights reserved" above is retained from the original source
+ *   but does not limit the permissions granted by the GPL.
  */
 
 #include "TPSFunction.H"

--- a/src/RBFMeshMotionSolver/RBFFunctions/TPSFunction.H
+++ b/src/RBFMeshMotionSolver/RBFFunctions/TPSFunction.H
@@ -1,11 +1,34 @@
 
-/*
- * Author
- *   David Blom, TU Delft. All rights reserved.
- *   NOTE: This file is distributed under the GNU General Public License (GPL).
- *   The phrase "All rights reserved" above is retained from the original source
- *   but does not limit the permissions granted by the GPL.
- */
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    TPSFunction
+
+Description
+    Thin-plate spline radial basis function.
+
+Author
+    David Blom, TU Delft. All rights reserved.
+    NOTE: This file is distributed under the GNU General Public License (GPL).
+    The phrase "All rights reserved" above is retained from the original
+    source but does not limit the permissions granted by the GPL.
+
+\*---------------------------------------------------------------------------*/
 
 #ifndef TPSFunction_H
 #define TPSFunction_H

--- a/src/RBFMeshMotionSolver/RBFFunctions/TPSFunction.H
+++ b/src/RBFMeshMotionSolver/RBFFunctions/TPSFunction.H
@@ -2,6 +2,9 @@
 /*
  * Author
  *   David Blom, TU Delft. All rights reserved.
+ *   NOTE: This file is distributed under the GNU General Public License (GPL).
+ *   The phrase "All rights reserved" above is retained from the original source
+ *   but does not limit the permissions granted by the GPL.
  */
 
 #ifndef TPSFunction_H

--- a/src/RBFMeshMotionSolver/RBFFunctions/WendlandC0Function.C
+++ b/src/RBFMeshMotionSolver/RBFFunctions/WendlandC0Function.C
@@ -1,11 +1,22 @@
 
-/*
- * Author
- *   David Blom, TU Delft. All rights reserved.
- *   NOTE: This file is distributed under the GNU General Public License (GPL).
- *   The phrase "All rights reserved" above is retained from the original source
- *   but does not limit the permissions granted by the GPL.
- */
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
 
 #include "WendlandC0Function.H"
 

--- a/src/RBFMeshMotionSolver/RBFFunctions/WendlandC0Function.C
+++ b/src/RBFMeshMotionSolver/RBFFunctions/WendlandC0Function.C
@@ -2,6 +2,9 @@
 /*
  * Author
  *   David Blom, TU Delft. All rights reserved.
+ *   NOTE: This file is distributed under the GNU General Public License (GPL).
+ *   The phrase "All rights reserved" above is retained from the original source
+ *   but does not limit the permissions granted by the GPL.
  */
 
 #include "WendlandC0Function.H"

--- a/src/RBFMeshMotionSolver/RBFFunctions/WendlandC0Function.H
+++ b/src/RBFMeshMotionSolver/RBFFunctions/WendlandC0Function.H
@@ -2,6 +2,9 @@
 /*
  * Author
  *   David Blom, TU Delft. All rights reserved.
+ *   NOTE: This file is distributed under the GNU General Public License (GPL).
+ *   The phrase "All rights reserved" above is retained from the original source
+ *   but does not limit the permissions granted by the GPL.
  */
 
 #ifndef WendlandC0Function_H

--- a/src/RBFMeshMotionSolver/RBFFunctions/WendlandC0Function.H
+++ b/src/RBFMeshMotionSolver/RBFFunctions/WendlandC0Function.H
@@ -1,11 +1,34 @@
 
-/*
- * Author
- *   David Blom, TU Delft. All rights reserved.
- *   NOTE: This file is distributed under the GNU General Public License (GPL).
- *   The phrase "All rights reserved" above is retained from the original source
- *   but does not limit the permissions granted by the GPL.
- */
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    WendlandC0Function
+
+Description
+    Wendland C0 radial basis function.
+
+Author
+    David Blom, TU Delft. All rights reserved.
+    NOTE: This file is distributed under the GNU General Public License (GPL).
+    The phrase "All rights reserved" above is retained from the original
+    source but does not limit the permissions granted by the GPL.
+
+\*---------------------------------------------------------------------------*/
 
 #ifndef WendlandC0Function_H
 #define WendlandC0Function_H

--- a/src/RBFMeshMotionSolver/RBFFunctions/WendlandC2Function.C
+++ b/src/RBFMeshMotionSolver/RBFFunctions/WendlandC2Function.C
@@ -1,11 +1,22 @@
 
-/*
- * Author
- *   David Blom, TU Delft. All rights reserved.
- *   NOTE: This file is distributed under the GNU General Public License (GPL).
- *   The phrase "All rights reserved" above is retained from the original source
- *   but does not limit the permissions granted by the GPL.
- */
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
 
 #include "WendlandC2Function.H"
 

--- a/src/RBFMeshMotionSolver/RBFFunctions/WendlandC2Function.C
+++ b/src/RBFMeshMotionSolver/RBFFunctions/WendlandC2Function.C
@@ -2,6 +2,9 @@
 /*
  * Author
  *   David Blom, TU Delft. All rights reserved.
+ *   NOTE: This file is distributed under the GNU General Public License (GPL).
+ *   The phrase "All rights reserved" above is retained from the original source
+ *   but does not limit the permissions granted by the GPL.
  */
 
 #include "WendlandC2Function.H"

--- a/src/RBFMeshMotionSolver/RBFFunctions/WendlandC2Function.H
+++ b/src/RBFMeshMotionSolver/RBFFunctions/WendlandC2Function.H
@@ -1,11 +1,34 @@
 
-/*
- * Author
- *   David Blom, TU Delft. All rights reserved.
- *   NOTE: This file is distributed under the GNU General Public License (GPL).
- *   The phrase "All rights reserved" above is retained from the original source
- *   but does not limit the permissions granted by the GPL.
- */
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    WendlandC2Function
+
+Description
+    Wendland C2 radial basis function.
+
+Author
+    David Blom, TU Delft. All rights reserved.
+    NOTE: This file is distributed under the GNU General Public License (GPL).
+    The phrase "All rights reserved" above is retained from the original
+    source but does not limit the permissions granted by the GPL.
+
+\*---------------------------------------------------------------------------*/
 
 #ifndef WendlandC2Function_H
 #define WendlandC2Function_H

--- a/src/RBFMeshMotionSolver/RBFFunctions/WendlandC2Function.H
+++ b/src/RBFMeshMotionSolver/RBFFunctions/WendlandC2Function.H
@@ -2,6 +2,9 @@
 /*
  * Author
  *   David Blom, TU Delft. All rights reserved.
+ *   NOTE: This file is distributed under the GNU General Public License (GPL).
+ *   The phrase "All rights reserved" above is retained from the original source
+ *   but does not limit the permissions granted by the GPL.
  */
 
 #ifndef WendlandC2Function_H

--- a/src/RBFMeshMotionSolver/RBFFunctions/WendlandC4Function.C
+++ b/src/RBFMeshMotionSolver/RBFFunctions/WendlandC4Function.C
@@ -2,6 +2,9 @@
 /*
  * Author
  *   David Blom, TU Delft. All rights reserved.
+ *   NOTE: This file is distributed under the GNU General Public License (GPL).
+ *   The phrase "All rights reserved" above is retained from the original source
+ *   but does not limit the permissions granted by the GPL.
  */
 
 #include "WendlandC4Function.H"

--- a/src/RBFMeshMotionSolver/RBFFunctions/WendlandC4Function.C
+++ b/src/RBFMeshMotionSolver/RBFFunctions/WendlandC4Function.C
@@ -1,11 +1,22 @@
 
-/*
- * Author
- *   David Blom, TU Delft. All rights reserved.
- *   NOTE: This file is distributed under the GNU General Public License (GPL).
- *   The phrase "All rights reserved" above is retained from the original source
- *   but does not limit the permissions granted by the GPL.
- */
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
 
 #include "WendlandC4Function.H"
 

--- a/src/RBFMeshMotionSolver/RBFFunctions/WendlandC4Function.H
+++ b/src/RBFMeshMotionSolver/RBFFunctions/WendlandC4Function.H
@@ -1,11 +1,34 @@
 
-/*
- * Author
- *   David Blom, TU Delft. All rights reserved.
- *   NOTE: This file is distributed under the GNU General Public License (GPL).
- *   The phrase "All rights reserved" above is retained from the original source
- *   but does not limit the permissions granted by the GPL.
- */
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    WendlandC4Function
+
+Description
+    Wendland C4 radial basis function.
+
+Author
+    David Blom, TU Delft. All rights reserved.
+    NOTE: This file is distributed under the GNU General Public License (GPL).
+    The phrase "All rights reserved" above is retained from the original
+    source but does not limit the permissions granted by the GPL.
+
+\*---------------------------------------------------------------------------*/
 
 #ifndef WendlandC4Function_H
 #define WendlandC4Function_H

--- a/src/RBFMeshMotionSolver/RBFFunctions/WendlandC4Function.H
+++ b/src/RBFMeshMotionSolver/RBFFunctions/WendlandC4Function.H
@@ -2,6 +2,9 @@
 /*
  * Author
  *   David Blom, TU Delft. All rights reserved.
+ *   NOTE: This file is distributed under the GNU General Public License (GPL).
+ *   The phrase "All rights reserved" above is retained from the original source
+ *   but does not limit the permissions granted by the GPL.
  */
 
 #ifndef WendlandC4Function_H

--- a/src/RBFMeshMotionSolver/RBFFunctions/WendlandC6Function.C
+++ b/src/RBFMeshMotionSolver/RBFFunctions/WendlandC6Function.C
@@ -1,11 +1,22 @@
 
-/*
- * Author
- *   David Blom, TU Delft. All rights reserved.
- *   NOTE: This file is distributed under the GNU General Public License (GPL).
- *   The phrase "All rights reserved" above is retained from the original source
- *   but does not limit the permissions granted by the GPL.
- */
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
 
 #include "WendlandC6Function.H"
 

--- a/src/RBFMeshMotionSolver/RBFFunctions/WendlandC6Function.C
+++ b/src/RBFMeshMotionSolver/RBFFunctions/WendlandC6Function.C
@@ -2,6 +2,9 @@
 /*
  * Author
  *   David Blom, TU Delft. All rights reserved.
+ *   NOTE: This file is distributed under the GNU General Public License (GPL).
+ *   The phrase "All rights reserved" above is retained from the original source
+ *   but does not limit the permissions granted by the GPL.
  */
 
 #include "WendlandC6Function.H"

--- a/src/RBFMeshMotionSolver/RBFFunctions/WendlandC6Function.H
+++ b/src/RBFMeshMotionSolver/RBFFunctions/WendlandC6Function.H
@@ -1,11 +1,34 @@
 
-/*
- * Author
- *   David Blom, TU Delft. All rights reserved.
- *   NOTE: This file is distributed under the GNU General Public License (GPL).
- *   The phrase "All rights reserved" above is retained from the original source
- *   but does not limit the permissions granted by the GPL.
- */
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    WendlandC6Function
+
+Description
+    Wendland C6 radial basis function.
+
+Author
+    David Blom, TU Delft. All rights reserved.
+    NOTE: This file is distributed under the GNU General Public License (GPL).
+    The phrase "All rights reserved" above is retained from the original
+    source but does not limit the permissions granted by the GPL.
+
+\*---------------------------------------------------------------------------*/
 
 #ifndef WendlandC6Function_H
 #define WendlandC6Function_H

--- a/src/RBFMeshMotionSolver/RBFFunctions/WendlandC6Function.H
+++ b/src/RBFMeshMotionSolver/RBFFunctions/WendlandC6Function.H
@@ -2,6 +2,9 @@
 /*
  * Author
  *   David Blom, TU Delft. All rights reserved.
+ *   NOTE: This file is distributed under the GNU General Public License (GPL).
+ *   The phrase "All rights reserved" above is retained from the original source
+ *   but does not limit the permissions granted by the GPL.
  */
 
 #ifndef WendlandC6Function_H

--- a/src/RBFMeshMotionSolver/RBFInterpolation.C
+++ b/src/RBFMeshMotionSolver/RBFInterpolation.C
@@ -2,6 +2,9 @@
 /*
  * Author
  *   David Blom, TU Delft. All rights reserved.
+ *   NOTE: This file is distributed under the GNU General Public License (GPL).
+ *   The phrase "All rights reserved" above is retained from the original source
+ *   but does not limit the permissions granted by the GPL.
  */
 
 #include "RBFInterpolation.H"

--- a/src/RBFMeshMotionSolver/RBFInterpolation.C
+++ b/src/RBFMeshMotionSolver/RBFInterpolation.C
@@ -1,11 +1,22 @@
 
-/*
- * Author
- *   David Blom, TU Delft. All rights reserved.
- *   NOTE: This file is distributed under the GNU General Public License (GPL).
- *   The phrase "All rights reserved" above is retained from the original source
- *   but does not limit the permissions granted by the GPL.
- */
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
 
 #include "RBFInterpolation.H"
 #include "TPSFunction.H"

--- a/src/RBFMeshMotionSolver/RBFInterpolation.H
+++ b/src/RBFMeshMotionSolver/RBFInterpolation.H
@@ -1,11 +1,37 @@
 
-/*
- * Author
- *   David Blom, TU Delft. All rights reserved.
- *   NOTE: This file is distributed under the GNU General Public License (GPL).
- *   The phrase "All rights reserved" above is retained from the original source
- *   but does not limit the permissions granted by the GPL.
- */
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    RBFInterpolation
+
+Description
+    Radial basis function interpolation utilities.
+
+Author
+    David Blom, TU Delft. All rights reserved.
+    NOTE: This file is distributed under the GNU General Public License (GPL).
+    The phrase "All rights reserved" above is retained from the original
+    source but does not limit the permissions granted by the GPL.
+
+SourceFiles
+    RBFInterpolation.C
+
+\*---------------------------------------------------------------------------*/
 
 #ifndef RBFInterpolation_H
 #define RBFInterpolation_H

--- a/src/RBFMeshMotionSolver/RBFInterpolation.H
+++ b/src/RBFMeshMotionSolver/RBFInterpolation.H
@@ -2,6 +2,9 @@
 /*
  * Author
  *   David Blom, TU Delft. All rights reserved.
+ *   NOTE: This file is distributed under the GNU General Public License (GPL).
+ *   The phrase "All rights reserved" above is retained from the original source
+ *   but does not limit the permissions granted by the GPL.
  */
 
 #ifndef RBFInterpolation_H

--- a/src/RBFMeshMotionSolver/RBFMeshMotionSolver.C
+++ b/src/RBFMeshMotionSolver/RBFMeshMotionSolver.C
@@ -2,6 +2,9 @@
 /*
  * Author
  *   David Blom, TU Delft. All rights reserved.
+ *   NOTE: This file is distributed under the GNU General Public License (GPL).
+ *   The phrase "All rights reserved" above is retained from the original source
+ *   but does not limit the permissions granted by the GPL.
  */
 
 #include "RBFMeshMotionSolver.H"

--- a/src/RBFMeshMotionSolver/RBFMeshMotionSolver.C
+++ b/src/RBFMeshMotionSolver/RBFMeshMotionSolver.C
@@ -1,11 +1,22 @@
 
-/*
- * Author
- *   David Blom, TU Delft. All rights reserved.
- *   NOTE: This file is distributed under the GNU General Public License (GPL).
- *   The phrase "All rights reserved" above is retained from the original source
- *   but does not limit the permissions granted by the GPL.
- */
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
 
 #include "RBFMeshMotionSolver.H"
 #include <unordered_map>

--- a/src/RBFMeshMotionSolver/RBFMeshMotionSolver.H
+++ b/src/RBFMeshMotionSolver/RBFMeshMotionSolver.H
@@ -2,6 +2,9 @@
 /*
  * Author
  *   David Blom, TU Delft. All rights reserved.
+ *   NOTE: This file is distributed under the GNU General Public License (GPL).
+ *   The phrase "All rights reserved" above is retained from the original source
+ *   but does not limit the permissions granted by the GPL.
  */
 
 #ifndef RBFMeshMotionSolver_H

--- a/src/RBFMeshMotionSolver/RBFMeshMotionSolver.H
+++ b/src/RBFMeshMotionSolver/RBFMeshMotionSolver.H
@@ -1,11 +1,37 @@
 
-/*
- * Author
- *   David Blom, TU Delft. All rights reserved.
- *   NOTE: This file is distributed under the GNU General Public License (GPL).
- *   The phrase "All rights reserved" above is retained from the original source
- *   but does not limit the permissions granted by the GPL.
- */
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    RBFMeshMotionSolver
+
+Description
+    Radial basis function mesh motion solver.
+
+Author
+    David Blom, TU Delft. All rights reserved.
+    NOTE: This file is distributed under the GNU General Public License (GPL).
+    The phrase "All rights reserved" above is retained from the original
+    source but does not limit the permissions granted by the GPL.
+
+SourceFiles
+    RBFMeshMotionSolver.C
+
+\*---------------------------------------------------------------------------*/
 
 #ifndef RBFMeshMotionSolver_H
 #define RBFMeshMotionSolver_H

--- a/src/RBFMeshMotionSolver/twoDPointCorrectorRBF.C
+++ b/src/RBFMeshMotionSolver/twoDPointCorrectorRBF.C
@@ -1,3 +1,21 @@
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
 
 #include "twoDPointCorrectorRBF.H"
 #include "polyMesh.H"

--- a/src/RBFMeshMotionSolver/twoDPointCorrectorRBF.H
+++ b/src/RBFMeshMotionSolver/twoDPointCorrectorRBF.H
@@ -1,3 +1,34 @@
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    twoDPointCorrectorRBF
+
+Description
+    2D point corrector for RBF mesh motion.
+
+Author
+    David Blom.
+    Philip Cardiff, UCD.
+
+SourceFiles
+    twoDPointCorrectorRBF.C
+
+\*---------------------------------------------------------------------------*/
 
 #ifndef twoDPointCorrectorRBF_H
 #define twoDPointCorrectorRBF_H
@@ -11,18 +42,19 @@
 
 namespace Foam
 {
-    // Forward class declarations
-    class polyMesh;
 
-    /*---------------------------------------------------------------------------*\
-    *                       Class twoDPointCorrectorRBF Declaration
-    \*---------------------------------------------------------------------------*/
+// Forward class declarations
+class polyMesh;
 
-    class twoDPointCorrectorRBF
-          :
-            public twoDPointCorrector
-    {
-        // Private data
+/*---------------------------------------------------------------------------*\
+*                       Class twoDPointCorrectorRBF Declaration
+\*---------------------------------------------------------------------------*/
+
+class twoDPointCorrectorRBF
+:
+    public twoDPointCorrector
+{
+    // Private data
 
         // - Reference to moving mesh
         const polyMesh & mesh_;
@@ -37,7 +69,7 @@ namespace Foam
         labelList shadowPointIDs_;
 
 
-        // Private Member Functions
+    // Private Member Functions
 
         // - Disallow default bitwise copy construct
         twoDPointCorrectorRBF( const twoDPointCorrectorRBF & );
@@ -47,24 +79,26 @@ namespace Foam
 
         void setMarker();
 
-        public:
-            // Constructors
+    public:
 
-            // - Construct from components
-            twoDPointCorrectorRBF( const polyMesh & mesh );
+    // Constructors
 
-
-            // Destructor
-
-            virtual ~twoDPointCorrectorRBF();
+        // - Construct from components
+        twoDPointCorrectorRBF( const polyMesh & mesh );
 
 
-            // Member Functions
+    // Destructor
 
-            const labelList & marker() const;
+        virtual ~twoDPointCorrectorRBF();
 
-            void setShadowSide( vectorField & newpoints ) const;
-    };
+
+    // Member Functions
+
+        const labelList & marker() const;
+
+        void setShadowSide(vectorField & newpoints) const;
+};
+
 } // End namespace Foam
 
 


### PR DESCRIPTION
## Summary

  Update the `src/RBFMeshMotionSolver` headers to follow the standard solids4foam GPL license convention used elsewhere in the repository.

### What changed
  - Replaced the custom short-form header blocks in all `H` and `C` files in `src/RBFMeshMotionSolver` with the standard solids4foam GPL preamble.
  - Preserved David Blom as the original author where that attribution already existed.
  - Kept the `All rights reserved` wording and added clarifying text in the author section to make the GPL status explicit.
  - Added a standard header block to `twoDPointCorrectorRBF.H` and `twoDPointCorrectorRBF.C`, which previously had no license header.
  - Noted the existing helper script for future bulk updates:
    - `applications/scripts/solids4FoamChangeCopyright.sh`

## Verification

  - `git diff --check -- src/RBFMeshMotionSolver`
  - Spot-checked representative `H` and `C` files to confirm the header format matches the repository convention.

## Notes

This is a comment/header-only change. No code behaviour was modified.
