### PR TITLE
Added highOrder option for cantilever2d case

### DIFF
--- a/tutorials/solids/linearElasticity/cantilever2d/0/D.highOrder
+++ b/tutorials/solids/linearElasticity/cantilever2d/0/D.highOrder
@@ -1,0 +1,75 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| solids4foam: solid mechanics and fluid-solid interaction simulations        |
+| Version:     v2.3                                                           |
+| Web:         https://solids4foam.github.io                                  |
+| Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
+|              producer and distributor of the OpenFOAM software via          |
+|              www.openfoam.com, and owner of the OPENFOAM® and OpenCFD®      |
+|              trade marks.                                                   |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       volVectorField;
+    location    "0";
+    object      D;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+dimensions      [0 1 0 0 0 0 0];
+
+internalField   uniform (0 0 0);
+
+boundaryField
+{
+    right
+    {
+        type            cantileverTraction;
+        P               0.1e6;
+        E               200e9;
+        nu              0.3;
+        L               2.0;
+        D               0.1;
+        value           uniform (0 0 0);
+    }
+
+    top
+    {
+        type            solidTraction;
+        traction        uniform ( 0 0 0 );
+        pressure        uniform 0;
+        value           uniform (0 0 0);
+    }
+
+    bottom
+    {
+        type            solidTraction;
+        traction        uniform ( 0 0 0 );
+        pressure        uniform 0;
+        value           uniform (0 0 0);
+    }
+
+    left
+    {
+        type            cantileverDisplacement;
+        P               0.1e6;
+        E               200e9;
+        nu              0.3;
+        L               2.0;
+        D               0.1;
+        value           uniform (0 0 0);
+    }
+
+    back
+    {
+         type            empty;
+    }
+
+    front
+    {
+         type            empty;
+    }
+}
+
+// ************************************************************************* //

--- a/tutorials/solids/linearElasticity/cantilever2d/Allclean
+++ b/tutorials/solids/linearElasticity/cantilever2d/Allclean
@@ -8,7 +8,9 @@ source solids4FoamScripts.sh
 
 wclean lib src
 
+[ -f constant/polyMesh/blockMeshDict ] && cp constant/polyMesh/blockMeshDict system/
 cleanCase
+[ -f system/blockMeshDict ] && mkdir -p constant/polyMesh && cp system/blockMeshDict constant/polyMesh/
 
 # Convert case version to FOAM EXTEND
 solids4Foam::convertCaseFormatFoamExtend .

--- a/tutorials/solids/linearElasticity/cantilever2d/Allrun
+++ b/tutorials/solids/linearElasticity/cantilever2d/Allrun
@@ -18,12 +18,14 @@ Where [approach] is one of:
   vertexCentred
   segregated
   unsCoupled
+  highOrder
 
 Examples:
   ./Allrun
   ./Allrun vertexCentred
   ./Allrun segregated
   ./Allrun unsCoupled
+  ./Allrun highOrder
 EOF
 }
 
@@ -50,7 +52,7 @@ APPROACH="${1:-petscSnes}"
 
 # Validate approach name
 case "$APPROACH" in
-    petscSnes|vertexCentred|segregated|unsCoupled) ;;
+    petscSnes|vertexCentred|segregated|unsCoupled|highOrder) ;;
     *)
         echo "Error: Unknown approach '$APPROACH'"
         usage
@@ -68,6 +70,7 @@ link_files_for_suffix() {
     local found=0
     while IFS= read -r -d '' f; do
         found=1
+        rm -f "${f%.*}"
         ln -vnsf "$(basename "$f")" "${f%.*}"
     done < <(find ./0 ./constant ./system -type f -name "*.${suffix}" -print0 2>/dev/null || true)
 
@@ -78,7 +81,7 @@ link_files_for_suffix() {
 
 require_petsc_or_exit_silently() {
     case "$APPROACH" in
-        petscSnes|vertexCentred)
+        petscSnes|vertexCentred|highOrder)
             if [[ -z "${PETSC_DIR:-}" ]]
             then
                 echo; echo "Skipping this case as PETSc is not installed"
@@ -104,9 +107,14 @@ select_approach() {
             solids4Foam::caseOnlyRunsWithFoamExtend
             link_files_for_suffix "unsCoupled"
             ;;
-        petscSnes|*)
+        petscSnes)
             echo "Using the petscSnes approach"
             link_files_for_suffix "petscSnes"
+            ;;
+        highOrder)
+            echo "Using the highOrder approach"
+            solids4Foam::caseDoesNotRunWithFoamExtend
+            link_files_for_suffix "highOrder"
             ;;
     esac
 }

--- a/tutorials/solids/linearElasticity/cantilever2d/README.md
+++ b/tutorials/solids/linearElasticity/cantilever2d/README.md
@@ -188,5 +188,6 @@ Table 1 lists the wall-clock times rounded to the nearest second for the
  methodology for linear elasticity and unstructured meshes. *Computers and Structures*,
  175, 2016, 100–122, 10.1016/j.compstruc.2016.07.004.](https://doi.org/10.1016/j.compstruc.2016.07.004)
 
-[5] [I. Batistić, P. Castrillo, P. Cardiff, A Jacobian-free Newton-Krylov method for high-order cell-centred finite volume solid mechanics. *arXiv preprint arXiv:2601.18417*,
- 2026.](https://arxiv.org/abs/2601.18417)
+[5] [I. Batistić, P. Castrillo, P. Cardiff, A Jacobian-free Newton-Krylov
+method for high-order cell-centred finite volume solid mechanics.
+*arXiv preprint arXiv:2601.18417*, 2026.](https://arxiv.org/abs/2601.18417)

--- a/tutorials/solids/linearElasticity/cantilever2d/README.md
+++ b/tutorials/solids/linearElasticity/cantilever2d/README.md
@@ -14,6 +14,7 @@ Prepared by Philip Cardiff
   bending.
 - Compare the performance of cell-centred and vertex-centred discretisatins and
   segregated and coupled solution algorithms for bending dominated scenarios.
+- Demonstrate how to set up a high-order cell-centred discretisation.
 - Demonstrates the slow convergence of the solution algorithm for high aspect
   ratio geometry undergoing bending.
 
@@ -77,7 +78,7 @@ functions
 ```
 
 In solids4foam, there are several solid models which can solve this problem;
- here, four approaches are considered:
+ here, five approaches are considered:
 
 1. A **cell-centred** finite volume approach with a **Jacobian-free Newton-Krylov**
    solution algorithm [2]. This is the default approach in the case, and is
@@ -96,6 +97,16 @@ In solids4foam, there are several solid models which can solve this problem;
 4. A **cell-centred** finite volume approach with an **exact Jacobian coupled**
    solution algorithm [4].  This approach is selected by specifying `solidModel coupledUnsLinearGeometryLinearElastic;`
    in `constant/solidProperties`.
+5. A **cell-centred high-order** finite volume approach with a **Jacobian-free Newton-Krylov**
+   solution algorithm. This approach uses the `linearGeometryTotalDisplacement`
+   solid model with `solutionAlgorithm PETScSNES;` and a high-order residual calculation
+   [5]. It is selected by specifying `solidModel linearGeometryTotalDisplacement;`
+   in `constant/solidProperties`, with `highOrderResidual true;` in the
+   `highOrderCoeffs` sub-dictionary. When `highOrderJacobian false;` is used,
+   the solver uses the same second-order Laplacian as approach 1 as a physical
+   preconditioner. Alternatively, `highOrderJacobian true;` can be used to
+   assemble the high-order Jacobian; this affects the timing but not the
+   accuracy.
 
 ```note
 Approach 4 uses simplified uniform displacement (left) and uniform traction
@@ -118,6 +129,7 @@ The tutorial case is located at `solids4foam/tutorials/solids/linearElasticity/c
 ./Allrun segregated     # Approach 2
 ./Allrun vertexCentred  # Approach 3
 ./Allrun unsCoupled     # Approach 4
+./Allrun highOrder      # Approach 5
 ```
 
 The `Allrun` script starts by updating the files in the case to match the
@@ -153,6 +165,7 @@ Table 1 lists the wall-clock times rounded to the nearest second for the
 | 2        | 5120           | 123         |
 | 3        | 5120           | 1           |
 | 4        | 5120           | -           |
+| 5        | 5120           | 1           |
 
 ---
 
@@ -163,8 +176,9 @@ Table 1 lists the wall-clock times rounded to the nearest second for the
  44, 2008, 595–601, 10.1016/j.finel.2008.01.010.](http://www.doi.org/10.1016/j.finel.2008.01.010)
 
 [2] [P. Cardiff, D. Armfield, Ž. Tuković, I. Batistić, A Jacobian-free Newton–Krylov
- method for cell-centred finite volume solid mechanics. *arXiv preprint arXiv:2502.17217*,
- 2025.](https://arxiv.org/abs/2502.17217)
+ method for cell-centred finite volume solid mechanics. *International Journal for
+ Numerical Methods in Engineering*, 127, e70268, 2026,
+ 10.1002/nme.70268.](https://doi.org/10.1002/nme.70268)
 
 [3] [F. Mazzanti, P. Cardiff, Performance of a vertex-centred block-coupled finite
  volume methodology for small-strain static elastoplasticity. *Computers and Mathematics
@@ -173,3 +187,6 @@ Table 1 lists the wall-clock times rounded to the nearest second for the
 [4] [P. Cardiff, Ž. Tuković, H. Jasak, A. Ivanković, A block-coupled finite volume
  methodology for linear elasticity and unstructured meshes. *Computers and Structures*,
  175, 2016, 100–122, 10.1016/j.compstruc.2016.07.004.](https://doi.org/10.1016/j.compstruc.2016.07.004)
+
+[5] [I. Batistić, P. Castrillo, P. Cardiff, A Jacobian-free Newton-Krylov method for high-order cell-centred finite volume solid mechanics. *arXiv preprint arXiv:2601.18417*,
+ 2026.](https://arxiv.org/abs/2601.18417)

--- a/tutorials/solids/linearElasticity/cantilever2d/constant/solidProperties.highOrder
+++ b/tutorials/solids/linearElasticity/cantilever2d/constant/solidProperties.highOrder
@@ -1,0 +1,60 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| solids4foam: solid mechanics and fluid-solid interaction simulations        |
+| Version:     v2.3                                                           |
+| Web:         https://solids4foam.github.io                                  |
+| Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
+|              producer and distributor of the OpenFOAM software via          |
+|              www.openfoam.com, and owner of the OPENFOAM® and OpenCFD®      |
+|              trade marks.                                                   |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "constant";
+    object      solidProperties;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+solidModel     linearGeometryTotalDisplacement;
+
+linearGeometryTotalDisplacementCoeffs
+{
+    // Solution algorithm
+    solutionAlgorithm    PETScSNES;
+
+    highOrderCoeffs
+    {
+        highOrderJacobian false;
+        highOrderResidual true;
+
+        displacement
+        {
+            // Polynomial order of displacement field
+            polynomialOrder 3;
+
+            // Extra cells in minimum size stencil
+            faceStencilExtraCells 15;
+
+            // Weight function for least square systems
+            weightFunctionCoeffs
+            {
+                type radiallySymmetricExponential;
+                k 6;
+            }
+            calcConditionNumber false;
+        }
+    }
+
+    stabilisation
+    {
+        momentum
+        {
+            type        alpha;
+            scaleFactor 0.1;
+        }
+    }
+}
+
+// ************************************************************************* //

--- a/tutorials/solids/linearElasticity/cantilever2d/regressionTest.sh
+++ b/tutorials/solids/linearElasticity/cantilever2d/regressionTest.sh
@@ -14,8 +14,8 @@ fi
 
 # ============================================================
 # cantilever2d regression test
-# Uses the fast default PETSc-SNES path and checks the final
-# solver extrema against the analytical benchmark output.
+# Checks selected solution approaches against the analytical
+# benchmark output.
 # ============================================================
 
 EPS_MIN=3.5e-4
@@ -25,6 +25,11 @@ SIGMA_MAX=1.05e8
 
 SOLVER_LOGFILE="log.solids4Foam"
 ALLRUN_LOGFILE="log.Allrun"
+
+APPROACHES=(
+    petscSnes
+    highOrder
+)
 
 echo "============================================================"
 echo "cantilever2d regression test"
@@ -74,14 +79,8 @@ done
 
 if [ "$CHECK_ONLY" = false ]; then
     prepare_case
-    ( cd "${CASE_DIR}" && ./Allrun > "${ALLRUN_LOGFILE}" 2>&1 )
 else
     echo "Running in check-only mode: skipping Allclean and Allrun"
-fi
-
-if solids4Foam::regressionCaseSkipped "${CASE_DIR}/${ALLRUN_LOGFILE}"; then
-    echo "Skipping regression checks because the tutorial skipped in this environment"
-    exit 0
 fi
 
 extract_max_epsilon() {
@@ -96,28 +95,67 @@ extract_max_sigma() {
         | awk '{print $NF}' || true
 }
 
-epsilon=$(extract_max_epsilon)
-sigma=$(extract_max_sigma)
+check_solver_extrema() {
+    local approach="$1"
+    local epsilon
+    local sigma
+    local failures=0
 
-if [[ -z "${epsilon}" || -z "${sigma}" ]]; then
-    echo "FAIL: Could not extract one or more regression quantities"
-    exit 1
-fi
+    epsilon=$(extract_max_epsilon)
+    sigma=$(extract_max_sigma)
+
+    if [[ -z "${epsilon}" || -z "${sigma}" ]]; then
+        echo "FAIL: Could not extract one or more regression quantities for ${approach}"
+        return 1
+    fi
+
+    if awk "BEGIN {exit !(${epsilon} >= ${EPS_MIN} && ${epsilon} <= ${EPS_MAX})}"; then
+        printf "PASS: Max epsilonEq = %.6g\n" "${epsilon}"
+    else
+        printf "FAIL: Max epsilonEq = %.6g\n" "${epsilon}"
+        failures=$((failures + 1))
+    fi
+
+    if awk "BEGIN {exit !(${sigma} >= ${SIGMA_MIN} && ${sigma} <= ${SIGMA_MAX})}"; then
+        printf "PASS: Max sigmaEq = %.6g\n" "${sigma}"
+    else
+        printf "FAIL: Max sigmaEq = %.6g\n" "${sigma}"
+        failures=$((failures + 1))
+    fi
+
+    return "${failures}"
+}
 
 failures=0
 
-if awk "BEGIN {exit !(${epsilon} >= ${EPS_MIN} && ${epsilon} <= ${EPS_MAX})}"; then
-    printf "PASS: Max epsilonEq = %.6g\n" "${epsilon}"
-else
-    printf "FAIL: Max epsilonEq = %.6g\n" "${epsilon}"
-    failures=$((failures + 1))
-fi
+if [ "$CHECK_ONLY" = false ]; then
+    for approach in "${APPROACHES[@]}"; do
+        echo
+        echo "------------------------------------------------------------"
+        echo "Testing approach: ${approach}"
+        echo "------------------------------------------------------------"
 
-if awk "BEGIN {exit !(${sigma} >= ${SIGMA_MIN} && ${sigma} <= ${SIGMA_MAX})}"; then
-    printf "PASS: Max sigmaEq = %.6g\n" "${sigma}"
+        ( cd "${CASE_DIR}" && ./Allclean > /dev/null 2>&1 ) || true
+        ( cd "${CASE_DIR}" && ./Allrun "${approach}" > "${ALLRUN_LOGFILE}" 2>&1 )
+
+        if solids4Foam::regressionCaseSkipped "${CASE_DIR}/${ALLRUN_LOGFILE}"; then
+            echo "Skipping ${approach} because it is unavailable in this environment"
+            continue
+        fi
+
+        if ! check_solver_extrema "${approach}"; then
+            failures=$((failures + 1))
+        fi
+    done
 else
-    printf "FAIL: Max sigmaEq = %.6g\n" "${sigma}"
-    failures=$((failures + 1))
+    if solids4Foam::regressionCaseSkipped "${CASE_DIR}/${ALLRUN_LOGFILE}"; then
+        echo "Skipping regression checks because the tutorial skipped in this environment"
+        exit 0
+    fi
+
+    if ! check_solver_extrema "check-only"; then
+        failures=$((failures + 1))
+    fi
 fi
 
 if [ "$CHECK_ONLY" = false ]; then

--- a/tutorials/solids/linearElasticity/cantilever2d/src/Allwmake
+++ b/tutorials/solids/linearElasticity/cantilever2d/src/Allwmake
@@ -1,4 +1,10 @@
 #!/bin/bash
 cd "${0%/*}" || exit  # Run from this directory
 
+if [[ -n "${S4F_NO_USE_EIGEN:-}" ]]; then
+    echo "Eigen is required to compile this local library"
+    echo "Unset S4F_NO_USE_EIGEN and rebuild solids4foam"
+    exit 1
+fi
+
 wmake $* libso

--- a/tutorials/solids/linearElasticity/cantilever2d/src/Make/options
+++ b/tutorials/solids/linearElasticity/cantilever2d/src/Make/options
@@ -4,9 +4,12 @@ sinclude $(SOLIDS4FOAM_ROOT)/etc/wmake-options
 sinclude $(SOLIDS4FOAM_ROOT)/../etc/wmake-options
 
 EXE_INC = \
+    -Wno-old-style-cast -Wno-deprecated-declarations \
     $(VERSION_SPECIFIC_INC) \
     -I$(SOLIDS4FOAM_ROOT)/src/solids4FoamModels/lnInclude \
     -I$(SOLIDS4FOAM_ROOT)/src/solids4FoamModels/numerics/compatibilityFunctions \
+    -I$(SOLIDS4FOAM_ROOT)/src/blockCoupledSolids4FoamTools/lnInclude \
+    -I$(SOLIDS4FOAM_ROOT)/ThirdParty/eigen3 \
     -I$(LIB_SRC)/finiteVolume/lnInclude \
     -I$(LIB_SRC)/meshTools/lnInclude \
     -I$(LIB_SRC)/finiteArea/lnInclude \
@@ -14,6 +17,7 @@ EXE_INC = \
     -I$(LIB_SRC)/dynamicMesh/lnInclude \
     -I$(LIB_SRC)/dynamicMesh/dynamicMesh/lnInclude \
     -I$(LIB_SRC)/dynamicMesh/dynamicFvMesh/lnInclude \
+    -I$(LIB_SRC)/dynamicFvMesh/lnInclude \
     -I$(LIB_SRC)/dynamicMesh/topoChangerFvMesh/lnInclude \
     -I$(LIB_SRC)/sampling/lnInclude \
     -I$(LIB_SRC)/surfMesh/lnInclude \

--- a/tutorials/solids/linearElasticity/cantilever2d/src/cantileverAnalytical/cantileverAnalytical.C
+++ b/tutorials/solids/linearElasticity/cantilever2d/src/cantileverAnalytical/cantileverAnalytical.C
@@ -100,6 +100,12 @@ Foam::tmp<Foam::vectorField> Foam::cantileverAnalytical::displacement
     const vectorField& locations
 ) const
 {
+    if (E_ < SMALL || L_ < SMALL || D_ < SMALL || I_ < SMALL)
+    {
+        FatalErrorInFunction
+            << "E, L, D and I must be greater than 0!" << exit(FatalError);
+    }
+
     // Prepare the result field
     tmp<vectorField> tresult(new vectorField(locations.size(), vector::zero));
     vectorField& result = tmpRef(tresult);

--- a/tutorials/solids/linearElasticity/cantilever2d/src/cantileverAnalytical/cantileverAnalytical.C
+++ b/tutorials/solids/linearElasticity/cantilever2d/src/cantileverAnalytical/cantileverAnalytical.C
@@ -100,12 +100,6 @@ Foam::tmp<Foam::vectorField> Foam::cantileverAnalytical::displacement
     const vectorField& locations
 ) const
 {
-    if (E_ < SMALL || L_ < SMALL || D_ < SMALL || I_ < SMALL)
-    {
-        FatalErrorInFunction
-            << "E, L, D and I must be greater than 0!" << exit(FatalError);
-    }
-
     // Prepare the result field
     tmp<vectorField> tresult(new vectorField(locations.size(), vector::zero));
     vectorField& result = tmpRef(tresult);

--- a/tutorials/solids/linearElasticity/cantilever2d/src/cantileverAnalyticalSolutionFunctionObject/cantileverAnalyticalSolution.H
+++ b/tutorials/solids/linearElasticity/cantilever2d/src/cantileverAnalyticalSolutionFunctionObject/cantileverAnalyticalSolution.H
@@ -28,6 +28,7 @@ Description
     Design, 44, 2008, 595–601, 10.1016/j.finel.2008.01.010.
 
     It is assumed that the origin is at the centre of the fixed patch.
+    Empty direction is z-axis.
 
     The beam is L long and D deep (thick).
 

--- a/tutorials/solids/linearElasticity/cantilever2d/src/cantileverDisplacement/cantileverDisplacementFvPatchVectorField.C
+++ b/tutorials/solids/linearElasticity/cantilever2d/src/cantileverDisplacement/cantileverDisplacementFvPatchVectorField.C
@@ -22,6 +22,7 @@ InClass
 
 #include "cantileverDisplacementFvPatchVectorField.H"
 #include "addToRunTimeSelectionTable.H"
+#include "lookupSolidModel.H"
 
 
 // * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
@@ -150,6 +151,57 @@ void Foam::cantileverDisplacementFvPatchVectorField::updateCoeffs()
 
     fixedValueFvPatchVectorField::updateCoeffs();
 }
+
+
+#ifndef FOAMEXTEND
+Foam::autoPtr<Foam::CompactListList<Foam::vector>>
+Foam::cantileverDisplacementFvPatchVectorField::evaluateQuadrature
+() const
+{
+    const fvMesh& mesh = patch().boundaryMesh().mesh();
+    const solidModel& solMod = lookupSolidModel(mesh);
+
+    // faceQuadPoints is list for the  whole mesh
+    const CompactListList<point>& faceQuadPoints =
+        solMod.displacementMLS().quadrature().faceQuadPoints();
+
+    // faceQuadPoints is list for whole mesh.
+    labelList nQpPerFace(this->size(), 0);
+    const label start = this->patch().start();
+    forAll(nQpPerFace, faceI)
+    {
+        const label globalFaceID = faceI + start;
+        nQpPerFace[faceI] = faceQuadPoints[globalFaceID].size();
+    }
+
+    autoPtr<CompactListList<vector>> tQuadPointsValue
+    (
+        new CompactListList<vector>(nQpPerFace)
+    );
+
+    // Get a reference to the actual data for easier access
+    CompactListList<vector>& quadPointsValue = tQuadPointsValue();
+
+    // Loop over faces
+    forAll(*this, faceI)
+    {
+        const label globalFaceID = faceI + start;
+
+        // Get the number of quadrature points for this face
+        const label nPoints = faceQuadPoints[globalFaceID].size();
+
+        // Assign the values to face quadrature points
+        for (label pointI = 0; pointI < nPoints; ++pointI)
+        {
+            const point quadPoint = faceQuadPoints[globalFaceID][pointI];
+            quadPointsValue[faceI][pointI] =
+                analyticalSol_.displacement(quadPoint);
+        }
+    }
+
+    return tQuadPointsValue;
+}
+#endif
 
 
 void Foam::cantileverDisplacementFvPatchVectorField::write(Ostream& os) const

--- a/tutorials/solids/linearElasticity/cantilever2d/src/cantileverDisplacement/cantileverDisplacementFvPatchVectorField.H
+++ b/tutorials/solids/linearElasticity/cantilever2d/src/cantileverDisplacement/cantileverDisplacementFvPatchVectorField.H
@@ -166,6 +166,12 @@ public:
             //- Update the coefficients associated with the patch field
             virtual void updateCoeffs();
 
+#ifndef FOAMEXTEND
+            //- Return face quadrature values
+            //  Used for high order solvers
+            virtual autoPtr<CompactListList<vector>>
+            evaluateQuadrature() const;
+#endif
 
         // Member functions
 

--- a/tutorials/solids/linearElasticity/cantilever2d/src/cantileverTraction/cantileverTractionFvPatchVectorField.C
+++ b/tutorials/solids/linearElasticity/cantilever2d/src/cantileverTraction/cantileverTractionFvPatchVectorField.C
@@ -23,6 +23,7 @@ InClass
 #include "cantileverTractionFvPatchVectorField.H"
 #include "addToRunTimeSelectionTable.H"
 #include "GeometricFields.H"
+#include "lookupSolidModel.H"
 
 
 // * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
@@ -165,6 +166,55 @@ void Foam::cantileverTractionFvPatchVectorField::updateCoeffs()
 }
 
 
+#ifndef FOAMEXTEND
+Foam::autoPtr<Foam::CompactListList<Foam::vector>>
+Foam::cantileverTractionFvPatchVectorField::evaluateQuadrature
+() const
+{
+    const fvMesh& mesh = patch().boundaryMesh().mesh();
+    const solidModel& solMod = lookupSolidModel(mesh);
+
+    // faceQuadPoints is list for the  whole mesh
+    const CompactListList<point>& faceQuadPoints =
+        solMod.displacementMLS().quadrature().faceQuadPoints();
+
+    // faceQuadPoints is list for whole mesh.
+    labelList nQpPerFace(this->size(), 0);
+    const label start = this->patch().start();
+    forAll(nQpPerFace, faceI)
+    {
+        const label globalFaceID = faceI + start;
+        nQpPerFace[faceI] = faceQuadPoints[globalFaceID].size();
+    }
+
+    autoPtr<CompactListList<vector>> tQuadPointsValue
+    (
+        new CompactListList<vector>(nQpPerFace)
+    );
+
+    // Get a reference to the actual data for easier access
+    CompactListList<vector>& quadPointsValue = tQuadPointsValue();
+
+    // Loop over faces
+    forAll(*this, faceI)
+    {
+        const label globalFaceID = faceI + start;
+
+        // Get the number of quadrature points for this face
+        const label nPoints = faceQuadPoints[globalFaceID].size();
+
+        // Assign the values to face quadrature points
+        for (label pointI = 0; pointI < nPoints; ++pointI)
+        {
+            const point quadPoint = faceQuadPoints[globalFaceID][pointI];
+            quadPointsValue[faceI][pointI] =
+                analyticalSol_.traction(quadPoint);
+        }
+    }
+
+    return tQuadPointsValue;
+}
+#endif
 
 
 void Foam::cantileverTractionFvPatchVectorField::write(Ostream& os) const

--- a/tutorials/solids/linearElasticity/cantilever2d/src/cantileverTraction/cantileverTractionFvPatchVectorField.H
+++ b/tutorials/solids/linearElasticity/cantilever2d/src/cantileverTraction/cantileverTractionFvPatchVectorField.H
@@ -145,6 +145,13 @@ public:
 
     // Member functions
 
+#ifndef FOAMEXTEND
+            //- Return face quadrature values
+            //  Used for high order solvers
+            virtual autoPtr<CompactListList<vector>>
+            evaluateQuadrature() const;
+#endif
+
         // Mapping functions
 
             //- Map (and resize as needed) from self given a mapping object

--- a/tutorials/solids/linearElasticity/cantilever2d/system/fvSchemes.highOrder
+++ b/tutorials/solids/linearElasticity/cantilever2d/system/fvSchemes.highOrder
@@ -1,0 +1,58 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| solids4foam: solid mechanics and fluid-solid interaction simulations        |
+| Version:     v2.3                                                           |
+| Web:         https://solids4foam.github.io                                  |
+| Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
+|              producer and distributor of the OpenFOAM software via          |
+|              www.openfoam.com, and owner of the OPENFOAM® and OpenCFD®      |
+|              trade marks.                                                   |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "system";
+    object      fvSchemes;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+d2dt2Schemes
+{
+    default                 steadyState;
+}
+
+ddtSchemes
+{
+    default                 steadyState;
+}
+
+gradSchemes
+{
+     default                none;
+     grad(D)                leastSquaresS4f;
+}
+
+divSchemes
+{
+    default                 none;
+    div(sigma)              Gauss linear;
+    div((impK*grad(D)))     Gauss linear;
+}
+
+laplacianSchemes
+{
+    default                 Gauss linear corrected;
+}
+
+snGradSchemes
+{
+    default                 corrected;
+}
+
+interpolationSchemes
+{
+    default                 linear;
+}
+
+// ************************************************************************* //

--- a/tutorials/solids/linearElasticity/cantilever2d/system/fvSolution.highOrder
+++ b/tutorials/solids/linearElasticity/cantilever2d/system/fvSolution.highOrder
@@ -1,0 +1,45 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| solids4foam: solid mechanics and fluid-solid interaction simulations        |
+| Version:     v2.3                                                           |
+| Web:         https://solids4foam.github.io                                  |
+| Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
+|              producer and distributor of the OpenFOAM software via          |
+|              www.openfoam.com, and owner of the OPENFOAM® and OpenCFD®      |
+|              trade marks.                                                   |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "system";
+    object      fvSolution;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+solvers
+{
+    D
+    {
+        solver          petsc;
+
+        options
+        {
+            snes_type newtonls;
+            snes_monitor;
+            snes_converged_reason;
+            snes_mf;
+            snes_mf_operator;
+
+            ksp_type lgmres;
+            ksp_gmres_restart "100";
+            ksp_converged_reason;
+
+            pc_type lu;
+            snes_lag_preconditioner_persists true;
+            snes_lag_preconditioner "-2";
+        }
+    }
+}
+
+// ************************************************************************* //


### PR DESCRIPTION
## Pull Request Description

  This pull request adds a high-order tutorial workflow for `tutorials/solids/linearElasticity/cantilever2d`.

  The case can now be run with:
  - `./Allrun highOrder`

The high-order path uses the corresponding tutorial dictionaries and a local `src/` library with the analytical displacement/stress function object. The README and regression test were updated accordingly.

  ## Related Issues and Discussions

  None.

  ## Changes Made

  - Updated `Allrun` to support `highOrder`
  - Updated `README.md` 
  - Updated `regressionTest.sh` to test the petscSnes and high-order approach

  ### Summary of Changes

  - **Files Modified**: `Allrun`, `README.md`, `regressionTest.sh`, `src/`
  - **Behavioural Changes**: adds a new `highOrder` tutorial path without changing the default `Allrun` behaviour

  ## Checklist

  - [x] Code compiles successfully with v2412 and OF9
  - [x] Added relevant documentation for the new tutorial option
  - [x] The PR targets the `development` branch
  - [x] Code follows the project's style and conventions

  ## Test Cases and Results

  - **Case Name**: `tutorials/solids/linearElasticity/cantilever2d`
  - **Results**: regression checks pass with v2412 and of9 (localy)

  ## Additional Notes

  This PR is tutorial-only and does not change solver behaviour outside the case setup.