### PR TITLE
Remove rights reserved statements to avoid confusion

### DIFF
--- a/applications/solvers/solids4Foam/solids4Foam.C
+++ b/applications/solvers/solids4Foam/solids4Foam.C
@@ -23,8 +23,8 @@ Description
     fluid-solid) is chosen at run-time.
 
 Author
-    Philip Cardiff, UCD.  All rights reserved.
-    Zeljko Tukovic, FSB Zagreb.  All rights reserved.
+    Philip Cardiff, UCD.
+    Zeljko Tukovic, FSB Zagreb.
 
 \*---------------------------------------------------------------------------*/
 

--- a/applications/utilities/addTinyPatch/addTinyPatch.C
+++ b/applications/utilities/addTinyPatch/addTinyPatch.C
@@ -32,7 +32,7 @@ Description
     The new mesh overwrites the previous mesh.
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/applications/utilities/projectPatchToSphere/projectPatchToSphere.C
+++ b/applications/utilities/projectPatchToSphere/projectPatchToSphere.C
@@ -26,7 +26,7 @@ Description
     cells.
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/applications/utilities/splitPatch/splitPatch.C
+++ b/applications/utilities/splitPatch/splitPatch.C
@@ -22,7 +22,7 @@ Description
     Splits up a patch by putting faces in the given bounding box in a new patch
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/RBFMeshMotionSolver/RBFCoarsening.C
+++ b/src/RBFMeshMotionSolver/RBFCoarsening.C
@@ -1,11 +1,22 @@
 
-/*
- * Author
- *   David Blom, TU Delft. All rights reserved.
- *   NOTE: This file is distributed under the GNU General Public License (GPL).
- *   The phrase "All rights reserved" above is retained from the original source
- *   but does not limit the permissions granted by the GPL.
- */
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
 
 #include "RBFCoarsening.H"
 #include "WendlandC2Function.H"

--- a/src/RBFMeshMotionSolver/RBFCoarsening.C
+++ b/src/RBFMeshMotionSolver/RBFCoarsening.C
@@ -2,6 +2,9 @@
 /*
  * Author
  *   David Blom, TU Delft. All rights reserved.
+ *   NOTE: This file is distributed under the GNU General Public License (GPL).
+ *   The phrase "All rights reserved" above is retained from the original source
+ *   but does not limit the permissions granted by the GPL.
  */
 
 #include "RBFCoarsening.H"

--- a/src/RBFMeshMotionSolver/RBFCoarsening.H
+++ b/src/RBFMeshMotionSolver/RBFCoarsening.H
@@ -2,6 +2,9 @@
 /*
  * Author
  *   David Blom, TU Delft. All rights reserved.
+ *   NOTE: This file is distributed under the GNU General Public License (GPL).
+ *   The phrase "All rights reserved" above is retained from the original source
+ *   but does not limit the permissions granted by the GPL.
  */
 
 #ifndef RBFCoarsening_H

--- a/src/RBFMeshMotionSolver/RBFCoarsening.H
+++ b/src/RBFMeshMotionSolver/RBFCoarsening.H
@@ -1,11 +1,37 @@
 
-/*
- * Author
- *   David Blom, TU Delft. All rights reserved.
- *   NOTE: This file is distributed under the GNU General Public License (GPL).
- *   The phrase "All rights reserved" above is retained from the original source
- *   but does not limit the permissions granted by the GPL.
- */
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    RBFCoarsening
+
+Description
+    Radial basis function coarsening utilities.
+
+Author
+    David Blom, TU Delft. All rights reserved.
+    NOTE: This file is distributed under the GNU General Public License (GPL).
+    The phrase "All rights reserved" above is retained from the original
+    source but does not limit the permissions granted by the GPL.
+
+SourceFiles
+    RBFCoarsening.C
+
+\*---------------------------------------------------------------------------*/
 
 #ifndef RBFCoarsening_H
 #define RBFCoarsening_H

--- a/src/RBFMeshMotionSolver/RBFFunctionInterface.H
+++ b/src/RBFMeshMotionSolver/RBFFunctionInterface.H
@@ -1,11 +1,34 @@
 
-/*
- * Author
- *   David Blom, TU Delft. All rights reserved.
- *   NOTE: This file is distributed under the GNU General Public License (GPL).
- *   The phrase "All rights reserved" above is retained from the original source
- *   but does not limit the permissions granted by the GPL.
- */
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    RBFFunctionInterface
+
+Description
+    Abstract interface for radial basis functions.
+
+Author
+    David Blom, TU Delft. All rights reserved.
+    NOTE: This file is distributed under the GNU General Public License (GPL).
+    The phrase "All rights reserved" above is retained from the original
+    source but does not limit the permissions granted by the GPL.
+
+\*---------------------------------------------------------------------------*/
 
 #ifndef RBFFunctionInterface_H
 #define RBFFunctionInterface_H

--- a/src/RBFMeshMotionSolver/RBFFunctionInterface.H
+++ b/src/RBFMeshMotionSolver/RBFFunctionInterface.H
@@ -2,6 +2,9 @@
 /*
  * Author
  *   David Blom, TU Delft. All rights reserved.
+ *   NOTE: This file is distributed under the GNU General Public License (GPL).
+ *   The phrase "All rights reserved" above is retained from the original source
+ *   but does not limit the permissions granted by the GPL.
  */
 
 #ifndef RBFFunctionInterface_H

--- a/src/RBFMeshMotionSolver/RBFFunctions/LinearFunction.C
+++ b/src/RBFMeshMotionSolver/RBFFunctions/LinearFunction.C
@@ -2,6 +2,9 @@
 /*
  * Author
  *   David Blom, TU Delft. All rights reserved.
+ *   NOTE: This file is distributed under the GNU General Public License (GPL).
+ *   The phrase "All rights reserved" above is retained from the original source
+ *   but does not limit the permissions granted by the GPL.
  */
 
 #include "LinearFunction.H"

--- a/src/RBFMeshMotionSolver/RBFFunctions/LinearFunction.C
+++ b/src/RBFMeshMotionSolver/RBFFunctions/LinearFunction.C
@@ -1,11 +1,22 @@
 
-/*
- * Author
- *   David Blom, TU Delft. All rights reserved.
- *   NOTE: This file is distributed under the GNU General Public License (GPL).
- *   The phrase "All rights reserved" above is retained from the original source
- *   but does not limit the permissions granted by the GPL.
- */
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
 
 #include "LinearFunction.H"
 

--- a/src/RBFMeshMotionSolver/RBFFunctions/LinearFunction.H
+++ b/src/RBFMeshMotionSolver/RBFFunctions/LinearFunction.H
@@ -2,6 +2,9 @@
 /*
  * Author
  *   David Blom, TU Delft. All rights reserved.
+ *   NOTE: This file is distributed under the GNU General Public License (GPL).
+ *   The phrase "All rights reserved" above is retained from the original source
+ *   but does not limit the permissions granted by the GPL.
  */
 
 #ifndef LinearFunction_H

--- a/src/RBFMeshMotionSolver/RBFFunctions/LinearFunction.H
+++ b/src/RBFMeshMotionSolver/RBFFunctions/LinearFunction.H
@@ -1,11 +1,34 @@
 
-/*
- * Author
- *   David Blom, TU Delft. All rights reserved.
- *   NOTE: This file is distributed under the GNU General Public License (GPL).
- *   The phrase "All rights reserved" above is retained from the original source
- *   but does not limit the permissions granted by the GPL.
- */
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    LinearFunction
+
+Description
+    Linear radial basis function.
+
+Author
+    David Blom, TU Delft. All rights reserved.
+    NOTE: This file is distributed under the GNU General Public License (GPL).
+    The phrase "All rights reserved" above is retained from the original
+    source but does not limit the permissions granted by the GPL.
+
+\*---------------------------------------------------------------------------*/
 
 #ifndef LinearFunction_H
 #define LinearFunction_H

--- a/src/RBFMeshMotionSolver/RBFFunctions/TPSFunction.C
+++ b/src/RBFMeshMotionSolver/RBFFunctions/TPSFunction.C
@@ -1,11 +1,22 @@
 
-/*
- * Author
- *   David Blom, TU Delft. All rights reserved.
- *   NOTE: This file is distributed under the GNU General Public License (GPL).
- *   The phrase "All rights reserved" above is retained from the original source
- *   but does not limit the permissions granted by the GPL.
- */
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
 
 #include "TPSFunction.H"
 

--- a/src/RBFMeshMotionSolver/RBFFunctions/TPSFunction.C
+++ b/src/RBFMeshMotionSolver/RBFFunctions/TPSFunction.C
@@ -2,6 +2,9 @@
 /*
  * Author
  *   David Blom, TU Delft. All rights reserved.
+ *   NOTE: This file is distributed under the GNU General Public License (GPL).
+ *   The phrase "All rights reserved" above is retained from the original source
+ *   but does not limit the permissions granted by the GPL.
  */
 
 #include "TPSFunction.H"

--- a/src/RBFMeshMotionSolver/RBFFunctions/TPSFunction.H
+++ b/src/RBFMeshMotionSolver/RBFFunctions/TPSFunction.H
@@ -1,11 +1,34 @@
 
-/*
- * Author
- *   David Blom, TU Delft. All rights reserved.
- *   NOTE: This file is distributed under the GNU General Public License (GPL).
- *   The phrase "All rights reserved" above is retained from the original source
- *   but does not limit the permissions granted by the GPL.
- */
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    TPSFunction
+
+Description
+    Thin-plate spline radial basis function.
+
+Author
+    David Blom, TU Delft. All rights reserved.
+    NOTE: This file is distributed under the GNU General Public License (GPL).
+    The phrase "All rights reserved" above is retained from the original
+    source but does not limit the permissions granted by the GPL.
+
+\*---------------------------------------------------------------------------*/
 
 #ifndef TPSFunction_H
 #define TPSFunction_H

--- a/src/RBFMeshMotionSolver/RBFFunctions/TPSFunction.H
+++ b/src/RBFMeshMotionSolver/RBFFunctions/TPSFunction.H
@@ -2,6 +2,9 @@
 /*
  * Author
  *   David Blom, TU Delft. All rights reserved.
+ *   NOTE: This file is distributed under the GNU General Public License (GPL).
+ *   The phrase "All rights reserved" above is retained from the original source
+ *   but does not limit the permissions granted by the GPL.
  */
 
 #ifndef TPSFunction_H

--- a/src/RBFMeshMotionSolver/RBFFunctions/WendlandC0Function.C
+++ b/src/RBFMeshMotionSolver/RBFFunctions/WendlandC0Function.C
@@ -1,11 +1,22 @@
 
-/*
- * Author
- *   David Blom, TU Delft. All rights reserved.
- *   NOTE: This file is distributed under the GNU General Public License (GPL).
- *   The phrase "All rights reserved" above is retained from the original source
- *   but does not limit the permissions granted by the GPL.
- */
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
 
 #include "WendlandC0Function.H"
 

--- a/src/RBFMeshMotionSolver/RBFFunctions/WendlandC0Function.C
+++ b/src/RBFMeshMotionSolver/RBFFunctions/WendlandC0Function.C
@@ -2,6 +2,9 @@
 /*
  * Author
  *   David Blom, TU Delft. All rights reserved.
+ *   NOTE: This file is distributed under the GNU General Public License (GPL).
+ *   The phrase "All rights reserved" above is retained from the original source
+ *   but does not limit the permissions granted by the GPL.
  */
 
 #include "WendlandC0Function.H"

--- a/src/RBFMeshMotionSolver/RBFFunctions/WendlandC0Function.H
+++ b/src/RBFMeshMotionSolver/RBFFunctions/WendlandC0Function.H
@@ -2,6 +2,9 @@
 /*
  * Author
  *   David Blom, TU Delft. All rights reserved.
+ *   NOTE: This file is distributed under the GNU General Public License (GPL).
+ *   The phrase "All rights reserved" above is retained from the original source
+ *   but does not limit the permissions granted by the GPL.
  */
 
 #ifndef WendlandC0Function_H

--- a/src/RBFMeshMotionSolver/RBFFunctions/WendlandC0Function.H
+++ b/src/RBFMeshMotionSolver/RBFFunctions/WendlandC0Function.H
@@ -1,11 +1,34 @@
 
-/*
- * Author
- *   David Blom, TU Delft. All rights reserved.
- *   NOTE: This file is distributed under the GNU General Public License (GPL).
- *   The phrase "All rights reserved" above is retained from the original source
- *   but does not limit the permissions granted by the GPL.
- */
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    WendlandC0Function
+
+Description
+    Wendland C0 radial basis function.
+
+Author
+    David Blom, TU Delft. All rights reserved.
+    NOTE: This file is distributed under the GNU General Public License (GPL).
+    The phrase "All rights reserved" above is retained from the original
+    source but does not limit the permissions granted by the GPL.
+
+\*---------------------------------------------------------------------------*/
 
 #ifndef WendlandC0Function_H
 #define WendlandC0Function_H

--- a/src/RBFMeshMotionSolver/RBFFunctions/WendlandC2Function.C
+++ b/src/RBFMeshMotionSolver/RBFFunctions/WendlandC2Function.C
@@ -1,11 +1,22 @@
 
-/*
- * Author
- *   David Blom, TU Delft. All rights reserved.
- *   NOTE: This file is distributed under the GNU General Public License (GPL).
- *   The phrase "All rights reserved" above is retained from the original source
- *   but does not limit the permissions granted by the GPL.
- */
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
 
 #include "WendlandC2Function.H"
 

--- a/src/RBFMeshMotionSolver/RBFFunctions/WendlandC2Function.C
+++ b/src/RBFMeshMotionSolver/RBFFunctions/WendlandC2Function.C
@@ -2,6 +2,9 @@
 /*
  * Author
  *   David Blom, TU Delft. All rights reserved.
+ *   NOTE: This file is distributed under the GNU General Public License (GPL).
+ *   The phrase "All rights reserved" above is retained from the original source
+ *   but does not limit the permissions granted by the GPL.
  */
 
 #include "WendlandC2Function.H"

--- a/src/RBFMeshMotionSolver/RBFFunctions/WendlandC2Function.H
+++ b/src/RBFMeshMotionSolver/RBFFunctions/WendlandC2Function.H
@@ -1,11 +1,34 @@
 
-/*
- * Author
- *   David Blom, TU Delft. All rights reserved.
- *   NOTE: This file is distributed under the GNU General Public License (GPL).
- *   The phrase "All rights reserved" above is retained from the original source
- *   but does not limit the permissions granted by the GPL.
- */
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    WendlandC2Function
+
+Description
+    Wendland C2 radial basis function.
+
+Author
+    David Blom, TU Delft. All rights reserved.
+    NOTE: This file is distributed under the GNU General Public License (GPL).
+    The phrase "All rights reserved" above is retained from the original
+    source but does not limit the permissions granted by the GPL.
+
+\*---------------------------------------------------------------------------*/
 
 #ifndef WendlandC2Function_H
 #define WendlandC2Function_H

--- a/src/RBFMeshMotionSolver/RBFFunctions/WendlandC2Function.H
+++ b/src/RBFMeshMotionSolver/RBFFunctions/WendlandC2Function.H
@@ -2,6 +2,9 @@
 /*
  * Author
  *   David Blom, TU Delft. All rights reserved.
+ *   NOTE: This file is distributed under the GNU General Public License (GPL).
+ *   The phrase "All rights reserved" above is retained from the original source
+ *   but does not limit the permissions granted by the GPL.
  */
 
 #ifndef WendlandC2Function_H

--- a/src/RBFMeshMotionSolver/RBFFunctions/WendlandC4Function.C
+++ b/src/RBFMeshMotionSolver/RBFFunctions/WendlandC4Function.C
@@ -2,6 +2,9 @@
 /*
  * Author
  *   David Blom, TU Delft. All rights reserved.
+ *   NOTE: This file is distributed under the GNU General Public License (GPL).
+ *   The phrase "All rights reserved" above is retained from the original source
+ *   but does not limit the permissions granted by the GPL.
  */
 
 #include "WendlandC4Function.H"

--- a/src/RBFMeshMotionSolver/RBFFunctions/WendlandC4Function.C
+++ b/src/RBFMeshMotionSolver/RBFFunctions/WendlandC4Function.C
@@ -1,11 +1,22 @@
 
-/*
- * Author
- *   David Blom, TU Delft. All rights reserved.
- *   NOTE: This file is distributed under the GNU General Public License (GPL).
- *   The phrase "All rights reserved" above is retained from the original source
- *   but does not limit the permissions granted by the GPL.
- */
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
 
 #include "WendlandC4Function.H"
 

--- a/src/RBFMeshMotionSolver/RBFFunctions/WendlandC4Function.H
+++ b/src/RBFMeshMotionSolver/RBFFunctions/WendlandC4Function.H
@@ -1,11 +1,34 @@
 
-/*
- * Author
- *   David Blom, TU Delft. All rights reserved.
- *   NOTE: This file is distributed under the GNU General Public License (GPL).
- *   The phrase "All rights reserved" above is retained from the original source
- *   but does not limit the permissions granted by the GPL.
- */
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    WendlandC4Function
+
+Description
+    Wendland C4 radial basis function.
+
+Author
+    David Blom, TU Delft. All rights reserved.
+    NOTE: This file is distributed under the GNU General Public License (GPL).
+    The phrase "All rights reserved" above is retained from the original
+    source but does not limit the permissions granted by the GPL.
+
+\*---------------------------------------------------------------------------*/
 
 #ifndef WendlandC4Function_H
 #define WendlandC4Function_H

--- a/src/RBFMeshMotionSolver/RBFFunctions/WendlandC4Function.H
+++ b/src/RBFMeshMotionSolver/RBFFunctions/WendlandC4Function.H
@@ -2,6 +2,9 @@
 /*
  * Author
  *   David Blom, TU Delft. All rights reserved.
+ *   NOTE: This file is distributed under the GNU General Public License (GPL).
+ *   The phrase "All rights reserved" above is retained from the original source
+ *   but does not limit the permissions granted by the GPL.
  */
 
 #ifndef WendlandC4Function_H

--- a/src/RBFMeshMotionSolver/RBFFunctions/WendlandC6Function.C
+++ b/src/RBFMeshMotionSolver/RBFFunctions/WendlandC6Function.C
@@ -1,11 +1,22 @@
 
-/*
- * Author
- *   David Blom, TU Delft. All rights reserved.
- *   NOTE: This file is distributed under the GNU General Public License (GPL).
- *   The phrase "All rights reserved" above is retained from the original source
- *   but does not limit the permissions granted by the GPL.
- */
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
 
 #include "WendlandC6Function.H"
 

--- a/src/RBFMeshMotionSolver/RBFFunctions/WendlandC6Function.C
+++ b/src/RBFMeshMotionSolver/RBFFunctions/WendlandC6Function.C
@@ -2,6 +2,9 @@
 /*
  * Author
  *   David Blom, TU Delft. All rights reserved.
+ *   NOTE: This file is distributed under the GNU General Public License (GPL).
+ *   The phrase "All rights reserved" above is retained from the original source
+ *   but does not limit the permissions granted by the GPL.
  */
 
 #include "WendlandC6Function.H"

--- a/src/RBFMeshMotionSolver/RBFFunctions/WendlandC6Function.H
+++ b/src/RBFMeshMotionSolver/RBFFunctions/WendlandC6Function.H
@@ -1,11 +1,34 @@
 
-/*
- * Author
- *   David Blom, TU Delft. All rights reserved.
- *   NOTE: This file is distributed under the GNU General Public License (GPL).
- *   The phrase "All rights reserved" above is retained from the original source
- *   but does not limit the permissions granted by the GPL.
- */
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    WendlandC6Function
+
+Description
+    Wendland C6 radial basis function.
+
+Author
+    David Blom, TU Delft. All rights reserved.
+    NOTE: This file is distributed under the GNU General Public License (GPL).
+    The phrase "All rights reserved" above is retained from the original
+    source but does not limit the permissions granted by the GPL.
+
+\*---------------------------------------------------------------------------*/
 
 #ifndef WendlandC6Function_H
 #define WendlandC6Function_H

--- a/src/RBFMeshMotionSolver/RBFFunctions/WendlandC6Function.H
+++ b/src/RBFMeshMotionSolver/RBFFunctions/WendlandC6Function.H
@@ -2,6 +2,9 @@
 /*
  * Author
  *   David Blom, TU Delft. All rights reserved.
+ *   NOTE: This file is distributed under the GNU General Public License (GPL).
+ *   The phrase "All rights reserved" above is retained from the original source
+ *   but does not limit the permissions granted by the GPL.
  */
 
 #ifndef WendlandC6Function_H

--- a/src/RBFMeshMotionSolver/RBFInterpolation.C
+++ b/src/RBFMeshMotionSolver/RBFInterpolation.C
@@ -2,6 +2,9 @@
 /*
  * Author
  *   David Blom, TU Delft. All rights reserved.
+ *   NOTE: This file is distributed under the GNU General Public License (GPL).
+ *   The phrase "All rights reserved" above is retained from the original source
+ *   but does not limit the permissions granted by the GPL.
  */
 
 #include "RBFInterpolation.H"

--- a/src/RBFMeshMotionSolver/RBFInterpolation.C
+++ b/src/RBFMeshMotionSolver/RBFInterpolation.C
@@ -1,11 +1,22 @@
 
-/*
- * Author
- *   David Blom, TU Delft. All rights reserved.
- *   NOTE: This file is distributed under the GNU General Public License (GPL).
- *   The phrase "All rights reserved" above is retained from the original source
- *   but does not limit the permissions granted by the GPL.
- */
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
 
 #include "RBFInterpolation.H"
 #include "TPSFunction.H"

--- a/src/RBFMeshMotionSolver/RBFInterpolation.H
+++ b/src/RBFMeshMotionSolver/RBFInterpolation.H
@@ -1,11 +1,37 @@
 
-/*
- * Author
- *   David Blom, TU Delft. All rights reserved.
- *   NOTE: This file is distributed under the GNU General Public License (GPL).
- *   The phrase "All rights reserved" above is retained from the original source
- *   but does not limit the permissions granted by the GPL.
- */
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    RBFInterpolation
+
+Description
+    Radial basis function interpolation utilities.
+
+Author
+    David Blom, TU Delft. All rights reserved.
+    NOTE: This file is distributed under the GNU General Public License (GPL).
+    The phrase "All rights reserved" above is retained from the original
+    source but does not limit the permissions granted by the GPL.
+
+SourceFiles
+    RBFInterpolation.C
+
+\*---------------------------------------------------------------------------*/
 
 #ifndef RBFInterpolation_H
 #define RBFInterpolation_H

--- a/src/RBFMeshMotionSolver/RBFInterpolation.H
+++ b/src/RBFMeshMotionSolver/RBFInterpolation.H
@@ -2,6 +2,9 @@
 /*
  * Author
  *   David Blom, TU Delft. All rights reserved.
+ *   NOTE: This file is distributed under the GNU General Public License (GPL).
+ *   The phrase "All rights reserved" above is retained from the original source
+ *   but does not limit the permissions granted by the GPL.
  */
 
 #ifndef RBFInterpolation_H

--- a/src/RBFMeshMotionSolver/RBFMeshMotionSolver.C
+++ b/src/RBFMeshMotionSolver/RBFMeshMotionSolver.C
@@ -2,6 +2,9 @@
 /*
  * Author
  *   David Blom, TU Delft. All rights reserved.
+ *   NOTE: This file is distributed under the GNU General Public License (GPL).
+ *   The phrase "All rights reserved" above is retained from the original source
+ *   but does not limit the permissions granted by the GPL.
  */
 
 #include "RBFMeshMotionSolver.H"

--- a/src/RBFMeshMotionSolver/RBFMeshMotionSolver.C
+++ b/src/RBFMeshMotionSolver/RBFMeshMotionSolver.C
@@ -1,11 +1,22 @@
 
-/*
- * Author
- *   David Blom, TU Delft. All rights reserved.
- *   NOTE: This file is distributed under the GNU General Public License (GPL).
- *   The phrase "All rights reserved" above is retained from the original source
- *   but does not limit the permissions granted by the GPL.
- */
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
 
 #include "RBFMeshMotionSolver.H"
 #include <unordered_map>

--- a/src/RBFMeshMotionSolver/RBFMeshMotionSolver.H
+++ b/src/RBFMeshMotionSolver/RBFMeshMotionSolver.H
@@ -2,6 +2,9 @@
 /*
  * Author
  *   David Blom, TU Delft. All rights reserved.
+ *   NOTE: This file is distributed under the GNU General Public License (GPL).
+ *   The phrase "All rights reserved" above is retained from the original source
+ *   but does not limit the permissions granted by the GPL.
  */
 
 #ifndef RBFMeshMotionSolver_H

--- a/src/RBFMeshMotionSolver/RBFMeshMotionSolver.H
+++ b/src/RBFMeshMotionSolver/RBFMeshMotionSolver.H
@@ -1,11 +1,37 @@
 
-/*
- * Author
- *   David Blom, TU Delft. All rights reserved.
- *   NOTE: This file is distributed under the GNU General Public License (GPL).
- *   The phrase "All rights reserved" above is retained from the original source
- *   but does not limit the permissions granted by the GPL.
- */
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    RBFMeshMotionSolver
+
+Description
+    Radial basis function mesh motion solver.
+
+Author
+    David Blom, TU Delft. All rights reserved.
+    NOTE: This file is distributed under the GNU General Public License (GPL).
+    The phrase "All rights reserved" above is retained from the original
+    source but does not limit the permissions granted by the GPL.
+
+SourceFiles
+    RBFMeshMotionSolver.C
+
+\*---------------------------------------------------------------------------*/
 
 #ifndef RBFMeshMotionSolver_H
 #define RBFMeshMotionSolver_H

--- a/src/RBFMeshMotionSolver/twoDPointCorrectorRBF.C
+++ b/src/RBFMeshMotionSolver/twoDPointCorrectorRBF.C
@@ -1,3 +1,21 @@
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
 
 #include "twoDPointCorrectorRBF.H"
 #include "polyMesh.H"

--- a/src/RBFMeshMotionSolver/twoDPointCorrectorRBF.H
+++ b/src/RBFMeshMotionSolver/twoDPointCorrectorRBF.H
@@ -1,3 +1,34 @@
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of solids4foam.
+
+    solids4foam is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the License, or (at your
+    option) any later version.
+
+    solids4foam is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    twoDPointCorrectorRBF
+
+Description
+    2D point corrector for RBF mesh motion.
+
+Author
+    David Blom.
+    Philip Cardiff, UCD.
+
+SourceFiles
+    twoDPointCorrectorRBF.C
+
+\*---------------------------------------------------------------------------*/
 
 #ifndef twoDPointCorrectorRBF_H
 #define twoDPointCorrectorRBF_H
@@ -11,18 +42,19 @@
 
 namespace Foam
 {
-    // Forward class declarations
-    class polyMesh;
 
-    /*---------------------------------------------------------------------------*\
-    *                       Class twoDPointCorrectorRBF Declaration
-    \*---------------------------------------------------------------------------*/
+// Forward class declarations
+class polyMesh;
 
-    class twoDPointCorrectorRBF
-          :
-            public twoDPointCorrector
-    {
-        // Private data
+/*---------------------------------------------------------------------------*\
+*                       Class twoDPointCorrectorRBF Declaration
+\*---------------------------------------------------------------------------*/
+
+class twoDPointCorrectorRBF
+:
+    public twoDPointCorrector
+{
+    // Private data
 
         // - Reference to moving mesh
         const polyMesh & mesh_;
@@ -37,7 +69,7 @@ namespace Foam
         labelList shadowPointIDs_;
 
 
-        // Private Member Functions
+    // Private Member Functions
 
         // - Disallow default bitwise copy construct
         twoDPointCorrectorRBF( const twoDPointCorrectorRBF & );
@@ -47,24 +79,26 @@ namespace Foam
 
         void setMarker();
 
-        public:
-            // Constructors
+    public:
 
-            // - Construct from components
-            twoDPointCorrectorRBF( const polyMesh & mesh );
+    // Constructors
 
-
-            // Destructor
-
-            virtual ~twoDPointCorrectorRBF();
+        // - Construct from components
+        twoDPointCorrectorRBF( const polyMesh & mesh );
 
 
-            // Member Functions
+    // Destructor
 
-            const labelList & marker() const;
+        virtual ~twoDPointCorrectorRBF();
 
-            void setShadowSide( vectorField & newpoints ) const;
-    };
+
+    // Member Functions
+
+        const labelList & marker() const;
+
+        void setShadowSide(vectorField & newpoints) const;
+};
+
 } // End namespace Foam
 
 

--- a/src/abaqusUMATs/abaqusUmatLinearElastic/abaqusUmatLinearElastic.H
+++ b/src/abaqusUMATs/abaqusUmatLinearElastic/abaqusUmatLinearElastic.H
@@ -25,7 +25,7 @@ SourceFiles
     abaqusUmatLinearElastic.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/blockCoupledSolids4FoamTools/BlockFvm/blockTangentialCoeffs/blockTangentialCoeffs.H
+++ b/src/blockCoupledSolids4FoamTools/BlockFvm/blockTangentialCoeffs/blockTangentialCoeffs.H
@@ -21,7 +21,7 @@ Description
     given here.
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/blockCoupledSolids4FoamTools/BlockLduSolvers/BlockEigenSolvers/BlockEigenSolver/BlockEigenSolver.H
+++ b/src/blockCoupledSolids4FoamTools/BlockLduSolvers/BlockEigenSolvers/BlockEigenSolver/BlockEigenSolver.H
@@ -30,7 +30,7 @@ Description
       files.
 
 Author
-    Philip Cardiff, UCD.  All rights reserved
+    Philip Cardiff, UCD.
 
 SourceFiles
     BlockEigenSolver.C

--- a/src/blockCoupledSolids4FoamTools/BlockLduSolvers/BlockEigenSolvers/BlockEigenSparseLU/BlockEigenSparseLUSolver.H
+++ b/src/blockCoupledSolids4FoamTools/BlockLduSolvers/BlockEigenSolvers/BlockEigenSparseLU/BlockEigenSparseLUSolver.H
@@ -31,7 +31,7 @@ Description
       files.
 
 Author
-    Philip Cardiff, UCD.  All rights reserved
+    Philip Cardiff, UCD.
 
 SourceFiles
     BlockEigenSparseLUSolver.C

--- a/src/blockCoupledSolids4FoamTools/blockFvPatchVectorFields/blockSolidVelocity/blockSolidVelocityFvPatchVectorField.H
+++ b/src/blockCoupledSolids4FoamTools/blockFvPatchVectorFields/blockSolidVelocity/blockSolidVelocityFvPatchVectorField.H
@@ -31,7 +31,7 @@ SourceFiles
     blockSolidVelocityFvPatchVectorField.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/blockCoupledSolids4FoamTools/blockGlobalPolyPatch/blockGlobalPolyPatch.C
+++ b/src/blockCoupledSolids4FoamTools/blockGlobalPolyPatch/blockGlobalPolyPatch.C
@@ -16,7 +16,7 @@ License
     along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
 
 Author
-    Hrvoje Jasak, Wikki Ltd.  All rights reserved.
+    Hrvoje Jasak, Wikki Ltd.
 
 Contributor
     Martin Beaudoin, Hydro-Quebec, (2008)

--- a/src/blockCoupledSolids4FoamTools/matrices/blockLduMatrix/BlockLduMatrix/blockLduMatrices.C
+++ b/src/blockCoupledSolids4FoamTools/matrices/blockLduMatrix/BlockLduMatrix/blockLduMatrices.C
@@ -19,7 +19,7 @@ Description
      Block matrix member static data members
 
 Author
-    Hrvoje Jasak, Wikki Ltd.  All rights reserved.
+    Hrvoje Jasak, Wikki Ltd.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/blockCoupledSolids4FoamTools/matrices/blockLduMatrix/BlockLduMatrix/blockLduMatrices.H
+++ b/src/blockCoupledSolids4FoamTools/matrices/blockLduMatrix/BlockLduMatrix/blockLduMatrices.H
@@ -22,7 +22,7 @@ Description
     Typedefs for block matrices
 
 Author
-    Hrvoje Jasak, Wikki Ltd.  All rights reserved.
+    Hrvoje Jasak, Wikki Ltd.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/blockCoupledSolids4FoamTools/matrices/blockLduMatrix/BlockLduSolvers/BlockBiCGStab/BlockBiCGStabSolver.H
+++ b/src/blockCoupledSolids4FoamTools/matrices/blockLduMatrix/BlockLduSolvers/BlockBiCGStab/BlockBiCGStabSolver.H
@@ -22,7 +22,7 @@ Description
     Preconditioned Bi-Conjugate Gradient stabilised solver.
 
 Author
-    Hrvoje Jasak, Wikki Ltd.  All rights reserved
+    Hrvoje Jasak, Wikki Ltd.
 
 SourceFiles
     BlockBiCGStabSolver.C

--- a/src/blockCoupledSolids4FoamTools/matrices/blockLduMatrix/BlockLduSolvers/BlockBiCGStab/blockBiCGStabSolvers.H
+++ b/src/blockCoupledSolids4FoamTools/matrices/blockLduMatrix/BlockLduSolvers/BlockBiCGStab/blockBiCGStabSolvers.H
@@ -22,7 +22,7 @@ Description
     Typedefs Preconditioned Bi-Conjugate Gradient stabilised solver.
 
 Author
-    Hrvoje Jasak, Wikki Ltd.  All rights reserved
+    Hrvoje Jasak, Wikki Ltd.
 
 SourceFiles
     blockICBiCGStabSolvers.C

--- a/src/blockCoupledSolids4FoamTools/myBlockCholeskyPrecon/myBlockCholeskyPrecon.H
+++ b/src/blockCoupledSolids4FoamTools/myBlockCholeskyPrecon/myBlockCholeskyPrecon.H
@@ -22,7 +22,7 @@ Description
     Incomplete Cholesky preconditioning with no fill-in.
 
 Author
-    Hrvoje Jasak, Wikki Ltd.  All rights reserved.
+    Hrvoje Jasak, Wikki Ltd.
 
 SourceFiles
     myBlockCholeskyPrecon.C

--- a/src/blockCoupledSolids4FoamTools/myBlockCholeskyPrecon/myBlockCholeskyPrecons.H
+++ b/src/blockCoupledSolids4FoamTools/myBlockCholeskyPrecon/myBlockCholeskyPrecons.H
@@ -22,7 +22,7 @@ Description
     Typedefs for Incomplete Cholesky preconditioning with no fill-in.
 
 Author
-    Hrvoje Jasak, Wikki Ltd.  All rights reserved.
+    Hrvoje Jasak, Wikki Ltd.
 
 SourceFiles
     myBlockCholeskyPrecons.C

--- a/src/blockCoupledSolids4FoamTools/myBlockCholeskyPrecon/scalarMyBlockCholeskyPrecon.H
+++ b/src/blockCoupledSolids4FoamTools/myBlockCholeskyPrecon/scalarMyBlockCholeskyPrecon.H
@@ -22,7 +22,7 @@ Description
     Template specialisation for scalar block Cholesky preconditioning
 
 Author
-    Hrvoje Jasak, Wikki Ltd.  All rights reserved.
+    Hrvoje Jasak, Wikki Ltd.
 
 SourceFiles
     scalarMyBlockCholeskyPrecon.C

--- a/src/blockCoupledSolids4FoamTools/myBlockCholeskyPrecon/tensorMyBlockCholeskyPrecon.H
+++ b/src/blockCoupledSolids4FoamTools/myBlockCholeskyPrecon/tensorMyBlockCholeskyPrecon.H
@@ -22,7 +22,7 @@ Description
     Template specialisation for tensor block Cholesky preconditioning
 
 Author
-    Hrvoje Jasak, Wikki Ltd.  All rights reserved.
+    Hrvoje Jasak, Wikki Ltd.
 
 SourceFiles
     tensorBlockCholeskyPrecon.C

--- a/src/blockCoupledSolids4FoamTools/solidPolyMesh/solidPolyBoundaryMesh.H
+++ b/src/blockCoupledSolids4FoamTools/solidPolyMesh/solidPolyBoundaryMesh.H
@@ -22,7 +22,7 @@ Description
     polyBoundaryMesh for the solidPolyMesh class.
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 SourceFiles
     solidPolyBoundaryMesh.C

--- a/src/blockCoupledSolids4FoamTools/solidPolyMesh/solidPolyMesh.H
+++ b/src/blockCoupledSolids4FoamTools/solidPolyMesh/solidPolyMesh.H
@@ -50,7 +50,7 @@ SourceFiles
     solidPolyMesh.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/blockCoupledSolids4FoamTools/solidPolyMesh/solidPolyMeshLduAddressing.H
+++ b/src/blockCoupledSolids4FoamTools/solidPolyMesh/solidPolyMeshLduAddressing.H
@@ -23,7 +23,7 @@ Description
     neighbours.
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/dynamicFvMesh/cellRemovalFvMesh/cellRemovalFvMesh.H
+++ b/src/solids4FoamModels/dynamicFvMesh/cellRemovalFvMesh/cellRemovalFvMesh.H
@@ -25,7 +25,7 @@ SourceFiles
     cellRemovalFvMesh.C
 
 Author
-    Philip Cardiff, UCD/UT. All rights reserved.
+    Philip Cardiff, UCD/UT.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/dynamicFvMesh/cellRemovalFvMesh/cellRemovalLaws/cellRemovalLaw/cellRemovalLaw.H
+++ b/src/solids4FoamModels/dynamicFvMesh/cellRemovalFvMesh/cellRemovalLaws/cellRemovalLaw/cellRemovalLaw.H
@@ -22,7 +22,7 @@ Description
     Law that selects which cells should be removed
 
 Authors
-    Philip Cardif, UCD. All rights reserved.
+    Philip Cardif, UCD.
 
 SourceFiles
     cellRemovalLaw.C

--- a/src/solids4FoamModels/dynamicFvMesh/cellRemovalFvMesh/cellRemovalLaws/epsilonPEqCellRemovalLaw/epsilonPEqCellRemovalLaw.H
+++ b/src/solids4FoamModels/dynamicFvMesh/cellRemovalFvMesh/cellRemovalLaws/epsilonPEqCellRemovalLaw/epsilonPEqCellRemovalLaw.H
@@ -23,7 +23,7 @@ Description
     greater than the specified critical equivalent value.
 
 Author
-    Philip Cardif, UCD/UT. All rights reserved.
+    Philip Cardif, UCD/UT.
 
 SourceFiles
     epsilonPEqCellRemovalLaw.C

--- a/src/solids4FoamModels/dynamicFvMesh/crackerFvMesh/crackerFvMesh.H
+++ b/src/solids4FoamModels/dynamicFvMesh/crackerFvMesh/crackerFvMesh.H
@@ -27,9 +27,9 @@ SourceFiles
     crackerFvMeshTemplates.C
 
 Author
-    Hrvoje Jasak, Wikki Ltd. All rights reserved
-    Zeljko Tukovic, FSB Zagreb. All rights reserved.
-    Philip Cardiff, UCD. All rights reserved.
+    Hrvoje Jasak, Wikki Ltd.
+    Zeljko Tukovic, FSB Zagreb.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/dynamicFvMesh/crackerFvMesh/faceBreakerLaws/cohesiveZoneInitiation/cohesiveZoneInitiation.H
+++ b/src/solids4FoamModels/dynamicFvMesh/crackerFvMesh/faceBreakerLaws/cohesiveZoneInitiation/cohesiveZoneInitiation.H
@@ -28,7 +28,7 @@ Description
     cohesiveZoneModel class what faces it would like to break.
 
 Author
-    Philip Cardif, UCD/UT. All rights reserved.
+    Philip Cardif, UCD/UT.
 
 SourceFiles
     cohesiveZoneInitiation.C

--- a/src/solids4FoamModels/dynamicFvMesh/crackerFvMesh/faceBreakerLaws/faceBreakerLaw/crackPathLimiters/boundingBoxLimiter/boundingBoxLimiter.H
+++ b/src/solids4FoamModels/dynamicFvMesh/crackerFvMesh/faceBreakerLaws/faceBreakerLaw/crackPathLimiters/boundingBoxLimiter/boundingBoxLimiter.H
@@ -37,7 +37,7 @@ Description
     endverbatim
 
 Author
-    Philip Cardif, UCD.  All rights reserved.
+    Philip Cardif, UCD.
 
 SourceFiles
     boundingBoxLimiter.C

--- a/src/solids4FoamModels/dynamicFvMesh/crackerFvMesh/faceBreakerLaws/faceBreakerLaw/crackPathLimiters/crackPathLimiter/crackPathLimiter.H
+++ b/src/solids4FoamModels/dynamicFvMesh/crackerFvMesh/faceBreakerLaws/faceBreakerLaw/crackPathLimiters/crackPathLimiter/crackPathLimiter.H
@@ -26,7 +26,7 @@ Description
         0 means face is not allowed to break
 
 Authors
-    Philip Cardif, UCD. All rights reserved.
+    Philip Cardif, UCD.
 
 SourceFiles
     crackPathLimiter.C

--- a/src/solids4FoamModels/dynamicFvMesh/crackerFvMesh/faceBreakerLaws/faceBreakerLaw/faceBreakerLaw.H
+++ b/src/solids4FoamModels/dynamicFvMesh/crackerFvMesh/faceBreakerLaws/faceBreakerLaw/faceBreakerLaw.H
@@ -22,7 +22,7 @@ Description
     Law that selects which internal faces should be cracked/broken.
 
 Authors
-    Philip Cardif, UCD. All rights reserved.
+    Philip Cardif, UCD.
 
 SourceFiles
     faceBreakerLaw.C

--- a/src/solids4FoamModels/dynamicFvMesh/crackerFvMesh/solidCohesive/cohesiveZoneModels/cohesiveZoneModel/cohesiveZoneModel.H
+++ b/src/solids4FoamModels/dynamicFvMesh/crackerFvMesh/solidCohesive/cohesiveZoneModels/cohesiveZoneModel/cohesiveZoneModel.H
@@ -29,7 +29,7 @@ Description
     (2) updateEnergies
         Calculate the current dissipated fracture energies;
 Authors
-    Philip Cardif, UCD/UT. All rights reserved.
+    Philip Cardif, UCD/UT.
 
 SourceFiles
     cohesiveZoneModel.C

--- a/src/solids4FoamModels/dynamicFvMesh/crackerFvMesh/solidCohesive/cohesiveZoneModels/fixedMixedModeCohesiveZoneModel/fixedMixedModeCohesiveZoneModel.H
+++ b/src/solids4FoamModels/dynamicFvMesh/crackerFvMesh/solidCohesive/cohesiveZoneModels/fixedMixedModeCohesiveZoneModel/fixedMixedModeCohesiveZoneModel.H
@@ -30,8 +30,8 @@ Description
     as an option.
 
 Author
-    Zeljko Tukovic, FSB Zagreb. All rights reserved.
-    Re-organised by Philip Cardif, UCD/UT. All rights reserved.
+    Zeljko Tukovic, FSB Zagreb.
+    Re-organised by Philip Cardif, UCD/UT.
 
 SourceFiles
     fixedMixedModeCohesiveZoneModel.C

--- a/src/solids4FoamModels/dynamicFvMesh/crackerFvMesh/solidCohesive/cohesiveZoneModels/modeICohesiveZoneModel/modeICohesiveZoneModel.H
+++ b/src/solids4FoamModels/dynamicFvMesh/crackerFvMesh/solidCohesive/cohesiveZoneModels/modeICohesiveZoneModel/modeICohesiveZoneModel.H
@@ -22,7 +22,7 @@ Description
     Mode-I Dugdale-type cohesive zone model.
 
 Author
-    Philip Cardif, UCD/UT. All rights reserved.
+    Philip Cardif, UCD/UT.
 
 SourceFiles
     modeICohesiveZoneModel.C

--- a/src/solids4FoamModels/dynamicFvMesh/crackerFvMesh/solidCohesive/cohesiveZoneModels/variableMixedModeCohesiveZoneModel/variableMixedModeCohesiveZoneModel.H
+++ b/src/solids4FoamModels/dynamicFvMesh/crackerFvMesh/solidCohesive/cohesiveZoneModels/variableMixedModeCohesiveZoneModel/variableMixedModeCohesiveZoneModel.H
@@ -24,7 +24,7 @@ Description
     displacement components.
 
 Author
-    Philip Cardif, UCD/UT. All rights reserved.
+    Philip Cardif, UCD/UT.
 
 SourceFiles
     variableMixedModeCohesiveZoneModel.C

--- a/src/solids4FoamModels/dynamicFvMesh/crackerFvMesh/solidCohesive/solidCohesiveFvPatchVectorField.H
+++ b/src/solids4FoamModels/dynamicFvMesh/crackerFvMesh/solidCohesive/solidCohesiveFvPatchVectorField.H
@@ -23,8 +23,8 @@ Description
     cohesiveZoneModel is run-time selectable.
 
 Author
-    Philip Cardiff, UCD/UT. All rights reserved.
-    Zeljko Tukovic, FSB Zaregb. All rights reserved.
+    Philip Cardiff, UCD/UT.
+    Zeljko Tukovic, FSB Zagreb.
 
 SourceFiles
     solidCohesiveFvPatchVectorField.C

--- a/src/solids4FoamModels/dynamicFvMesh/simpleCrackerFvMesh/simpleCohesiveZone/simpleCohesiveZoneFvPatchVectorField.H
+++ b/src/solids4FoamModels/dynamicFvMesh/simpleCrackerFvMesh/simpleCohesiveZone/simpleCohesiveZoneFvPatchVectorField.H
@@ -32,8 +32,8 @@ SourceFiles
     simpleCohesiveZoneFvPatchVectorField.C
 
 Author
-    Zeljko Tukovic. FSB Zaregb. All rights reserved.
-    Philip Cardiff. UCD. All rights reserved.
+    Zeljko Tukovic. FSB Zagreb.
+    Philip Cardiff. UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/dynamicFvMesh/simpleCrackerFvMesh/simpleCrackerFvMesh.H
+++ b/src/solids4FoamModels/dynamicFvMesh/simpleCrackerFvMesh/simpleCrackerFvMesh.H
@@ -28,7 +28,7 @@ SourceFiles
     simpleCrackerFvMesh.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved, UT. All rights reserved.
+    Philip Cardiff, UCD., UT.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/fluidModels/fluidModel/fluidModel.H
+++ b/src/solids4FoamModels/fluidModels/fluidModel/fluidModel.H
@@ -22,9 +22,9 @@ Description
     Virtual base class for fluid solvers.
 
 Author
-    Hrvoje Jasak, Wikki Ltd.  All rights reserved.
-    Zeljko Tukovic, FSB Zagreb.  All rights reserved.
-    Philip Cardiff, UCD. All rights reserved.
+    Hrvoje Jasak, Wikki Ltd.
+    Zeljko Tukovic, FSB Zagreb.
+    Philip Cardiff, UCD.
 
 SourceFiles
     fluidModel.C

--- a/src/solids4FoamModels/fluidModels/fvPatchFields/outflowPressure/outflowPressureFvPatchScalarField.H
+++ b/src/solids4FoamModels/fluidModels/fvPatchFields/outflowPressure/outflowPressureFvPatchScalarField.H
@@ -22,7 +22,7 @@ Description
     Foam::outflowPressureFvPatchScalarField
 
 Author
-    Zeljko Tukovic, FSB Zagreb.  All rights reserved.
+    Zeljko Tukovic, FSB Zagreb.
 
 SourceFiles
     outflowPressureFvPatchScalarField.C

--- a/src/solids4FoamModels/fluidModels/fvPatchFields/paraboloidInletVelocity/paraboloidInletVelocityFvPatchVectorField.H
+++ b/src/solids4FoamModels/fluidModels/fvPatchFields/paraboloidInletVelocity/paraboloidInletVelocityFvPatchVectorField.H
@@ -30,8 +30,8 @@ SourceFiles
     paraboloidInletVelocityFvPatchVectorField.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved
-    Zeljko Tukovic, FSB Zagreb. All rights reserved
+    Philip Cardiff, UCD.
+    Zeljko Tukovic, FSB Zagreb.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/fluidModels/fvPatchFields/pulsedParabolicVelocity/pulsedParabolicVelocityFvPatchVectorField.H
+++ b/src/solids4FoamModels/fluidModels/fvPatchFields/pulsedParabolicVelocity/pulsedParabolicVelocityFvPatchVectorField.H
@@ -36,7 +36,7 @@ SourceFiles
     pulsedParabolicVelocityFvPatchVectorField.C
 
 Author
-    Hrvoje Jasak, Wikki Ltd.  All rights reserved
+    Hrvoje Jasak, Wikki Ltd.
     Modified by Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/

--- a/src/solids4FoamModels/fluidModels/fvPatchFields/skewCorrectedLinearDC/skewCorrectedLinearDC.H
+++ b/src/solids4FoamModels/fluidModels/fvPatchFields/skewCorrectedLinearDC/skewCorrectedLinearDC.H
@@ -25,7 +25,7 @@ Description
     Correction is calculated using difference between linear and upwind interp.
 
 Author
-    Zeljko Tukovic, FSB Zagreb  All rights reserved.
+    Zeljko Tukovic, FSB Zagreb
 
 SourceFiles
     skewCorrectedLinearDC.C

--- a/src/solids4FoamModels/fluidModels/fvPatchFields/thermalRobin/thermalRobinFvPatchScalarField.H
+++ b/src/solids4FoamModels/fluidModels/fvPatchFields/thermalRobin/thermalRobinFvPatchScalarField.H
@@ -24,7 +24,7 @@ Description
     "dirichlet_ = true" and "neumann_ = false".
 
 Author
-    Zeljko Tukovic, FSB Zagreb.  All rights reserved.
+    Zeljko Tukovic, FSB Zagreb.
 
 SourceFiles
     thermalRobinFvPatchScalarField.C

--- a/src/solids4FoamModels/fluidModels/fvPatchFields/transitionalParabolicVelocity/transitionalParabolicVelocityFvPatchVectorField.H
+++ b/src/solids4FoamModels/fluidModels/fvPatchFields/transitionalParabolicVelocity/transitionalParabolicVelocityFvPatchVectorField.H
@@ -27,7 +27,7 @@ SourceFiles
     transitionalParabolicVelocityFvPatchVectorField.C
 
 Author
-    Hrvoje Jasak, Wikki Ltd.  All rights reserved
+    Hrvoje Jasak, Wikki Ltd.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/fluidModels/oneWayFsiFluid/oneWayFsiFluid.H
+++ b/src/solids4FoamModels/fluidModels/oneWayFsiFluid/oneWayFsiFluid.H
@@ -24,7 +24,7 @@ Description
     interaction simulation.
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 SourceFiles
     oneWayFsiFluid.C

--- a/src/solids4FoamModels/fluidModels/pimpleFluid/pimpleFluid.foamextend.H
+++ b/src/solids4FoamModels/fluidModels/pimpleFluid/pimpleFluid.foamextend.H
@@ -31,8 +31,8 @@ Description
     transfer.
 
 Author
-    Zeljko Tukovic, FSB Zagreb. All rights reserved.
-    Philip Cardiff, UCD. All rights reserved.
+    Zeljko Tukovic, FSB Zagreb.
+    Philip Cardiff, UCD.
 
 SourceFiles
     pimpleFluid.foamextend.C

--- a/src/solids4FoamModels/fluidModels/pimpleOversetFluid/pimpleOversetFluid.H
+++ b/src/solids4FoamModels/fluidModels/pimpleOversetFluid/pimpleOversetFluid.H
@@ -26,9 +26,9 @@ Description
 
 
 Author
-    Hrvoje Jasak, Wikki Ltd.  All rights reserved.
-    Zeljko Tukovic, FSB Zagreb.  All rights reserved.
-    Philip Cardiff, UCD. All rights reserved.
+    Hrvoje Jasak, Wikki Ltd.
+    Zeljko Tukovic, FSB Zagreb.
+    Philip Cardiff, UCD.
 
 SourceFiles
     pimpleOversetFluid.C

--- a/src/solids4FoamModels/fluidModels/pointPatchFields/timeVaryingVelocity/timeVaryingVelocityPointPatchVectorField.H
+++ b/src/solids4FoamModels/fluidModels/pointPatchFields/timeVaryingVelocity/timeVaryingVelocityPointPatchVectorField.H
@@ -30,7 +30,7 @@ SourceFiles
     timeVaryingVelocityPointPatchVectorField.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/fluidModels/sonicLiquidFluid/sonicLiquidFluid.esi.H
+++ b/src/solids4FoamModels/fluidModels/sonicLiquidFluid/sonicLiquidFluid.esi.H
@@ -25,7 +25,7 @@ Description
 
 Author
     Iago Lessa de Oliveira, FEIS/UNESP/UCD.
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 SourceFiles
     sonicLiquidFluid.esi.C

--- a/src/solids4FoamModels/fluidModels/sonicLiquidFluid/sonicLiquidFluid.foamextend.H
+++ b/src/solids4FoamModels/fluidModels/sonicLiquidFluid/sonicLiquidFluid.foamextend.H
@@ -25,7 +25,7 @@ Description
 
 Author
     Iago Lessa de Oliveira, FEIS/UNESP/UCD.
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 SourceFiles
     sonicLiquidFluid.foamextend.C

--- a/src/solids4FoamModels/fluidModels/sonicLiquidFluid/sonicLiquidFluid.foundation.H
+++ b/src/solids4FoamModels/fluidModels/sonicLiquidFluid/sonicLiquidFluid.foundation.H
@@ -25,7 +25,7 @@ Description
 
 Author
     Iago Lessa de Oliveira, FEIS/UNESP/UCD.
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 SourceFiles
     sonicLiquidFluid.foundation.C

--- a/src/solids4FoamModels/fluidSolidInterfaces/AitkenCouplingInterface/AitkenCouplingInterface.H
+++ b/src/solids4FoamModels/fluidSolidInterfaces/AitkenCouplingInterface/AitkenCouplingInterface.H
@@ -22,8 +22,8 @@ Description
     Strong Dirichlet-Neumann coupling with Aitken accelerated under-relaxation.
 
 Author
-    Zeljko Tukovic, FSB Zagreb.  All rights reserved.
-    Philip Cardiff, UCD. All rights reserved.
+    Zeljko Tukovic, FSB Zagreb.
+    Philip Cardiff, UCD.
 
 SourceFiles
     AitkenCouplingInterface.C

--- a/src/solids4FoamModels/fluidSolidInterfaces/IQNILSCouplingInterface/IQNILSCouplingInterface.H
+++ b/src/solids4FoamModels/fluidSolidInterfaces/IQNILSCouplingInterface/IQNILSCouplingInterface.H
@@ -27,8 +27,8 @@ Description
     procedure in fluid-solid interaction. Computers & Solids
 
 Author
-    Zeljko Tukovic, FSB Zagreb.  All rights reserved.
-    Philip Cardiff, UCD. All rights reserved.
+    Zeljko Tukovic, FSB Zagreb.
+    Philip Cardiff, UCD.
 
 SourceFiles
     IQNILSCouplingInterface.C

--- a/src/solids4FoamModels/fluidSolidInterfaces/fixedRelaxationCouplingInterface/fixedRelaxationCouplingInterface.H
+++ b/src/solids4FoamModels/fluidSolidInterfaces/fixedRelaxationCouplingInterface/fixedRelaxationCouplingInterface.H
@@ -22,8 +22,8 @@ Description
     Strong Dirichlet-Neumann coupling with fixed under-relaxation.
 
 Author
-    Zeljko Tukovic, FSB Zagreb.  All rights reserved.
-    Philip Cardiff, UCD. All rights reserved.
+    Zeljko Tukovic, FSB Zagreb.
+    Philip Cardiff, UCD.
 
 SourceFiles
     fixedRelaxationCouplingInterface.C

--- a/src/solids4FoamModels/fluidSolidInterfaces/fluidSolidInterface/fluidSolidInterface.H
+++ b/src/solids4FoamModels/fluidSolidInterfaces/fluidSolidInterface/fluidSolidInterface.H
@@ -22,8 +22,8 @@ Description
     Virtual base class for fluid-solid interface coupling.
 
 Author
-    Zeljko Tukovic, FSB Zagreb.  All rights reserved.
-    Philip Cardiff, UCD. All rights reserved.
+    Zeljko Tukovic, FSB Zagreb.
+    Philip Cardiff, UCD.
     Extended to multiple interfaces by Danial Khazaei
 
 SourceFiles

--- a/src/solids4FoamModels/fluidSolidInterfaces/fluidSolidInterface/interfaceToInterfaceMapping/amiInterfaceToInterfaceMapping/amiInterfaceToInterfaceMapping.H
+++ b/src/solids4FoamModels/fluidSolidInterfaces/fluidSolidInterface/interfaceToInterfaceMapping/amiInterfaceToInterfaceMapping/amiInterfaceToInterfaceMapping.H
@@ -22,7 +22,7 @@ Description
     interfaceToInterfaceMapping wrapper for AMI interpolation
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 SourceFiles
     amiInterfaceToInterfaceMapping.C

--- a/src/solids4FoamModels/fluidSolidInterfaces/fluidSolidInterface/interfaceToInterfaceMapping/directMapInterfaceToInterfaceMapping/directMapInterfaceToInterfaceMapping.H
+++ b/src/solids4FoamModels/fluidSolidInterfaces/fluidSolidInterface/interfaceToInterfaceMapping/directMapInterfaceToInterfaceMapping/directMapInterfaceToInterfaceMapping.H
@@ -23,7 +23,7 @@ Description
     meshes
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 SourceFiles
     directMapInterfaceToInterfaceMapping.C

--- a/src/solids4FoamModels/fluidSolidInterfaces/fluidSolidInterface/interfaceToInterfaceMapping/ggiInterfaceToInterfaceMapping/ggiInterfaceToInterfaceMapping.H
+++ b/src/solids4FoamModels/fluidSolidInterfaces/fluidSolidInterface/interfaceToInterfaceMapping/ggiInterfaceToInterfaceMapping/ggiInterfaceToInterfaceMapping.H
@@ -22,7 +22,7 @@ Description
     interfaceToInterfaceMapping wrapper for GGI interpolation
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 SourceFiles
     ggiInterfaceToInterfaceMapping.C

--- a/src/solids4FoamModels/fluidSolidInterfaces/fluidSolidInterface/interfaceToInterfaceMapping/interfaceToInterfaceMapping/interfaceToInterfaceMapping.H
+++ b/src/solids4FoamModels/fluidSolidInterfaces/fluidSolidInterface/interfaceToInterfaceMapping/interfaceToInterfaceMapping/interfaceToInterfaceMapping.H
@@ -22,7 +22,7 @@ Description
     Virtual base class for mapping/interpolating between two interfaces
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 SourceFiles
     interfaceToInterfaceMapping.C

--- a/src/solids4FoamModels/fluidSolidInterfaces/fluidSolidInterface/interfaceToInterfaceMapping/rbfInterfaceToInterfaceMapping/rbfInterfaceToInterfaceMapping.H
+++ b/src/solids4FoamModels/fluidSolidInterfaces/fluidSolidInterface/interfaceToInterfaceMapping/rbfInterfaceToInterfaceMapping/rbfInterfaceToInterfaceMapping.H
@@ -22,7 +22,7 @@ Description
     interfaceToInterfaceMapping wrapper using radial basis functions
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
     This class is a wrapper for the code from David Blom
 
 SourceFiles

--- a/src/solids4FoamModels/fluidSolidInterfaces/fvPatchFields/fsiInterfaceSolid/fsiInterfaceSolidFvPatchVectorField.H
+++ b/src/solids4FoamModels/fluidSolidInterfaces/fvPatchFields/fsiInterfaceSolid/fsiInterfaceSolidFvPatchVectorField.H
@@ -26,7 +26,7 @@ SourceFiles
     fsiInterfaceSolidFvPatchVectorField.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/fluidSolidInterfaces/oneWayCouplingInterface/oneWayCouplingInterface.H
+++ b/src/solids4FoamModels/fluidSolidInterfaces/oneWayCouplingInterface/oneWayCouplingInterface.H
@@ -24,7 +24,7 @@ Description
     interaction simulation.
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 SourceFiles
     oneWayCouplingInterface.C

--- a/src/solids4FoamModels/fluidSolidInterfaces/thermalCouplingInterface/thermalCouplingInterface.H
+++ b/src/solids4FoamModels/fluidSolidInterfaces/thermalCouplingInterface/thermalCouplingInterface.H
@@ -22,8 +22,8 @@ Description
     Strong Dirichlet-Neumann coupling with fixed under-relaxation.
 
 Author
-    Zeljko Tukovic, FSB Zagreb.  All rights reserved.
-    Philip Cardiff, UCD. All rights reserved.
+    Zeljko Tukovic, FSB Zagreb.
+    Philip Cardiff, UCD.
 
 SourceFiles
     thermalCouplingInterface.C

--- a/src/solids4FoamModels/fluidSolidInterfaces/weakCouplingInterface/weakCouplingInterface.H
+++ b/src/solids4FoamModels/fluidSolidInterfaces/weakCouplingInterface/weakCouplingInterface.H
@@ -23,8 +23,8 @@ Description
     performed each time-step.
 
 Author
-    Zeljko Tukovic, FSB Zagreb.  All rights reserved.
-    Philip Cardiff, UCD. All rights reserved.
+    Zeljko Tukovic, FSB Zagreb.
+    Philip Cardiff, UCD.
 
 SourceFiles
     weakCouplingInterface.C

--- a/src/solids4FoamModels/functionObjects/contactPatchTestAnalyticalSolution/contactPatchTestAnalyticalSolution.H
+++ b/src/solids4FoamModels/functionObjects/contactPatchTestAnalyticalSolution/contactPatchTestAnalyticalSolution.H
@@ -31,7 +31,7 @@ Description
         - nu : Poisson's ratio
 
 Author
-    Ivan Batistic & Philip Cardiff, UCD. All rights reserved.
+    Ivan Batistic & Philip Cardiff, UCD.
 
 SourceFiles
     contactPatchTestAnalyticalSolution.C

--- a/src/solids4FoamModels/functionObjects/curvedCantileverAnalyticalSolution/curvedCantileverAnalyticalSolution.H
+++ b/src/solids4FoamModels/functionObjects/curvedCantileverAnalyticalSolution/curvedCantileverAnalyticalSolution.H
@@ -38,7 +38,7 @@ Description
     It is assumed that the inner and outer beam surfaces are traction-free.
 
 Author
-    Ivan Batistic & Philip Cardiff, UCD. All rights reserved.
+    Ivan Batistic & Philip Cardiff, UCD.
 
 SourceFiles
     curvedCantileverAnalyticalSolution.C

--- a/src/solids4FoamModels/functionObjects/fsiConvergenceData/fsiConvergenceData.C
+++ b/src/solids4FoamModels/functionObjects/fsiConvergenceData/fsiConvergenceData.C
@@ -16,7 +16,7 @@ License
     along with solids4foam.  If not, see <http://www.gnu.org/licenses/>.
 
 Author
-    Zeljko Tukovic, FSB Zagreb.  All rights reserved
+    Zeljko Tukovic, FSB Zagreb.
 
 \*----------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/functionObjects/fsiConvergenceData/fsiConvergenceData.H
+++ b/src/solids4FoamModels/functionObjects/fsiConvergenceData/fsiConvergenceData.H
@@ -22,7 +22,7 @@ Description
     FunctionObject reports FSI convergence data
 
 Author
-    Zeljko Tukovic, FSB.  All rights reserved
+    Zeljko Tukovic, FSB.
 
 SourceFiles
     fsiConvergenceData.C

--- a/src/solids4FoamModels/functionObjects/hotCylinderAnalyticalSolution/hotCylinderAnalyticalSolution.H
+++ b/src/solids4FoamModels/functionObjects/hotCylinderAnalyticalSolution/hotCylinderAnalyticalSolution.H
@@ -36,7 +36,7 @@ Description
     It is assumed that the inner and outer pipe surfaces are traction-free.
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 SourceFiles
     hotCylinderAnalyticalSolution.C

--- a/src/solids4FoamModels/functionObjects/hydrostaticPressure/hydrostaticPressure.H
+++ b/src/solids4FoamModels/functionObjects/hydrostaticPressure/hydrostaticPressure.H
@@ -44,7 +44,7 @@ Description
     @endverbatim
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 SourceFiles
     hydrostaticPressure.C

--- a/src/solids4FoamModels/functionObjects/plateHoleAnalyticalSolution/plateHoleAnalyticalSolution.H
+++ b/src/solids4FoamModels/functionObjects/plateHoleAnalyticalSolution/plateHoleAnalyticalSolution.H
@@ -31,7 +31,7 @@ Description
         - nu : Poisson's ratio
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 SourceFiles
     plateHoleAnalyticalSolution.C

--- a/src/solids4FoamModels/functionObjects/principalStresses/principalStresses.H
+++ b/src/solids4FoamModels/functionObjects/principalStresses/principalStresses.H
@@ -52,7 +52,7 @@ Description
     @endverbatim
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 SourceFiles
     principalStresses.C

--- a/src/solids4FoamModels/functionObjects/solidDisplacements/solidDisplacements.H
+++ b/src/solids4FoamModels/functionObjects/solidDisplacements/solidDisplacements.H
@@ -23,7 +23,7 @@ Description
     min X, min Y, min Z, max X, max Y, max Z, average.
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 SourceFiles
     solidDisplacements.C

--- a/src/solids4FoamModels/functionObjects/solidForces/solidForces.H
+++ b/src/solids4FoamModels/functionObjects/solidForces/solidForces.H
@@ -22,7 +22,7 @@ Description
     FunctionObject reports forces on the patch of a solid.
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 SourceFiles
     solidForces.C

--- a/src/solids4FoamModels/functionObjects/solidForcesDisplacements/solidForcesDisplacements.H
+++ b/src/solids4FoamModels/functionObjects/solidForcesDisplacements/solidForcesDisplacements.H
@@ -22,7 +22,7 @@ Description
     FunctionObject reports force vs displacement for specified patch.
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 SourceFiles
     solidForcesDisplacements.C

--- a/src/solids4FoamModels/functionObjects/solidKineticEnergy/solidKineticEnergy.H
+++ b/src/solids4FoamModels/functionObjects/solidKineticEnergy/solidKineticEnergy.H
@@ -22,7 +22,7 @@ Description
     FunctionObject reports the kinetic energy of a solid.
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 SourceFiles
     solidKineticEnergy.C

--- a/src/solids4FoamModels/functionObjects/solidPointDisplacement/solidPointDisplacement.H
+++ b/src/solids4FoamModels/functionObjects/solidPointDisplacement/solidPointDisplacement.H
@@ -26,7 +26,7 @@ Description
     least squares vol-to-point interpolator.
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 SourceFiles
     solidPointDisplacement.C

--- a/src/solids4FoamModels/functionObjects/solidPotentialEnergy/solidPotentialEnergy.H
+++ b/src/solids4FoamModels/functionObjects/solidPotentialEnergy/solidPotentialEnergy.H
@@ -25,7 +25,7 @@ Description
     be specified.
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 SourceFiles
     solidPotentialEnergy.C

--- a/src/solids4FoamModels/functionObjects/solidPressureMinMax/solidPressureMinMax.H
+++ b/src/solids4FoamModels/functionObjects/solidPressureMinMax/solidPressureMinMax.H
@@ -42,7 +42,7 @@ Description
         }
 
 Author
-    Philip Cardiff, UCD.  All rights reserved.
+    Philip Cardiff, UCD.
 
 SourceFiles
     solidPressureMinMax.C

--- a/src/solids4FoamModels/functionObjects/solidStresses/solidStresses.H
+++ b/src/solids4FoamModels/functionObjects/solidStresses/solidStresses.H
@@ -23,7 +23,7 @@ Description
     solid.
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 SourceFiles
     solidStresses.C

--- a/src/solids4FoamModels/functionObjects/solidTorque/solidTorque.H
+++ b/src/solids4FoamModels/functionObjects/solidTorque/solidTorque.H
@@ -28,7 +28,7 @@ Description
     direction.
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 SourceFiles
     solidTorque.C

--- a/src/solids4FoamModels/functionObjects/solidTractions/solidTractions.H
+++ b/src/solids4FoamModels/functionObjects/solidTractions/solidTractions.H
@@ -23,7 +23,7 @@ Description
     post-processing.
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 SourceFiles
     solidTractions.C

--- a/src/solids4FoamModels/functionObjects/sphericalCavityAnalyticalSolution/sphericalCavityAnalyticalSolution.H
+++ b/src/solids4FoamModels/functionObjects/sphericalCavityAnalyticalSolution/sphericalCavityAnalyticalSolution.H
@@ -48,7 +48,7 @@ Description
     concentration factor at the edge of the cavity.
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 SourceFiles
     sphericalCavityAnalyticalSolution.C

--- a/src/solids4FoamModels/functionObjects/sphericalCavityAnalyticalSolution/sphericalCavityStressDisplacement.H
+++ b/src/solids4FoamModels/functionObjects/sphericalCavityAnalyticalSolution/sphericalCavityStressDisplacement.H
@@ -48,7 +48,7 @@ Description
     concentration factor at the edge of the cavity.
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 SourceFiles
     sphericalCavityStressDisplacement.C

--- a/src/solids4FoamModels/functionObjects/squarePlateAnalyticalSolution/squarePlateAnalyticalSolution.H
+++ b/src/solids4FoamModels/functionObjects/squarePlateAnalyticalSolution/squarePlateAnalyticalSolution.H
@@ -29,7 +29,7 @@ Description
     The plate dimensions are a x b, thickness of the plate is h.
 
 Author
-    Ivan Batistic & Philip Cardiff, UCD. All rights reserved.
+    Ivan Batistic & Philip Cardiff, UCD.
 
 SourceFiles
     squarePlateAnalyticalSolution.C

--- a/src/solids4FoamModels/functionObjects/squarePlateAnalyticalSolution/squarePlateStressDisplacement.H
+++ b/src/solids4FoamModels/functionObjects/squarePlateAnalyticalSolution/squarePlateStressDisplacement.H
@@ -47,7 +47,7 @@ Description
     - the origin is at the centre of plate
 
 Author
-    Ivan Batistic & Philip Cardiff, UCD. All rights reserved.
+    Ivan Batistic & Philip Cardiff, UCD.
 
 SourceFiles
     squarePlateStressDisplacement.C

--- a/src/solids4FoamModels/functionObjects/stressTriaxiality/stressTriaxiality.H
+++ b/src/solids4FoamModels/functionObjects/stressTriaxiality/stressTriaxiality.H
@@ -39,7 +39,7 @@ Description
     @endverbatim
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 SourceFiles
     stressTriaxiality.C

--- a/src/solids4FoamModels/functionObjects/transformStressToCylindrical/transformStressToCylindrical.H
+++ b/src/solids4FoamModels/functionObjects/transformStressToCylindrical/transformStressToCylindrical.H
@@ -23,7 +23,7 @@ Description
     coordinate system.
 
 Author
-    Ivan Batistic, FSB. All rights reserved.
+    Ivan Batistic, FSB.
 
 SourceFiles
     transformStressToCylindrical.C

--- a/src/solids4FoamModels/functionObjects/volumetricStrain/volumetricStrain.H
+++ b/src/solids4FoamModels/functionObjects/volumetricStrain/volumetricStrain.H
@@ -40,7 +40,7 @@ Description
     @endverbatim
 
 Author
-    Scott Levie, Philip Cardiff, UCD. All rights reserved.
+    Scott Levie, Philip Cardiff, UCD.
 
 SourceFiles
     volumetricStrain.C

--- a/src/solids4FoamModels/higherOrderHelpers/fvMeshQuadrature/fvMeshQuadrature.H
+++ b/src/solids4FoamModels/higherOrderHelpers/fvMeshQuadrature/fvMeshQuadrature.H
@@ -45,7 +45,7 @@ Description
 
 Author
     Ivan Batistic, UCD.
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 SourceFiles
     fvMeshQuadrature.C

--- a/src/solids4FoamModels/higherOrderHelpers/hofv/hofvc.H
+++ b/src/solids4FoamModels/higherOrderHelpers/hofv/hofvc.H
@@ -24,7 +24,7 @@ SourceFiles
 
 Author
     Ivan Batistic, UCD.
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/higherOrderHelpers/hofv/hofvm.H
+++ b/src/solids4FoamModels/higherOrderHelpers/hofv/hofvm.H
@@ -24,7 +24,7 @@ SourceFiles
 
 Author
     Ivan Batistic, UCD.
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/higherOrderHelpers/movingLeastSquares/movingLeastSquares.H
+++ b/src/solids4FoamModels/higherOrderHelpers/movingLeastSquares/movingLeastSquares.H
@@ -42,7 +42,7 @@ Description
 
 Author
     Ivan Batistic, UCD.
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 SourceFiles
     movingLeastSquares.C

--- a/src/solids4FoamModels/higherOrderHelpers/movingLeastSquaresStencil/movingLeastSquaresStencil.H
+++ b/src/solids4FoamModels/higherOrderHelpers/movingLeastSquaresStencil/movingLeastSquaresStencil.H
@@ -45,8 +45,8 @@ SourceFile
     movingLeastSquaresStencilTemplates.C
 
 Author
-    Ivan Batistic, UCD. All rights reserved.
-    Philip Cardiff, UCD. All rights reserved.
+    Ivan Batistic, UCD.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/higherOrderHelpers/quadrature/lineQuadrature.H
+++ b/src/solids4FoamModels/higherOrderHelpers/quadrature/lineQuadrature.H
@@ -43,8 +43,8 @@ SourceFile
     lineQuadrature.C
 
 Author
-    Ivan Batistic, UCD. All rights reserved.
-    Philip Cardiff, UCD. All rights reserved.
+    Ivan Batistic, UCD.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/higherOrderHelpers/quadrature/quadrature.H
+++ b/src/solids4FoamModels/higherOrderHelpers/quadrature/quadrature.H
@@ -42,8 +42,8 @@ SourceFile
     quadrature.C
 
 Author
-    Ivan Batistic, UCD. All rights reserved.
-    Philip Cardiff, UCD. All rights reserved.
+    Ivan Batistic, UCD.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/higherOrderHelpers/quadrature/tetQuadrature.H
+++ b/src/solids4FoamModels/higherOrderHelpers/quadrature/tetQuadrature.H
@@ -42,9 +42,9 @@ SourceFile
     tetQuadrature.C
 
 Author
-    Ivan Batistic, UCD. All rights reserved.
-    Pablo Castrillo, UCD. All rights reserved.
-    Philip Cardiff, UCD. All rights reserved.
+    Ivan Batistic, UCD.
+    Pablo Castrillo, UCD.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/higherOrderHelpers/quadrature/triQuadrature.H
+++ b/src/solids4FoamModels/higherOrderHelpers/quadrature/triQuadrature.H
@@ -42,9 +42,9 @@ SourceFile
     triQuadrature.C
 
 Author
-    Ivan Batistic, UCD. All rights reserved.
-    Pablo Castrillo, UCD. All rights reserved.
-    Philip Cardiff, UCD. All rights reserved.
+    Ivan Batistic, UCD.
+    Pablo Castrillo, UCD.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/higherOrderHelpers/weightFunction/weightFunction.H
+++ b/src/solids4FoamModels/higherOrderHelpers/weightFunction/weightFunction.H
@@ -35,8 +35,8 @@ SourceFile
     weightFunction.C
 
 Author
-    Ivan Batistic, UCD. All rights reserved.
-    Philip Cardiff, UCD. All rights reserved.
+    Ivan Batistic, UCD.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/materialModels/mechanicalModel/dualMechanicalModel.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/dualMechanicalModel.H
@@ -30,7 +30,7 @@ SourceFiles
     dualMechanicalModel.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/anisotropicBiotElastic/anisotropicBiotElastic.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/anisotropicBiotElastic/anisotropicBiotElastic.H
@@ -40,8 +40,8 @@ SourceFiles
     anisotropicBiotElastic.C
 
 Author
-    Original author: Tian Tang, DTU. All rights reserved.
-    Ported to solids4foam by: Philip Cardiff, UCD. All rights reserved.
+    Original author: Tian Tang, DTU.
+    Ported to solids4foam by: Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/diffusionElastic/diffusionElastic.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/diffusionElastic/diffusionElastic.H
@@ -33,7 +33,7 @@ SourceFiles
     diffusionElastic.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElastic/linearElastic.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElastic/linearElastic.H
@@ -25,7 +25,7 @@ SourceFiles
     linearElastic.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticMisesPlastic/linearElasticMisesPlastic.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticMisesPlastic/linearElasticMisesPlastic.H
@@ -41,7 +41,7 @@ SourceFiles
     linearElasticMisesPlastic.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticMohrCoulombPlastic/linearElasticMohrCoulombPlastic.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticMohrCoulombPlastic/linearElasticMohrCoulombPlastic.H
@@ -40,8 +40,8 @@ SourceFiles
     linearElasticMohrCoulombPlastic.C
 
 Author
-    Tian Tang, DTU. All rights reserved.
-    Philip Cardiff, UCD. All rights reserved.
+    Tian Tang, DTU.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/orthotropicLinearElastic/orthotropicLinearElastic.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/orthotropicLinearElastic/orthotropicLinearElastic.H
@@ -50,7 +50,7 @@ SourceFiles
     orthotropicLinearElastic.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/poroMechanicalLaw/poroMechanicalLaw.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/poroMechanicalLaw/poroMechanicalLaw.H
@@ -29,7 +29,7 @@ SourceFiles
     poroMechanicalLaw.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
     Inspired by Denis Maier, BAW, code design suggestions.
 
 \*---------------------------------------------------------------------------*/

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/thermoMechanicalLaw/thermoMechanicalLaw.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/thermoMechanicalLaw/thermoMechanicalLaw.H
@@ -31,7 +31,7 @@ SourceFiles
     thermoMechanicalLaw.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
     Inspired by Denis Maier, BAW, code design suggestions.
 
 \*---------------------------------------------------------------------------*/

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/viscousHookeanElastic/viscousHookeanElastic.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/viscousHookeanElastic/viscousHookeanElastic.H
@@ -54,7 +54,7 @@ SourceFiles
     viscousHookeanElastic.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/GuccioneElastic/GuccioneElastic.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/GuccioneElastic/GuccioneElastic.H
@@ -28,7 +28,7 @@ SourceFiles
     GuccioneElastic.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/MooneyRivlinElastic/MooneyRivlinElastic.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/MooneyRivlinElastic/MooneyRivlinElastic.H
@@ -63,7 +63,6 @@ SourceFiles
 Author
     Iago Oliveira, based on code of Philip Cardiff, UCD.
     Ported by Philip Cardiff, UCD.
-    All rights reserved.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/OgdenElastic/OgdenElastic.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/OgdenElastic/OgdenElastic.H
@@ -51,7 +51,6 @@ SourceFiles
 Author
     Joszef Nagy, Eulerian Solutions.
     Philip Cardiff, UCD.
-    All rights reserved.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/StVenantKirchhoffElastic/StVenantKirchhoffElastic.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/StVenantKirchhoffElastic/StVenantKirchhoffElastic.H
@@ -36,7 +36,7 @@ SourceFiles
     StVenantKirchhoffElastic.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/StVenantKirchhoffOrthotropicElastic/StVenantKirchhoffOrthotropicElastic.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/StVenantKirchhoffOrthotropicElastic/StVenantKirchhoffOrthotropicElastic.H
@@ -37,7 +37,7 @@ SourceFiles
     StVenantKirchhoffOrthotropicElastic.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/YeohElastic/YeohElastic.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/YeohElastic/YeohElastic.H
@@ -49,7 +49,6 @@ SourceFiles
 Author
     Iago Oliveira, based on code by Philip Cardiff, UCD.
     Ported by Philip Cardiff, UCD.
-    All rights reserved.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/diffusionHyperElastic/diffusionHyperElastic.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/diffusionHyperElastic/diffusionHyperElastic.H
@@ -33,7 +33,7 @@ SourceFiles
     diffusionHyperElastic.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/electroMechanicalLaw/electroMechanicalLaw.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/electroMechanicalLaw/electroMechanicalLaw.H
@@ -29,7 +29,7 @@ SourceFiles
     electroMechanicalLaw.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/isotropicFungElastic/isotropicFungElastic.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/isotropicFungElastic/isotropicFungElastic.H
@@ -47,7 +47,6 @@ SourceFiles
 Author
     Iago Oliveira, based on code by Philip Cardiff, UCD.
     Minor modifications by Philip Cardiff, UCD.
-    All rights reserved.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/neoHookeanElastic/neoHookeanElastic.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/neoHookeanElastic/neoHookeanElastic.H
@@ -45,7 +45,7 @@ SourceFiles
     neoHookeanElastic.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/neoHookeanElasticMisesPlastic/neoHookeanElasticMisesPlastic.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/neoHookeanElasticMisesPlastic/neoHookeanElasticMisesPlastic.H
@@ -41,7 +41,7 @@ SourceFiles
     neoHookeanElasticMisesPlastic.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/rotationInvariantLinearElastic/rotationInvariantLinearElastic.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/rotationInvariantLinearElastic/rotationInvariantLinearElastic.H
@@ -44,7 +44,7 @@ SourceFiles
     rotationInvariantLinearElastic.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/viscoNeoHookeanElastic/viscoNeoHookeanElastic.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/viscoNeoHookeanElastic/viscoNeoHookeanElastic.H
@@ -35,7 +35,7 @@ SourceFiles
     viscoNeoHookeanElastic.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved
+    Philip Cardiff, UCD.
     Xiaoxue Shen, CSU.
 
 \*---------------------------------------------------------------------------*/

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalModel.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalModel.H
@@ -32,7 +32,7 @@ SourceFiles
     mechanicalModel.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/materialModels/mechanicalModel/solidSubMeshes/solidSubMeshes.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/solidSubMeshes/solidSubMeshes.H
@@ -32,7 +32,7 @@ SourceFiles
     solidSubMeshes.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/materialModels/thermalModel/thermalLaws/constantThermal/constantThermal.H
+++ b/src/solids4FoamModels/materialModels/thermalModel/thermalLaws/constantThermal/constantThermal.H
@@ -22,8 +22,8 @@ Description
     Constant thermal properties
 
 Author
-    Hrvoje Jasak, Wikki Ltd.  All rights reserved.
-    Philip Cardiff, UCD.  All rights reserved.
+    Hrvoje Jasak, Wikki Ltd.
+    Philip Cardiff, UCD.
 
 SourceFiles
     constantThermal.C

--- a/src/solids4FoamModels/materialModels/thermalModel/thermalLaws/thermalLaw/thermalLaw.H
+++ b/src/solids4FoamModels/materialModels/thermalModel/thermalLaws/thermalLaw/thermalLaw.H
@@ -22,8 +22,8 @@ Description
     Thermal material properties for solids.
 
 Author
-    Hrvoje Jasak, Wikki Ltd.  All rights reserved.
-    Philip Cardiff, UCD.  All rights reserved.
+    Hrvoje Jasak, Wikki Ltd.
+    Philip Cardiff, UCD.
 
 SourceFiles
     thermalLaw.C

--- a/src/solids4FoamModels/materialModels/thermalModel/thermalModel.C
+++ b/src/solids4FoamModels/materialModels/thermalModel/thermalModel.C
@@ -22,7 +22,7 @@ Description
     Thermal  material properties for solids.
 
 Author
-    Hrvoje Jasak, Wikki Ltd.  All rights reserved.
+    Hrvoje Jasak, Wikki Ltd.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/materialModels/thermalModel/thermalModel.H
+++ b/src/solids4FoamModels/materialModels/thermalModel/thermalModel.H
@@ -22,7 +22,7 @@ Description
     Thermal material properties for solids.
 
 Author
-    Hrvoje Jasak, Wikki Ltd.  All rights reserved.
+    Hrvoje Jasak, Wikki Ltd.
 
 SourceFiles
     thermalModel.C

--- a/src/solids4FoamModels/numerics/FieldSumOp/FieldSumOp.H
+++ b/src/solids4FoamModels/numerics/FieldSumOp/FieldSumOp.H
@@ -24,7 +24,7 @@ Description
     This is required for clang, where reduce operations on lists are ambiguous.
 
 Author
-    Philip Cardiff, UCD.  All rights reserved
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/numerics/ListMaxOp/ListMaxOp.H
+++ b/src/solids4FoamModels/numerics/ListMaxOp/ListMaxOp.H
@@ -22,7 +22,7 @@ Description
     Op function class to perform operations on a list.
 
 Author
-    Philip Cardiff, UCD.  All rights reserved
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/numerics/ListSumOp/ListSumOp.H
+++ b/src/solids4FoamModels/numerics/ListSumOp/ListSumOp.H
@@ -22,7 +22,7 @@ Description
     Op function class to perform operations on a list.
 
 Author
-    Philip Cardiff, UCD.  All rights reserved
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/numerics/amiZoneInterpolation/amiZoneInterpolation.H
+++ b/src/solids4FoamModels/numerics/amiZoneInterpolation/amiZoneInterpolation.H
@@ -23,7 +23,7 @@ Description
     interpolation functions.
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 SourceFiles
     amiZoneInterpolation.C

--- a/src/solids4FoamModels/numerics/dynamicFvMesh/newDynamicBodyFvMesh/newDynamicBodyFvMesh.H
+++ b/src/solids4FoamModels/numerics/dynamicFvMesh/newDynamicBodyFvMesh/newDynamicBodyFvMesh.H
@@ -27,7 +27,7 @@ SourceFiles
     newDynamicBodyFvMesh.C
 
 Author
-    Hrvoje Jasak, Wikki Ltd.  All rights reserved
+    Hrvoje Jasak, Wikki Ltd.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/numerics/foamPetscSnesHelper/foamPetscSnesHelper.H
+++ b/src/solids4FoamModels/numerics/foamPetscSnesHelper/foamPetscSnesHelper.H
@@ -35,7 +35,7 @@ Description
        approximation of the Jacobian, e.g. fvm::laplacian.
 
 Author
-    Philip Cardiff, UCD.  All rights reserved.
+    Philip Cardiff, UCD.
 
 SourceFiles
     foamPetscSnesHelper.C

--- a/src/solids4FoamModels/numerics/globalPolyPatch/globalPolyPatch.H
+++ b/src/solids4FoamModels/numerics/globalPolyPatch/globalPolyPatch.H
@@ -23,8 +23,8 @@ Description
     on all processors.
 
 Author
-    Hrvoje Jasak, Wikki Ltd.  All rights reserved
-    Modifications/additions by Philip Cardiff, UCD.  All rights reserved
+    Hrvoje Jasak, Wikki Ltd.
+    Modifications/additions by Philip Cardiff, UCD.
 
 SourceFiles
     globalPolyPatch.C

--- a/src/solids4FoamModels/numerics/globalPolyPatch/standAlonePatch.H
+++ b/src/solids4FoamModels/numerics/globalPolyPatch/standAlonePatch.H
@@ -22,7 +22,7 @@ Description
     standAlonePatch is a primiteve patch that holds its point and face list.
 
 Author
-    Hrvoje Jasak, Wikki Ltd.  All rights reserved.
+    Hrvoje Jasak, Wikki Ltd.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/numerics/logExpVolFields/eig3/eig3.H
+++ b/src/solids4FoamModels/numerics/logExpVolFields/eig3/eig3.H
@@ -26,7 +26,7 @@ SourceFiles
     eig3.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/numerics/mechanicalEnergies/mechanicalEnergies.H
+++ b/src/solids4FoamModels/numerics/mechanicalEnergies/mechanicalEnergies.H
@@ -29,7 +29,7 @@ Description
     to dissipate high frequency energy in explicit simulations.
 
 Author
-    Philip Cardiff, UCD.  All rights reserved.
+    Philip Cardiff, UCD.
 
 SourceFiles
     mechanicalEnergies.C

--- a/src/solids4FoamModels/numerics/meshDual/dualMeshToMeshMap.H
+++ b/src/solids4FoamModels/numerics/meshDual/dualMeshToMeshMap.H
@@ -31,7 +31,7 @@ Description
     Take care as entries will be -1 if the map does not exist for the entity.
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 SourceFiles
     dualMeshToMeshMap.C

--- a/src/solids4FoamModels/numerics/multiplyCoeff/multiplyCoeff.H
+++ b/src/solids4FoamModels/numerics/multiplyCoeff/multiplyCoeff.H
@@ -26,8 +26,8 @@ SourceFile
     multiplyCoeff.C
 
 Author
-    Federico Mazzanti, UCD. All rights reserved.
-    Philip Cardiff, UCD. All rights reserved.
+    Federico Mazzanti, UCD.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/numerics/newGGIInterpolation/newGGIInterpolate.C
+++ b/src/solids4FoamModels/numerics/newGGIInterpolation/newGGIInterpolate.C
@@ -19,7 +19,7 @@ Description
     GGI interpolation functions
 
 Author
-    Hrvoje Jasak, Wikki Ltd.  All rights reserved
+    Hrvoje Jasak, Wikki Ltd.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/numerics/newGGIInterpolation/newGGIInterpolationName.C
+++ b/src/solids4FoamModels/numerics/newGGIInterpolation/newGGIInterpolationName.C
@@ -19,7 +19,7 @@ Description
     Shared template name for GGI interpolation
 
 Author
-    Hrvoje Jasak, Wikki Ltd.  All rights reserved
+    Hrvoje Jasak, Wikki Ltd.
 
 Contributor:
     Martin Beaudoin, Hydro-Quebec, (2008)

--- a/src/solids4FoamModels/numerics/newGGIInterpolation/newGGIInterpolationTemplate.H
+++ b/src/solids4FoamModels/numerics/newGGIInterpolation/newGGIInterpolationTemplate.H
@@ -38,7 +38,7 @@ Description
     globalData to false.  HJ, 27/Apr/2016
 
 Author
-    Hrvoje Jasak, Wikki Ltd.  All rights reserved
+    Hrvoje Jasak, Wikki Ltd.
 
 Contributor:
     Martin Beaudoin, Hydro-Quebec, (2008)

--- a/src/solids4FoamModels/numerics/newGGIInterpolation/newGGIInterpolationWeights.C
+++ b/src/solids4FoamModels/numerics/newGGIInterpolation/newGGIInterpolationWeights.C
@@ -20,7 +20,7 @@ Description
     primitivePatches
 
 Author
-    Hrvoje Jasak, Wikki Ltd.  All rights reserved
+    Hrvoje Jasak, Wikki Ltd.
 
 Modification by:
     Martin Beaudoin, Hydro-Quebec, (2008)

--- a/src/solids4FoamModels/numerics/newGGIInterpolation/newGgiInterpolation.H
+++ b/src/solids4FoamModels/numerics/newGGIInterpolation/newGgiInterpolation.H
@@ -19,7 +19,7 @@ Class
     newGgiInterpolation
 
 Author
-    Hrvoje Jasak, Wikki Ltd.  All rights reserved
+    Hrvoje Jasak, Wikki Ltd.
 
 Description
     Mass-conservative face interpolation: typedefs for polyPatch and faceZone

--- a/src/solids4FoamModels/numerics/patchCorrectionVectors/patchCorrectionVectors.H
+++ b/src/solids4FoamModels/numerics/patchCorrectionVectors/patchCorrectionVectors.H
@@ -30,7 +30,7 @@ SourceFile
     patchCorrectionVectors.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/numerics/pointFieldFunctions/pointFieldFunctions.H
+++ b/src/solids4FoamModels/numerics/pointFieldFunctions/pointFieldFunctions.H
@@ -29,7 +29,7 @@ SourceFile
     pointFieldFunctions.C
 
 Author
-    Federico Mazzanti, UCD. All rights reserved.
+    Federico Mazzanti, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/numerics/stabilisationModels/JamesonSchmidtTurkelStab/JamesonSchmidtTurkelStab.H
+++ b/src/solids4FoamModels/numerics/stabilisationModels/JamesonSchmidtTurkelStab/JamesonSchmidtTurkelStab.H
@@ -30,7 +30,7 @@ SourceFiles
     JamesonSchmidtTurkelStabTemplates.H
 
 Author
-    Philip Cardiff, UCD. All rights reserved
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/numerics/stabilisationModels/alphaStab/alphaStab.H
+++ b/src/solids4FoamModels/numerics/stabilisationModels/alphaStab/alphaStab.H
@@ -30,7 +30,7 @@ SourceFiles
     alphaStabTemplates.H
 
 Author
-    Philip Cardiff, UCD. All rights reserved
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/numerics/stabilisationModels/diffStencilLaplacianStab/RhieChowStab/RhieChowStab.H
+++ b/src/solids4FoamModels/numerics/stabilisationModels/diffStencilLaplacianStab/RhieChowStab/RhieChowStab.H
@@ -25,7 +25,7 @@ SourceFiles
     RhieChowStab.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/numerics/stabilisationModels/diffStencilLaplacianStab/diffStencilLaplacianStab.H
+++ b/src/solids4FoamModels/numerics/stabilisationModels/diffStencilLaplacianStab/diffStencilLaplacianStab.H
@@ -31,7 +31,7 @@ SourceFiles
     diffStencilLaplacianStabTemplates.H
 
 Author
-    Philip Cardiff, UCD. All rights reserved
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/numerics/stabilisationModels/generalisedEvenOrderLaplacianStab/generalisedEvenOrderLaplacianStab.H
+++ b/src/solids4FoamModels/numerics/stabilisationModels/generalisedEvenOrderLaplacianStab/generalisedEvenOrderLaplacianStab.H
@@ -29,7 +29,7 @@ SourceFiles
     generalisedEvenOrderLaplacianStabTemplates.H
 
 Author
-    Philip Cardiff, UCD. All rights reserved
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/numerics/stabilisationModels/gradDivStab/gradDivStab.H
+++ b/src/solids4FoamModels/numerics/stabilisationModels/gradDivStab/gradDivStab.H
@@ -30,7 +30,7 @@ SourceFiles
     gradDivStabTemplates.H
 
 Author
-    Philip Cardiff, UCD. All rights reserved
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/numerics/stabilisationModels/laplacianStab/laplacianStab.H
+++ b/src/solids4FoamModels/numerics/stabilisationModels/laplacianStab/laplacianStab.H
@@ -30,7 +30,7 @@ SourceFiles
     laplacianStabTemplates.H
 
 Author
-    Philip Cardiff, UCD. All rights reserved
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/numerics/stabilisationModels/multipleStabilisationModels/multipleStabilisationModels.H
+++ b/src/solids4FoamModels/numerics/stabilisationModels/multipleStabilisationModels/multipleStabilisationModels.H
@@ -57,7 +57,7 @@ SourceFiles
     multipleStabilisationModels.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/numerics/stabilisationModels/volStrainRateStab/volStrainRateStab.H
+++ b/src/solids4FoamModels/numerics/stabilisationModels/volStrainRateStab/volStrainRateStab.H
@@ -92,7 +92,7 @@ SourceFiles
     volStrainRateStab.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/physicsModel/physicsModel.H
+++ b/src/solids4FoamModels/physicsModel/physicsModel.H
@@ -23,8 +23,8 @@ Description
     solution procedures.
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
-    Zeljko Tukovic, FSB Zagreb.  All rights reserved.
+    Philip Cardiff, UCD.
+    Zeljko Tukovic, FSB Zagreb.
 
 SourceFiles
     physicsModel.C

--- a/src/solids4FoamModels/solidModels/coupledUnsLinGeomLinearElasticSolid/coupledUnsLinGeomLinearElasticSolid.H
+++ b/src/solids4FoamModels/solidModels/coupledUnsLinGeomLinearElasticSolid/coupledUnsLinGeomLinearElasticSolid.H
@@ -32,7 +32,7 @@ Description
     and Structures, 2016, 10.1016/j.compstruc.2016.07.004.
 
 Author
-    Philip Cardiff, UCD.  All rights reserved.
+    Philip Cardiff, UCD.
 
 SourceFiles
     coupledUnsLinGeomLinearElasticSolid.C

--- a/src/solids4FoamModels/solidModels/fvPatchFields/displacementOrTraction/displacementOrTractionFvPatchVectorField.H
+++ b/src/solids4FoamModels/solidModels/fvPatchFields/displacementOrTraction/displacementOrTractionFvPatchVectorField.H
@@ -44,7 +44,7 @@ SourceFiles
     displacementOrTractionFvPatchVectorField.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/solidModels/fvPatchFields/fixedDisplacement/fixedDisplacementFvPatchVectorField.H
+++ b/src/solids4FoamModels/solidModels/fvPatchFields/fixedDisplacement/fixedDisplacementFvPatchVectorField.H
@@ -28,7 +28,7 @@ SourceFiles
     fixedDisplacementFvPatchVectorField.C
 
 Author
-    Philip Cardiff, UCD/UT. All rights reserved.
+    Philip Cardiff, UCD/UT.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/solidModels/fvPatchFields/fixedDisplacementZeroShear/fixedDisplacementZeroShearFvPatchVectorField.H
+++ b/src/solids4FoamModels/solidModels/fvPatchFields/fixedDisplacementZeroShear/fixedDisplacementZeroShearFvPatchVectorField.H
@@ -30,7 +30,7 @@ SourceFiles
     fixedDisplacementZeroShearFvPatchVectorField.C
 
 Author
-    Philip Cardiff, UCD/UT. All rights reserved.
+    Philip Cardiff, UCD/UT.
     Based on velocityDisplacement by Aleksandar Karac
 
 \*---------------------------------------------------------------------------*/

--- a/src/solids4FoamModels/solidModels/fvPatchFields/fixedRotation/fixedRotationFvPatchVectorField.H
+++ b/src/solids4FoamModels/solidModels/fvPatchFields/fixedRotation/fixedRotationFvPatchVectorField.H
@@ -28,7 +28,7 @@ SourceFiles
     fixedRotationFvPatchVectorField.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/solidModels/fvPatchFields/fixedTemperature/fixedTemperatureFvPatchScalarField.H
+++ b/src/solids4FoamModels/solidModels/fvPatchFields/fixedTemperature/fixedTemperatureFvPatchScalarField.H
@@ -28,7 +28,7 @@ SourceFiles
     fixedTemperatureFvPatchScalarField.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/solidModels/fvPatchFields/linearSpatialDisplacement/linearSpatialDisplacementFvPatchVectorField.H
+++ b/src/solids4FoamModels/solidModels/fvPatchFields/linearSpatialDisplacement/linearSpatialDisplacementFvPatchVectorField.H
@@ -30,7 +30,7 @@ SourceFiles
     linearSpatialDisplacementFvPatchVectorField.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/solidModels/fvPatchFields/normalDisplacementZeroShear/normalDisplacementZeroShearFvPatchVectorField.H
+++ b/src/solids4FoamModels/solidModels/fvPatchFields/normalDisplacementZeroShear/normalDisplacementZeroShearFvPatchVectorField.H
@@ -30,7 +30,7 @@ SourceFiles
     normalDisplacementZeroShearFvPatchVectorField.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/solidModels/fvPatchFields/solidContact/contactModels/frictionContactModels/frictionContactModel/frictionContactModel.H
+++ b/src/solids4FoamModels/solidModels/fvPatchFields/solidContact/contactModels/frictionContactModels/frictionContactModel/frictionContactModel.H
@@ -29,7 +29,7 @@ SourceFiles
     newFrictionContactModel.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/solidModels/fvPatchFields/solidContact/contactModels/frictionContactModels/frictionLaws/coulombFriction/coulombFriction.H
+++ b/src/solids4FoamModels/solidModels/fvPatchFields/solidContact/contactModels/frictionContactModels/frictionLaws/coulombFriction/coulombFriction.H
@@ -27,7 +27,7 @@ SourceFiles
     coulombFriction.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/solidModels/fvPatchFields/solidContact/contactModels/frictionContactModels/frictionLaws/frictionLaw/frictionLaw.H
+++ b/src/solids4FoamModels/solidModels/fvPatchFields/solidContact/contactModels/frictionContactModels/frictionLaws/frictionLaw/frictionLaw.H
@@ -28,7 +28,7 @@ SourceFiles
     newFrictionLaw.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/solidModels/fvPatchFields/solidContact/contactModels/frictionContactModels/frictionless/frictionless.H
+++ b/src/solids4FoamModels/solidModels/fvPatchFields/solidContact/contactModels/frictionContactModels/frictionless/frictionless.H
@@ -25,7 +25,7 @@ SourceFiles
     frictionless.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/solidModels/fvPatchFields/solidContact/contactModels/frictionContactModels/standardPenaltyFriction/standardPenaltyFriction.H
+++ b/src/solids4FoamModels/solidModels/fvPatchFields/solidContact/contactModels/frictionContactModels/standardPenaltyFriction/standardPenaltyFriction.H
@@ -26,8 +26,8 @@ SourceFiles
     standardPenaltyFriction.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
-    Matthias Schnaithmann, Universitat Stuttgart. All rights reserved.
+    Philip Cardiff, UCD.
+    Matthias Schnaithmann, Universitat Stuttgart.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/solidModels/fvPatchFields/solidContact/contactModels/normalContactModels/normalContactModel/normalContactModel.H
+++ b/src/solids4FoamModels/solidModels/fvPatchFields/solidContact/contactModels/normalContactModels/normalContactModel/normalContactModel.H
@@ -26,7 +26,7 @@ SourceFiles
     newNormalContactModel.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/solidModels/fvPatchFields/solidContact/contactModels/normalContactModels/standardPenalty/standardPenalty.H
+++ b/src/solids4FoamModels/solidModels/fvPatchFields/solidContact/contactModels/normalContactModels/standardPenalty/standardPenalty.H
@@ -31,7 +31,7 @@ SourceFiles
     standardPenalty.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/solidModels/fvPatchFields/solidDirectionMixed/solidDirectionMixedFvPatchVectorField.H
+++ b/src/solids4FoamModels/solidModels/fvPatchFields/solidDirectionMixed/solidDirectionMixedFvPatchVectorField.H
@@ -22,8 +22,8 @@ Description
     directionMixed with non-orthogonal correction for the diffusion term
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
-    Zeljko Tukovic, FSB Zagreb. All rights reserved.
+    Philip Cardiff, UCD.
+    Zeljko Tukovic, FSB Zagreb.
 
 SourceFiles
     solidDirectionMixedFvPatchVectorField.C

--- a/src/solids4FoamModels/solidModels/fvPatchFields/solidRigidContact/solidRigidContactFvPatchVectorField.H
+++ b/src/solids4FoamModels/solidModels/fvPatchFields/solidRigidContact/solidRigidContactFvPatchVectorField.H
@@ -50,7 +50,7 @@ SourceFiles
     solidRigidContactFvPatchVectorFieldCalcContact.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
     Rewrite by Hrvoje Jasak.
 
 \*---------------------------------------------------------------------------*/

--- a/src/solids4FoamModels/solidModels/fvPatchFields/solidSymmetry/solidSymmetryFvPatchScalarField.H
+++ b/src/solids4FoamModels/solidModels/fvPatchFields/solidSymmetry/solidSymmetryFvPatchScalarField.H
@@ -25,7 +25,7 @@ SourceFiles
     solidSymmetryFvPatchScalarField.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved based on symmetryDisplacement
+    Philip Cardiff, UCD. based on symmetryDisplacement
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/solidModels/fvPatchFields/solidVelocity/solidVelocityFvPatchVectorField.H
+++ b/src/solids4FoamModels/solidModels/fvPatchFields/solidVelocity/solidVelocityFvPatchVectorField.H
@@ -30,7 +30,7 @@ SourceFiles
     solidVelocityFvPatchVectorField.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/solidModels/fvPatchFields/solidWedge/solidWedgeFvPatchScalarField.H
+++ b/src/solids4FoamModels/solidModels/fvPatchFields/solidWedge/solidWedgeFvPatchScalarField.H
@@ -25,7 +25,7 @@ SourceFiles
     solidWedgeFvPatchScalarField.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/solidModels/fvPatchFields/solidWedge/solidWedgeFvPatchVectorField.H
+++ b/src/solids4FoamModels/solidModels/fvPatchFields/solidWedge/solidWedgeFvPatchVectorField.H
@@ -25,7 +25,7 @@ SourceFiles
     solidWedgeFvPatchVectorField.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/solidModels/kirchhoffPlateSolid/kirchhoffPlateSolid.H
+++ b/src/solids4FoamModels/solidModels/kirchhoffPlateSolid/kirchhoffPlateSolid.H
@@ -24,7 +24,7 @@ Description
     Based on "rotation-free formulation" of Torlak (2006).
 
 Author
-    Philip Cardiff, UCD.  All rights reserved.
+    Philip Cardiff, UCD.
 
 SourceFiles
     kirchhoffPlateSolid.C

--- a/src/solids4FoamModels/solidModels/linGeomTotalDispSolid/linGeomTotalDispSolid.H
+++ b/src/solids4FoamModels/solidModels/linGeomTotalDispSolid/linGeomTotalDispSolid.H
@@ -26,7 +26,7 @@ Description
     The stress is calculated by the run-time selectable mechanical law.
 
 Author
-    Philip Cardiff, UCD.  All rights reserved.
+    Philip Cardiff, UCD.
 
 SourceFiles
     linGeomTotalDispSolid.C

--- a/src/solids4FoamModels/solidModels/nonLinGeomTotalLagTotalDispSolid/nonLinGeomTotalLagTotalDispSolid.H
+++ b/src/solids4FoamModels/solidModels/nonLinGeomTotalLagTotalDispSolid/nonLinGeomTotalLagTotalDispSolid.H
@@ -30,7 +30,7 @@ Description
     doi=10.1002/nme.5345.
 
 Author
-    Philip Cardiff, UCD.  All rights reserved.
+    Philip Cardiff, UCD.
 
 SourceFiles
     nonLinGeomTotalLagTotalDispSolid.C

--- a/src/solids4FoamModels/solidModels/nonLinGeomUpdatedLagSolid/nonLinGeomUpdatedLagSolid.H
+++ b/src/solids4FoamModels/solidModels/nonLinGeomUpdatedLagSolid/nonLinGeomUpdatedLagSolid.H
@@ -30,7 +30,7 @@ Description
     doi=10.1002/nme.5345.
 
 Author
-    Philip Cardiff, UCD.  All rights reserved.
+    Philip Cardiff, UCD.
 
 SourceFiles
     nonLinGeomUpdatedLagSolid.C

--- a/src/solids4FoamModels/solidModels/pointPatchFields/pointFixedRotation/fixedRotationPointPatchVectorField.H
+++ b/src/solids4FoamModels/solidModels/pointPatchFields/pointFixedRotation/fixedRotationPointPatchVectorField.H
@@ -28,8 +28,8 @@ SourceFiles
     fixedRotationPointPatchVectorField.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
-    Federico Mazzanti, UCD. All rights reserved.
+    Philip Cardiff, UCD.
+    Federico Mazzanti, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/solidModels/pointPatchFields/pointSolidContact/pointContactModels/pointNormalContactModels/pointNormalContactModel/pointNormalContactModel.H
+++ b/src/solids4FoamModels/solidModels/pointPatchFields/pointSolidContact/pointContactModels/pointNormalContactModels/pointNormalContactModel/pointNormalContactModel.H
@@ -26,7 +26,7 @@ SourceFiles
     newPointNormalContactModel.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/solidModels/pointPatchFields/pointSolidContact/pointContactModels/pointNormalContactModels/pointStandardPenalty/pointStandardPenalty.H
+++ b/src/solids4FoamModels/solidModels/pointPatchFields/pointSolidContact/pointContactModels/pointNormalContactModels/pointStandardPenalty/pointStandardPenalty.H
@@ -25,7 +25,7 @@ SourceFiles
     pointStandardPenalty.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/src/solids4FoamModels/solidModels/poroLinGeomSolid/poroLinGeomSolid.H
+++ b/src/solids4FoamModels/solidModels/poroLinGeomSolid/poroLinGeomSolid.H
@@ -43,8 +43,8 @@ Description
 
 
 Author
-    Tian Tang, DTU.  All rights reserved.
-    Philip Cardiff, UCD.  All rights reserved.
+    Tian Tang, DTU.
+    Philip Cardiff, UCD.
 
 SourceFiles
     poroLinGeomSolid.C

--- a/src/solids4FoamModels/solidModels/solidModel/solidModel.H
+++ b/src/solids4FoamModels/solidModels/solidModel/solidModel.H
@@ -22,8 +22,8 @@ Description
     Virtual base class for solid mechanics models
 
 Author
-    Zeljko Tukovic, FSB Zagreb.  All rights reserved.
-    Philip Cardiff, UCD. All rights reserved.
+    Zeljko Tukovic, FSB Zagreb.
+    Philip Cardiff, UCD.
 
 SourceFiles
     solidModel.C

--- a/src/solids4FoamModels/solidModels/thermalLinGeomSolid/thermalLinGeomSolid.H
+++ b/src/solids4FoamModels/solidModels/thermalLinGeomSolid/thermalLinGeomSolid.H
@@ -28,7 +28,7 @@ Description
     The stress is calculated by the run-time selectable mechanical law.
 
 Author
-    Philip Cardiff, UCD.  All rights reserved.
+    Philip Cardiff, UCD.
 
 SourceFiles
     thermalLinGeomSolid.C

--- a/src/solids4FoamModels/solidModels/thermalSolid/thermalSolid.H
+++ b/src/solids4FoamModels/solidModels/thermalSolid/thermalSolid.H
@@ -30,8 +30,8 @@ Description
     Added functions required for CHT explicit coupling
 
 Author
-    Philip Cardiff, UCD.  All rights reserved.
-    Tukovic Zeljko, FSB.  All rights reserved.
+    Philip Cardiff, UCD.
+    Tukovic Zeljko, FSB.
 
 SourceFiles
     thermalSolid.C

--- a/src/solids4FoamModels/solidModels/unsLinGeomSolid/unsLinGeomSolid.H
+++ b/src/solids4FoamModels/solidModels/unsLinGeomSolid/unsLinGeomSolid.H
@@ -28,8 +28,8 @@ Description
     the face tangential gradient are calculated using a face-Gauss approach.
 
 Author
-    Zeljko Tukovic, FSB Zagreb.  All rights reserved.
-    Philip Cardiff, UCD.  All rights reserved.
+    Zeljko Tukovic, FSB Zagreb.
+    Philip Cardiff, UCD.
 
 SourceFiles
     unsLinGeomSolid.C

--- a/src/solids4FoamModels/solidModels/unsNonLinGeomTotalLagSolid/unsNonLinGeomTotalLagSolid.H
+++ b/src/solids4FoamModels/solidModels/unsNonLinGeomTotalLagSolid/unsNonLinGeomTotalLagSolid.H
@@ -28,8 +28,8 @@ Description
     the face tangential gradient are calculated using a face-Gauss approach.
 
 Author
-    Zeljko Tukovic, FSB Zagreb.  All rights reserved.
-    Philip Cardiff, UCD.  All rights reserved.
+    Zeljko Tukovic, FSB Zagreb.
+    Philip Cardiff, UCD.
 
 SourceFiles
     unsNonLinGeomTotalLagSolid.C

--- a/src/solids4FoamModels/solidModels/unsNonLinGeomUpdatedLagSolid/unsNonLinGeomUpdatedLagSolid.H
+++ b/src/solids4FoamModels/solidModels/unsNonLinGeomUpdatedLagSolid/unsNonLinGeomUpdatedLagSolid.H
@@ -28,8 +28,8 @@ Description
     the face tangential gradient are calculated using a face-Gauss approach.
 
 Author
-    Zeljko Tukovic, FSB Zagreb.  All rights reserved.
-    Philip Cardiff, UCD.  All rights reserved.
+    Zeljko Tukovic, FSB Zagreb.
+    Philip Cardiff, UCD.
 
 SourceFiles
     unsNonLinGeomUpdatedLagSolid.C

--- a/src/solids4FoamModels/solidModels/vertexCentredLinGeomSolid/vertexCentredLinGeomSolid.H
+++ b/src/solids4FoamModels/solidModels/vertexCentredLinGeomSolid/vertexCentredLinGeomSolid.H
@@ -31,8 +31,8 @@ Description
     An implicit Newton-Raphson algorithm is employed.
 
 Author
-    Philip Cardiff, UCD.  All rights reserved.
-    Federico Mazzanti, UCD.  All rights reserved.
+    Philip Cardiff, UCD.
+    Federico Mazzanti, UCD.
 
 SourceFiles
     vertexCentredLinGeomSolid.C

--- a/src/solids4FoamModels/solidModels/weakThermalLinGeomSolid/weakThermalLinGeomSolid.H
+++ b/src/solids4FoamModels/solidModels/weakThermalLinGeomSolid/weakThermalLinGeomSolid.H
@@ -25,7 +25,7 @@ Description
     The stress is calculated by the run-time selectable mechanical law.
 
 Author
-    Philip Cardiff, UCD.  All rights reserved.
+    Philip Cardiff, UCD.
 
 SourceFiles
     weakThermalLinGeomSolid.C

--- a/tutorials/fluids/decayingTaylorGreenVortex/src/decayingTaylorGreenVortexFvPatchVectorField/patchCorrectionVectors.H
+++ b/tutorials/fluids/decayingTaylorGreenVortex/src/decayingTaylorGreenVortexFvPatchVectorField/patchCorrectionVectors.H
@@ -30,7 +30,7 @@ SourceFile
     patchCorrectionVectors.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/tutorials/solids/linearElasticity/cantilever2d/src/cantileverAnalytical/cantileverAnalytical.H
+++ b/tutorials/solids/linearElasticity/cantilever2d/src/cantileverAnalytical/cantileverAnalytical.H
@@ -34,7 +34,7 @@ SourceFile
     cantileverAnalytical.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/tutorials/solids/linearElasticity/cantilever2d/src/cantileverAnalyticalSolutionFunctionObject/cantileverAnalyticalSolution.H
+++ b/tutorials/solids/linearElasticity/cantilever2d/src/cantileverAnalyticalSolutionFunctionObject/cantileverAnalyticalSolution.H
@@ -32,7 +32,7 @@ Description
     The beam is L long and D deep (thick).
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 SourceFiles
     cantileverAnalyticalSolution.C

--- a/tutorials/solids/linearElasticity/cantilever2d/src/cantileverDisplacement/cantileverDisplacementFvPatchVectorField.H
+++ b/tutorials/solids/linearElasticity/cantilever2d/src/cantileverDisplacement/cantileverDisplacementFvPatchVectorField.H
@@ -35,7 +35,7 @@ SourceFiles
     cantileverDisplacementFvPatchVectorField.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 

--- a/tutorials/solids/linearElasticity/cantilever2d/src/cantileverTraction/cantileverTractionFvPatchVectorField.H
+++ b/tutorials/solids/linearElasticity/cantilever2d/src/cantileverTraction/cantileverTractionFvPatchVectorField.H
@@ -35,7 +35,7 @@ SourceFiles
     cantileverTractionFvPatchVectorField.C
 
 Author
-    Philip Cardiff, UCD. All rights reserved.
+    Philip Cardiff, UCD.
 
 \*---------------------------------------------------------------------------*/
 


### PR DESCRIPTION
## Motivation

  The repository uses GPL licensing, but a number of code headers still include `All rights reserved` notices. That wording is confusing in a GPL project and suggests a restriction that isn't intended. This change removes that ambiguity while preserving the original author attribution where needed.

  ## Summary

  - Removed `All rights reserved` from code headers outside `src/RBFMeshMotionSolver`.
  - Kept the existing author names and other attribution text.
  - Fixed the `FSB Zaregb` typo to `FSB Zagreb` in the affected headers and the review note.

  ## Verification

  - `git diff --check -- src applications tutorials`
  - Verified that `All rights reserved` now only remains in `src/RBFMeshMotionSolver`, where the clarifying GPL note is already present.
  - Verified that the mispelling `Zaregb` no longer appears in the repository.
