### PR TITLE
Fix nonlinear pressure gradient Jacobian scaling

### DIFF
--- a/src/solids4FoamModels/solidModels/nonLinGeomTotalLagTotalDispSolid/nonLinGeomTotalLagTotalDispSolid.C
+++ b/src/solids4FoamModels/solidModels/nonLinGeomTotalLagTotalDispSolid/nonLinGeomTotalLagTotalDispSolid.C
@@ -1159,10 +1159,10 @@ label nonLinGeomTotalLagTotalDispSolid::formJacobian
                 pressureEqnScale_           // scale (helper returns -V*div with +1)
             );
 
-            // Insert p-in-D term. InsertFvmGrad's updated sign
-            // convention: scale=+1 assembles `-V*grad(p)`. Apply the
-            // pressure-unknown scale so the column corresponds to the
-            // scaled unknown pHat = p/pressureUnknownScale_.
+            // Insert p-in-D term. InsertFvmGradIntoPETScMatrix uses the
+            // least-squares gradient convention where scale=-1 assembles
+            // `-V*grad(p)`. Apply the pressure-unknown scale so the column
+            // corresponds to the scaled unknown pHat = p/pressureUnknownScale_.
             foamPetscSnesHelper::InsertFvmGradIntoPETScMatrix
             (
                 p,
@@ -1170,7 +1170,7 @@ label nonLinGeomTotalLagTotalDispSolid::formJacobian
                 0,                          // row offset
                 blockSize_ - 1,             // column offset
                 solidModel::twoD() ? 2 : 3, // number of D components
-                pressureUnknownScale_       // scale (helper returns -V*grad with +1)
+                -pressureUnknownScale_      // scale for -V*grad(pHat)
             );
         }
     }

--- a/src/solids4FoamModels/solidModels/nonLinGeomUpdatedLagSolid/nonLinGeomUpdatedLagSolid.C
+++ b/src/solids4FoamModels/solidModels/nonLinGeomUpdatedLagSolid/nonLinGeomUpdatedLagSolid.C
@@ -1115,11 +1115,10 @@ label nonLinGeomUpdatedLagSolid::formJacobian
             pressureEqnScale_           // scale (helper returns -V*div with +1)
         );
 
-        // Insert p-in-DD term. InsertFvmGrad's updated sign
-        // convention: scale=+1 assembles `-V*grad(p)` (matching the
-        // momentum equation contribution of -grad(p)). Apply the
-        // pressure-unknown scale so the column corresponds to the
-        // scaled unknown pHat = p/pressureUnknownScale_.
+        // Insert p-in-DD term. InsertFvmGradIntoPETScMatrix uses the
+        // least-squares gradient convention where scale=-1 assembles
+        // `-V*grad(p)`. Apply the pressure-unknown scale so the column
+        // corresponds to the scaled unknown pHat = p/pressureUnknownScale_.
         foamPetscSnesHelper::InsertFvmGradIntoPETScMatrix
         (
             p,
@@ -1127,7 +1126,7 @@ label nonLinGeomUpdatedLagSolid::formJacobian
             0,                          // row offset
             blockSize_ - 1,             // column offset
             solidModel::twoD() ? 2 : 3, // number of DD components
-            pressureUnknownScale_       // scale (helper returns -V*grad with +1)
+            -pressureUnknownScale_      // scale for -V*grad(pHat)
         );
     }
 


### PR DESCRIPTION
• - Fixes the nonlinear mixed pressure-displacement PETSc Jacobian scaling.
  - Affected models:
      - nonLinGeomTotalLagTotalDispSolid
      - nonLinGeomUpdatedLagSolid
  - The pressure unknown is stored in PETSc as:

    pHat = p/pressureUnknownScale_

  - The pressure-to-displacement Jacobian block therefore still needs the pressure unknown scale, but must preserve the correct -V*grad(p) sign.
  - The previous port passed a positive scale to InsertFvmGradIntoPETScMatrix, but that helper’s least-squares convention uses scale = -1 to assemble -V*grad(p).
  - Changed the pressure-gradient Jacobian scale from:

    pressureUnknownScale_

    to:

    -pressureUnknownScale_

  - Updated the nearby comments to clarify that InsertFvmGradIntoPETScMatrix uses the least-squares gradient convention where scale = -1 assembles -V*grad(p).
  - This makes the nonlinear models consistent with the intended PETSc pressure scaling while correcting the sign of the J_Dp block.


Seems to be working now for the Land 2 test case - though I am waiting for the finer meshes to finish running - but meshes 1 and 2 were much faster and have not crashed like the were doing previously.
