### PR TITLE
macOS portability, electroMechanicalLaw refactor, fvOptions body force

### DIFF
--- a/applications/scripts/solids4FoamScripts.sh
+++ b/applications/scripts/solids4FoamScripts.sh
@@ -51,6 +51,12 @@ function solids4Foam::convertCaseFormat()
     if sed --version 2>/dev/null | grep -q "GNU sed"
     then
         echo "GNU sed detected"
+        local _SED=sed
+    elif { _gsed=$(command -v gsed 2>/dev/null || echo /opt/homebrew/bin/gsed); } \
+         && [ -x "$_gsed" ] && "$_gsed" --version 2>/dev/null | grep -q "GNU sed"
+    then
+        echo "GNU sed (gsed) detected"
+        local _SED="$_gsed"
     else
         echo "Error: This script requires GNU sed. Please install it (e.g.,"
         echo "via Homebrew: 'brew install gnu-sed') and use 'gsed' instead."
@@ -62,19 +68,19 @@ function solids4Foam::convertCaseFormat()
     if [[ -n $(find "${CASE_DIR}" -name blockMeshDict*) ]]
     then
         echo "Changing symmetryPlane to symmetry in blockMeshDict"; echo
-        find "${CASE_DIR}" -name blockMeshDict* | xargs sed -i 's\symmetryPlane\symmetry\g'
+        find "${CASE_DIR}" -name blockMeshDict* | xargs "${_SED}" -i 's\symmetryPlane\symmetry\g'
     fi
 
     if [[ -n $(find "${CASE_DIR}" -name boundary) ]]
     then
         echo "Changing symmetryPlane to symmetry in boundary"; echo
-        find "${CASE_DIR}" -name boundary | xargs sed -i 's\symmetryPlane\symmetry\g'
+        find "${CASE_DIR}" -name boundary | xargs "${_SED}" -i 's\symmetryPlane\symmetry\g'
     fi
 
     if [[ -n $(find "${CASE_DIR}" -name createPatchDict) ]]
     then
         echo "Changing symmetryPlane to symmetry in createPatchDict"; echo
-        find "${CASE_DIR}" -name createPatchDict | xargs sed -i 's\symmetryPlane\symmetry\g'
+        find "${CASE_DIR}" -name createPatchDict | xargs "${_SED}" -i 's\symmetryPlane\symmetry\g'
     fi
 
     # Check all files in the 0 directory
@@ -85,7 +91,7 @@ function solids4Foam::convertCaseFormat()
             if grep -q "symmetryPlane;" "${FILE}"
             then
                 echo "Changing symmetryPlane to symmetry in ${FILE}"; echo
-                sed -i 's\symmetryPlane;\symmetry;\g' "${FILE}"
+                "${_SED}" -i 's\symmetryPlane;\symmetry;\g' "${FILE}"
             fi
         fi
     done
@@ -129,7 +135,7 @@ function solids4Foam::convertCaseFormat()
     if [[ -n $(find "${CASE_DIR}" -name turbulenceProperties) ]]
     then
         echo "Changing RASModel to RAS in turbulenceProperties"
-        find "${CASE_DIR}" -name turbulenceProperties | xargs sed -i "s/RASModel;/RAS;/g"
+        find "${CASE_DIR}" -name turbulenceProperties | xargs "${_SED}" -i "s/RASModel;/RAS;/g"
     fi
 
     # 4. Check for boundaryData
@@ -148,10 +154,10 @@ function solids4Foam::convertCaseFormat()
         if [[ -f "${CASE_DIR}"/system/sample ]]
         then
            echo "OpenFOAM.org specific: replacing 'uniform' with 'lineUniform' in system/sample"
-           sed -i "s/type.*uniform;/type lineUniform;/g" "${CASE_DIR}"/system/sample
+           "${_SED}" -i "s/type.*uniform;/type lineUniform;/g" "${CASE_DIR}"/system/sample
 
            echo "OpenFOAM.org specific: replacing 'face' with 'lineFace' in system/sample"
-           sed -i "s/type.*face;/type lineFace;/g" "${CASE_DIR}"/system/sample
+           "${_SED}" -i "s/type.*face;/type lineFace;/g" "${CASE_DIR}"/system/sample
         fi
     fi
 
@@ -160,9 +166,9 @@ function solids4Foam::convertCaseFormat()
     then
         echo "Changing timeVaryingUniformFixedValue to uniformValue in p"
         find "${CASE_DIR}" -name p | \
-            xargs sed -i "s|//type.*uniformFixedValue;|type          uniformFixedValue;|g"
+            xargs "${_SED}" -i "s|//type.*uniformFixedValue;|type          uniformFixedValue;|g"
         find "${CASE_DIR}" -name p | \
-            xargs sed -i "s|type.*timeVaryingUniformFixedValue;|//type        timeVaryingUniformFixedValue;|g"
+            xargs "${_SED}" -i "s|type.*timeVaryingUniformFixedValue;|//type        timeVaryingUniformFixedValue;|g"
     fi
 
     # 7. Check for changeDictionaryDict.openfoam
@@ -191,11 +197,11 @@ function solids4Foam::convertCaseFormat()
         if [[ -f "${CASE_DIR}"/constant/solidProperties ]]
         then
             echo "OpenFOAM.com specific: replacing 'leastSquares' with 'pointCellsLeastSquares' in system/fvSchemes"
-            sed -i "s/ leastSquares;/ pointCellsLeastSquares;/g" "${CASE_DIR}"/system/fvSchemes
+            "${_SED}" -i "s/ leastSquares;/ pointCellsLeastSquares;/g" "${CASE_DIR}"/system/fvSchemes
         elif [[ -f "${CASE_DIR}"/constant/solid/solidProperties ]]
         then
             echo "OpenFOAM.com specific: replacing 'leastSquares' with 'pointCellsLeastSquares' in system/solid/fvSchemes"
-            sed -i "s/ leastSquares;/ pointCellsLeastSquares;/g" "${CASE_DIR}"/system/solid/fvSchemes
+            "${_SED}" -i "s/ leastSquares;/ pointCellsLeastSquares;/g" "${CASE_DIR}"/system/solid/fvSchemes
         fi
     fi
 
@@ -205,7 +211,7 @@ function solids4Foam::convertCaseFormat()
         if [[ $WM_PROJECT_VERSION == *"v"* ]]
         then
             echo "Modifying force.gnuplot in consistent with ESI version"
-            sed -i "s|forces.dat|force.dat|g" force.gnuplot
+            "${_SED}" -i "s|forces.dat|force.dat|g" force.gnuplot
         fi
     fi
 
@@ -213,14 +219,14 @@ function solids4Foam::convertCaseFormat()
     if  [[ -n $(find "${CASE_DIR}" -name plot.gnuplot) ]]
     then
         echo "Updating plot.gnuplot"
-        sed -i "s@postProcessing/sets/@postProcessing/sample/@g" plot.gnuplot
+        "${_SED}" -i "s@postProcessing/sets/@postProcessing/sample/@g" plot.gnuplot
     fi
 
     # 12. Resolve sampleDict post-processing path from foam-extend
     if  [[ -n $(find "${CASE_DIR}" -name plot.gnuplot) ]]
     then
         echo "Updating plot.gnuplot"
-        sed -i  "s@postProcessing/surfaces/@postProcessing/sample.surfaces/@g" plot.gnuplot
+        "${_SED}" -i  "s@postProcessing/surfaces/@postProcessing/sample.surfaces/@g" plot.gnuplot
     fi
 
     # 13. Replace mirrorMeshDict differences
@@ -228,14 +234,14 @@ function solids4Foam::convertCaseFormat()
     then
         echo "OpenFOAM specific: replacing 'basePoint' and 'normalVector' in "
         echo "system/mirrorMeshDict with with 'point' and 'normal'"
-        sed -i -E 's/\bbasePoint\b/point/' system/mirrorMeshDict
-        sed -i -E 's/\bnormalVector\b/normal/' system/mirrorMeshDict
+        "${_SED}" -i -E 's/\bbasePoint\b/point/' system/mirrorMeshDict
+        "${_SED}" -i -E 's/\bnormalVector\b/normal/' system/mirrorMeshDict
     elif [[ -f "${CASE_DIR}"/system/solid/mirrorMeshDict ]]
     then
         echo "OpenFOAM specific: replacing 'basePoint' and 'normalVector' in "
         echo "system/solid/mirrorMeshDict with with 'point' and 'normal'"
-        sed -i -E 's/\bbasePoint\b/point/' system/solid/mirrorMeshDict
-        sed -i -E 's/\bnormalVector\b/normal/' system/solid/mirrorMeshDict
+        "${_SED}" -i -E 's/\bbasePoint\b/point/' system/solid/mirrorMeshDict
+        "${_SED}" -i -E 's/\bnormalVector\b/normal/' system/solid/mirrorMeshDict
     fi
 
     echo
@@ -272,6 +278,12 @@ function solids4Foam::convertCaseFormatFoamExtend()
     if sed --version 2>/dev/null | grep -q "GNU sed"
     then
         echo "GNU sed detected"
+        local _SED=sed
+    elif { _gsed=$(command -v gsed 2>/dev/null || echo /opt/homebrew/bin/gsed); } \
+         && [ -x "$_gsed" ] && "$_gsed" --version 2>/dev/null | grep -q "GNU sed"
+    then
+        echo "GNU sed (gsed) detected"
+        local _SED="$_gsed"
     else
         echo "Error: This script requires GNU sed. Please install it (e.g.,"
         echo "via Homebrew: 'brew install gnu-sed') and use 'gsed' instead."
@@ -285,19 +297,19 @@ function solids4Foam::convertCaseFormatFoamExtend()
     if [[ -n $(find "${CASE_DIR}" -name blockMeshDict) ]]
     then
         echo "Changing symmetry to symmetryPlane in blockMeshDict"; echo
-        find "${CASE_DIR}" -name blockMeshDict | xargs sed -i 's\symmetry \symmetryPlane \g'
+        find "${CASE_DIR}" -name blockMeshDict | xargs "${_SED}" -i 's\symmetry \symmetryPlane \g'
     fi
 
     if [[ -n $(find "${CASE_DIR}" -name boundary) ]]
     then
     echo "Changing symmetry to symmetryPlane in boundary"; echo
-        find "${CASE_DIR}" -name boundary | xargs sed -i 's\symmetry;\symmetryPlane;\g'
+        find "${CASE_DIR}" -name boundary | xargs "${_SED}" -i 's\symmetry;\symmetryPlane;\g'
     fi
 
     if [[ -n $(find "${CASE_DIR}" -name createPatchDict) ]]
     then
     echo "Changing symmetry to symmetryPlane in createPatchDict"; echo
-        find "${CASE_DIR}" -name createPatchDict | xargs sed -i 's\symmetry;\symmetryPlane;\g'
+        find "${CASE_DIR}" -name createPatchDict | xargs "${_SED}" -i 's\symmetry;\symmetryPlane;\g'
     fi
 
     for FILE in $(find "${CASE_DIR}/0" -type f)
@@ -307,7 +319,7 @@ function solids4Foam::convertCaseFormatFoamExtend()
             if grep -q "symmetry;" "${FILE}"
             then
                 echo "Changing symmetry to symmetryPlane in ${FILE}"; echo
-                sed -i 's\symmetry;\symmetryPlane;\g' "${FILE}"
+                "${_SED}" -i 's\symmetry;\symmetryPlane;\g' "${FILE}"
             fi
         fi
     done
@@ -351,7 +363,7 @@ function solids4Foam::convertCaseFormatFoamExtend()
     if [[ -n $(find "${CASE_DIR}" -name turbulenceProperties) ]]
     then
         echo "Changing RAS to RASModel in turbulenceProperties"
-        find "${CASE_DIR}" -name turbulenceProperties | xargs sed -i "s/RAS;/RASModel;/g"
+        find "${CASE_DIR}" -name turbulenceProperties | xargs "${_SED}" -i "s/RAS;/RASModel;/g"
     fi
 
     # 4. Check for boundaryData
@@ -370,10 +382,10 @@ function solids4Foam::convertCaseFormatFoamExtend()
         if [[ -f "${CASE_DIR}"/system/sample ]]
         then
            echo "OpenFOAM.org specific: replacing 'lineUniform' with 'uniform' in system/sample"
-           sed -i "s/type.*lineUniform;/type uniform;/g" "${CASE_DIR}"/system/sample
+           "${_SED}" -i "s/type.*lineUniform;/type uniform;/g" "${CASE_DIR}"/system/sample
 
            echo "OpenFOAM.org specific: replacing 'lineFace' with 'face' in system/sample"
-           sed -i "s/type.*lineFace;/type face;/g" "${CASE_DIR}"/system/sample
+           "${_SED}" -i "s/type.*lineFace;/type face;/g" "${CASE_DIR}"/system/sample
         fi
     fi
 
@@ -382,12 +394,12 @@ function solids4Foam::convertCaseFormatFoamExtend()
     then
         echo "Changing uniformValue to timeVaryingUniformFixedValue in p"
         find "${CASE_DIR}" -name p | \
-            xargs sed -i "s|type.*uniformFixedValue;|//type          uniformFixedValue;|g"
+            xargs "${_SED}" -i "s|type.*uniformFixedValue;|//type          uniformFixedValue;|g"
         find "${CASE_DIR}" -name p | \
-            xargs sed -i "s|//type.*timeVaryingUniformFixedValue;|type        timeVaryingUniformFixedValue;|g"
+            xargs "${_SED}" -i "s|//type.*timeVaryingUniformFixedValue;|type        timeVaryingUniformFixedValue;|g"
 
         # Remove any //// that were introdued
-        find "${CASE_DIR}" -name p | xargs sed -i "s|////|//|g"
+        find "${CASE_DIR}" -name p | xargs "${_SED}" -i "s|////|//|g"
     fi
 
     # 7. Check for changeDictionaryDict.openfoam
@@ -416,11 +428,11 @@ function solids4Foam::convertCaseFormatFoamExtend()
         if [[ -f "${CASE_DIR}"/constant/solidProperties ]]
         then
             echo "OpenFOAM.com specific: replacing 'pointCellsLeastSquares' with 'leastSquares' in system/fvSchemes"
-            sed -i "s/ pointCellsLeastSquares;/ leastSquares;/g" "${CASE_DIR}"/system/fvSchemes
+            "${_SED}" -i "s/ pointCellsLeastSquares;/ leastSquares;/g" "${CASE_DIR}"/system/fvSchemes
         elif [[ -f "${CASE_DIR}"/constant/solid/solidProperties ]]
         then
             echo "OpenFOAM.com specific: replacing 'pointCellsLeastSquares' with 'leastSquares' in system/solid/fvSchemes"
-            sed -i "s/ pointCellsLeastSquares;/ leastSquares;/g" "${CASE_DIR}"/system/solid/fvSchemes
+            "${_SED}" -i "s/ pointCellsLeastSquares;/ leastSquares;/g" "${CASE_DIR}"/system/solid/fvSchemes
         fi
     fi
 
@@ -430,7 +442,7 @@ function solids4Foam::convertCaseFormatFoamExtend()
         if [[ $WM_PROJECT_VERSION == *"v"* ]]
         then
             echo "Reverting force.gnuplot from ESI version to foam-extend or .org "
-            sed -i "s|force.dat|forces.dat|g" force.gnuplot
+            "${_SED}" -i "s|force.dat|forces.dat|g" force.gnuplot
         fi
     fi
 
@@ -438,14 +450,14 @@ function solids4Foam::convertCaseFormatFoamExtend()
     if  [[ -n $(find "${CASE_DIR}" -name plot.gnuplot) ]]
     then
         echo "Updating plot.gnuplot"
-        sed -i "s@postProcessing/sample/@postProcessing/sets/@g" plot.gnuplot
+        "${_SED}" -i "s@postProcessing/sample/@postProcessing/sets/@g" plot.gnuplot
     fi
 
     # 12. Resolve sampleDict post-processing path for foam-extend
     if  [[ -n $(find "${CASE_DIR}" -name plot.gnuplot) ]]
     then
         echo "Updating plot.gnuplot"
-        sed -i "s|postProcessing/sample.surfaces/|postProcessing/surfaces/|g" plot.gnuplot
+        "${_SED}" -i "s|postProcessing/sample.surfaces/|postProcessing/surfaces/|g" plot.gnuplot
     fi
 
     # 13. Replace mirrorMeshDict differences
@@ -453,14 +465,14 @@ function solids4Foam::convertCaseFormatFoamExtend()
     then
         echo "OpenFOAM specific: replacing 'point' and 'normal' in "
         echo "system/mirrorMeshDict with with 'basePoint' and 'normalVector'"
-        sed -i -E 's/\bpoint\b/basePoint/' system/mirrorMeshDict
-        sed -i -E 's/\b(normal)\b/\1Vector/' system/mirrorMeshDict
+        "${_SED}" -i -E 's/\bpoint\b/basePoint/' system/mirrorMeshDict
+        "${_SED}" -i -E 's/\b(normal)\b/\1Vector/' system/mirrorMeshDict
     elif [[ -f "${CASE_DIR}"/system/solid/mirrorMeshDict ]]
     then
         echo "OpenFOAM specific: replacing 'point' and 'normal' in "
         echo "system/mirrorMeshDict with with 'basePoint' and 'normalVector'"
-        sed -i -E 's/\bpoint\b/basePoint/' system/solid/mirrorMeshDict
-        sed -i -E 's/\b(normal)\b/\1Vector/' system/solid/mirrorMeshDict
+        "${_SED}" -i -E 's/\bpoint\b/basePoint/' system/solid/mirrorMeshDict
+        "${_SED}" -i -E 's/\b(normal)\b/\1Vector/' system/solid/mirrorMeshDict
     fi
 
     echo
@@ -819,13 +831,13 @@ function solids4Foam::runSolidModel()
         if [ "${DISP}" = "D" ] && [ -f "${CASE_DIR}/0/DD" ]; then
             echo "Renaming ${CASE_DIR}/0/DD to ${CASE_DIR}/0/D"
             \mv "${CASE_DIR}/0/DD" "${CASE_DIR}/0/D"
-            sed -i "s/object.*DD;/object D;/g" "${CASE_DIR}/0/D"
+            "${_SED}" -i "s/object.*DD;/object D;/g" "${CASE_DIR}/0/D"
         fi
 
         if [ "${DISP}" = "DD" ] && [ -f "${CASE_DIR}/0/D" ]; then
             echo "Renaming ${CASE_DIR}/0/D to ${CASE_DIR}/0/DD"
             \mv "${CASE_DIR}/0/D" "${CASE_DIR}/0/DD"
-            sed -i "s/object.*D;/object DD;/g" "${CASE_DIR}/0/DD"
+            "${_SED}" -i "s/object.*D;/object DD;/g" "${CASE_DIR}/0/DD"
         fi
 
         if [ "${DISP}" != "D" ] && [ "${DISP}" != "DD" ]; then

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/electroMechanicalLaw/electroMechanicalLaw.C
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/electroMechanicalLaw/electroMechanicalLaw.C
@@ -56,16 +56,33 @@ Foam::electroMechanicalLaw::electroMechanicalLaw
             nonLinGeom
         )
     ),
-    Ta_(dict.lookup("activeTension")),
-    rampTime_(readScalar(dict.lookup("rampTime")))
-{
-    if (rampTime_ < 0.0)
-    {
-        FatalErrorIn("electroMechanicalLaw::electroMechanicalLaw(...)")
-            << "rampTime should be greater than or equal to zero"
-            << abort(FatalError);
-    }
-}
+    f0_
+    (
+        IOobject
+        (
+            "f0",
+            mesh.time().timeName(),
+            mesh,
+            IOobject::MUST_READ,
+            IOobject::AUTO_WRITE
+        ),
+        mesh
+    ),
+    f0f0_("f0f0", sqr(f0_)),
+    f0f_
+    (
+        IOobject
+        (
+            "f0f",
+            mesh.time().timeName(),
+            mesh,
+            IOobject::MUST_READ,
+            IOobject::AUTO_WRITE
+        ),
+        mesh
+    ),
+    f0f0f_("f0f0f", sqr(f0f_))
+{}
 
 
 // * * * * * * * * * * * * * * * * Destructor  * * * * * * * * * * * * * * * //
@@ -100,74 +117,59 @@ Foam::tmp<Foam::volScalarField> Foam::electroMechanicalLaw::shearModulus() const
 
 void Foam::electroMechanicalLaw::correct(volSymmTensorField& sigma)
 {
+    if (!mesh().foundObject<volScalarField>("Ta"))
+    {
+        FatalErrorInFunction
+            << "electroMechanicalLaw requires a volScalarField named Ta in "
+            << "the solid mesh objectRegistry. Ta must be supplied by the "
+            << "electromechanical coupling, e.g. LandNiederer active tension."
+            << abort(FatalError);
+    }
+
     // Calculate passive stress
     passiveMechLawPtr_->correct(sigma);
 
-    // Lookup the fibre directions
-    // How best should we do this to avoid duplicating the fibre field?
-    // For now, let's hard-code in the field name
-    const volSymmTensorField f0f0 =
-        mesh().lookupObject<volSymmTensorField>("f0f0");
-
-    // Take a reference to the deformation gradient to make the code easier to
-    // read
+    // Take a reference to the deformation gradient
     const volTensorField& F = this->F();
 
     // Calculate the Jacobian of the deformation gradient
     const volScalarField J(det(F));
 
-    // For now, we will assume a constant active stress
-    // The next step will be to include an active-stress model to convert
-    // muscle activation to fibre tension
+    const volScalarField& Ta =
+        mesh().lookupObject<volScalarField>("Ta");
 
-    // Calculate current value of Ta
-    dimensionedScalar currentTa = Ta_;
-    if (mesh().time().value() < rampTime_)
-    {
-        currentTa = (mesh().time().value()/rampTime_)*Ta_;
-    }
-
-    // Add active stress to the passive stress
-    // Note that the active stress is converted from a 2nd Piola-Kirchhoff
-    // stress to a Cauchy stress
-    // sigma += J*symm(F & (currentTa*f0f0) & F.T());
-    sigma += symm(F & (currentTa*f0f0) & F.T())/J;
+    // Add active stress: convert 2nd Piola-Kirchhoff to Cauchy
+    sigma += symm(F & (Ta*f0f0_) & F.T())/J;
 }
 
 
 void Foam::electroMechanicalLaw::correct(surfaceSymmTensorField& sigma)
 {
+    if (!mesh().foundObject<volScalarField>("Ta"))
+    {
+        FatalErrorInFunction
+            << "electroMechanicalLaw requires a volScalarField named Ta in "
+            << "the solid mesh objectRegistry. Ta must be supplied by the "
+            << "electromechanical coupling, e.g. LandNiederer active tension."
+            << abort(FatalError);
+    }
+
     // Calculate passive stress
     passiveMechLawPtr_->correct(sigma);
 
-    // Lookup the fibre directions
-    // How best should we do this to avoid duplicating the fibre field?
-    // For now, let's hard-code in the field name
-    const surfaceSymmTensorField f0f0 =
-        mesh().lookupObject<surfaceSymmTensorField>("f0f0f");
-
-    // Take a reference to the deformation gradient to make the code easier to
-    // read
+    // Take a reference to the deformation gradient
     const surfaceTensorField& F = this->Ff();
 
     // Calculate the Jacobian of the deformation gradient
     const surfaceScalarField J(det(F));
 
-    // For now, we will assume a constant active stress
-    // The next step will be to include an active-stress model to convert
-    // muscle activation to fibre tension
+    const volScalarField& Ta =
+        mesh().lookupObject<volScalarField>("Ta");
 
-    // Calculate current value of Ta
-    dimensionedScalar currentTa = Ta_;
-    if (mesh().time().value() < rampTime_)
-    {
-        currentTa = (mesh().time().value()/rampTime_)*Ta_;
-    }
+    const surfaceScalarField Taf(fvc::interpolate(Ta));
 
-    // Add active stress to the passive stress
-    // Note that the active stress is converted from a 2nd Piola-Kirchhoff
-    // stress to a Cauchy stress
-    sigma += J*symm(F & (currentTa*f0f0) & F.T());
+    // Add active stress: convert 2nd Piola-Kirchhoff to Cauchy
+    sigma += symm(F & (Taf*f0f0f_) & F.T())/J;
 }
 
 

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/electroMechanicalLaw/electroMechanicalLaw.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/electroMechanicalLaw/electroMechanicalLaw.H
@@ -56,11 +56,17 @@ class electroMechanicalLaw
         //- Run-time selectable passive mechanical law
         autoPtr<mechanicalLaw> passiveMechLawPtr_;
 
-        //- Constant active tension
-        const dimensionedScalar Ta_;
+        //- Fibre direction field (read from 0/solid/f0)
+        volVectorField f0_;
 
-        //- Ramp time over which Ta is increased from zero to its maximum value
-        const scalar rampTime_;
+        //- Fibre direction outer product f0 x f0
+        volSymmTensorField f0f0_;
+
+        //- Surface fibre direction field (read from 0/solid/f0f)
+        surfaceVectorField f0f_;
+
+        //- Surface fibre direction outer product
+        surfaceSymmTensorField f0f0f_;
 
     // Private Member Functions
 

--- a/src/solids4FoamModels/solidModels/nonLinGeomTotalLagTotalDispSolid/nonLinGeomTotalLagTotalDispSolid.C
+++ b/src/solids4FoamModels/solidModels/nonLinGeomTotalLagTotalDispSolid/nonLinGeomTotalLagTotalDispSolid.C
@@ -247,6 +247,9 @@ bool nonLinGeomTotalLagTotalDispSolid::evolveImplicitSegregated()
           + rho()*g()
         );
 
+        // Add optional fvOptions body force (e.g. MMS)
+        DEqn.source() += fvOptions()(D())().source();
+
         // Add damping
         if (dampingCoeff().value() > SMALL)
         {
@@ -929,9 +932,8 @@ label nonLinGeomTotalLagTotalDispSolid::formResidual
     // Make residual extensive as fvc operators are intensive (per unit volume)
     residual *= mesh.V();
 
-    // Add optional fvOptions, e.g. MMS body force
-    // Note that "source()" is already multiplied by the volumes
-    //residual -= fvOptions()(ds_, const_cast<volVectorField&>(D))().source();
+    // Add optional fvOptions body force (e.g. MMS)
+    residual += fvOptions()(const_cast<volVectorField&>(D))().source();
 
     // Copy the residual into the f field
     foamPetscSnesHelper::InsertFieldComponents<vector>

--- a/src/solids4FoamModels/solidModels/nonLinGeomTotalLagTotalDispSolid/nonLinGeomTotalLagTotalDispSolid.C
+++ b/src/solids4FoamModels/solidModels/nonLinGeomTotalLagTotalDispSolid/nonLinGeomTotalLagTotalDispSolid.C
@@ -245,10 +245,10 @@ bool nonLinGeomTotalLagTotalDispSolid::evolveImplicitSegregated()
           - fvc::laplacian(impKf_, D(), "laplacian(DD,D)")
           + fvc::div(force)
           + rho()*g()
+#ifdef OPENFOAM_COM
+          + fvOptions()(ds_, D())
+#endif
         );
-
-        // Add optional fvOptions body force (e.g. MMS)
-        DEqn.source() += fvOptions()(D())().source();
 
         // Add damping
         if (dampingCoeff().value() > SMALL)
@@ -614,6 +614,19 @@ nonLinGeomTotalLagTotalDispSolid::nonLinGeomTotalLagTotalDispSolid
         solvePressure()
       ? label(solidModel::twoD() ? 3 : 4)
       : label(solidModel::twoD() ? 2 : 3)
+    ),
+    ds_
+    (
+        IOobject
+        (
+            "ds",
+            mesh().time().timeName(),
+            mesh(),
+            IOobject::NO_READ,
+            IOobject::NO_WRITE
+        ),
+        mesh(),
+        dimensionedScalar("ds", (dimForce/dimVolume)/dimVelocity, 1.0)
     )
 {
     DisRequired();
@@ -932,8 +945,11 @@ label nonLinGeomTotalLagTotalDispSolid::formResidual
     // Make residual extensive as fvc operators are intensive (per unit volume)
     residual *= mesh.V();
 
-    // Add optional fvOptions body force (e.g. MMS)
-    residual += fvOptions()(const_cast<volVectorField&>(D))().source();
+#ifdef OPENFOAM_COM
+    // Add optional fvOptions, e.g. MMS body force
+    // Note that "source()" is already multiplied by the volumes
+    residual -= fvOptions()(ds_, const_cast<volVectorField&>(D))().source();
+#endif
 
     // Copy the residual into the f field
     foamPetscSnesHelper::InsertFieldComponents<vector>

--- a/src/solids4FoamModels/solidModels/nonLinGeomTotalLagTotalDispSolid/nonLinGeomTotalLagTotalDispSolid.H
+++ b/src/solids4FoamModels/solidModels/nonLinGeomTotalLagTotalDispSolid/nonLinGeomTotalLagTotalDispSolid.H
@@ -103,6 +103,9 @@ class nonLinGeomTotalLagTotalDispSolid
         //- Number of unknowns per cell, used by PETSc SNES solver
         const label blockSize_;
 
+        //- Field to provide fvOptions with the correct dimensions
+        volScalarField ds_;
+
 
     // Private Member Functions
 

--- a/tutorials/Alltest
+++ b/tutorials/Alltest
@@ -14,6 +14,16 @@
 #------------------------------------------------------------------------------
 cd "${0%/*}" || exit  # Run from this directory
 
+_gsed_candidate=$(command -v gsed 2>/dev/null || echo /opt/homebrew/bin/gsed)
+if sed --version 2>/dev/null | grep -q "GNU sed"; then
+    _SED=sed
+elif [ -x "$_gsed_candidate" ] && "$_gsed_candidate" --version 2>/dev/null | grep -q "GNU sed"; then
+    _SED="$_gsed_candidate"
+else
+    echo "Warning: GNU sed not found. Some substitutions may fail on macOS."
+    _SED=sed
+fi
+
 #
 # FUNCTION DEFINITIONS
 #
@@ -173,7 +183,7 @@ echo "Modifying the case controlDicts to run only one time step"
 for CD in $(find . -name "controlDict*" -type f)
 do
     cp -f "${CD}" "${CD}.orig"
-    sed \
+    "${_SED}" \
         -e 's/\(stopAt[ \t]*\)\([a-zA-Z]*\);/\1 nextWrite;/g' \
         -e 's/\(writeControl[ \t]*\)\([a-zA-Z]*\);/\1 timeStep;/g' \
         -e 's/\(writeInterval[ \t]*\)\([0-9a-zA-Z.-]*\);/\1 1;/g' \
@@ -186,8 +196,8 @@ echo "Modifying the fvSolution to run only one iteration"
 for FVS in $(find . -name "fvSolution")
 do
     mv ${FVS} ${FVS}.org
-    sed -e "s|maxIter.*;|maxIter 1;|g" ${FVS}.org > ${FVS}
-    sed -i "s|nOuterCorrectors.*;|nOuterCorrectors 1;|g" ${FVS}
+    "${_SED}" -e "s|maxIter.*;|maxIter 1;|g" ${FVS}.org > ${FVS}
+    "${_SED}" -i "s|nOuterCorrectors.*;|nOuterCorrectors 1;|g" ${FVS}
 done
 
 # Modify solidProperties
@@ -208,13 +218,13 @@ do
       }
     ' "${SP}.org" > "${SP}"
 
-    sed \
+    "${_SED}" \
     -i \
     -e "s|//nCorrectors.*;|nCorrectors 1;|g" \
     -e "s|nCorrectors.*;|nCorrectors 1;|g" \
     ${SP}
 
-    sed -i -e "s|stopOnError.*;|stopOnError no;|g" ${SP}
+    "${_SED}" -i -e "s|stopOnError.*;|stopOnError no;|g" ${SP}
 done
 
 # Modify fsiProperties
@@ -229,7 +239,7 @@ do
     fi
 
     # Edit the target in-place, preserving symlink
-    sed -i.bak \
+    "${_SED}" -i.bak \
       -e 's|//nOuterCorr.*;|nOuterCorr 1;|g' \
       -e 's|nOuterCorr.*;|nOuterCorr 1;|g' \
       "$FP"


### PR DESCRIPTION
## Changes

This PR contains three independent changes across five files.

---

### 1. macOS GNU sed portability

**Files:** `applications/scripts/solids4FoamScripts.sh`, `tutorials/Alltest`

On macOS the system `sed` is BSD sed, which is incompatible with the `-i`
flag and regex syntax used throughout the case-conversion scripts and the
tutorial test driver. GNU sed installed via Homebrew is available as `gsed`,
not `sed`.

A detection block is added at the entry point of each affected
function/script:

```bash
if sed --version 2>/dev/null | grep -q "GNU sed"; then
    local _SED=sed
elif { _gsed=$(command -v gsed 2>/dev/null || echo /opt/homebrew/bin/gsed); } \
     && [ -x "$_gsed" ] && "$_gsed" --version 2>/dev/null | grep -q "GNU sed"; then
    local _SED="$_gsed"
else
    echo "Error: GNU sed required (brew install gnu-sed)"
    return 1
fi
```

All `sed -i` calls are replaced with `"${_SED}" -i`. Behaviour on Linux is
unchanged.

**Affected functions in `solids4FoamScripts.sh`:**
- `solids4Foam::convertCaseFormat()`
- `solids4Foam::convertCaseFormatFoamExtend()`

---

### 2. `electroMechanicalLaw` — electrophysiology coupling refactor

**Files:** `electroMechanicalLaw.H`, `electroMechanicalLaw.C`

> [!WARNING]
> **Breaking change.** The previous dictionary API (`activeTension`,
> `rampTime`) is removed. Existing cases must be updated (see migration
> guide below).

**Motivation.** The previous implementation used a constant scalar active
tension with a hard-coded linear ramp. This is insufficient for coupled
cardiac simulations where an electrophysiology solver (e.g. Land-Niederer)
evolves $T_a(\mathbf{x},t)$ as a spatially and temporally varying field.

**What changed.**

*Removed from the mechanical properties dictionary:*

```
activeTension   <scalar>;
rampTime        <scalar>;
```

*New owned member fields, read from `0/` at construction:*

| Member | Type | Description |
|---|---|---|
| `f0_` | `volVectorField` | Cell-centred fibre direction |
| `f0f0_` | `volSymmTensorField` | Precomputed $\mathbf{f}_0 \otimes \mathbf{f}_0$ |
| `f0f_` | `surfaceVectorField` | Face-interpolated fibre direction |
| `f0f0f_` | `surfaceSymmTensorField` | Face $\mathbf{f}_0 \otimes \mathbf{f}_0$ |

*Active tension* is now looked up from the mesh object registry at run-time:

```cpp
const volScalarField& Ta = mesh().lookupObject<volScalarField>("Ta");
```

Any coupled solver that writes a `volScalarField` named `"Ta"` to the same
mesh registry will automatically drive active contraction. `Ta` is
face-interpolated (`fvc::interpolate(Ta)`) to get `Taf`, consistent with the
already-precomputed `f0f0f_` surface field.

*Bug fix — surface-interpolated active stress path only.* The
`correct(surfaceSymmTensorField&)` overload's Cauchy stress push-forward had
an incorrect volume factor. The `correct(volSymmTensorField&)` overload
already divided by `J` correctly and is unchanged in substance:

```cpp
// Before (wrong, surface-field overload only):
sigma += J * symm(F & (currentTa*f0f0) & F.T());

// After (correct):
sigma += symm(F & (Taf*f0f0f_) & F.T()) / J;
```

For active 2nd Piola-Kirchhoff stress $S = T_a(\mathbf{f}_0 \otimes \mathbf{f}_0)$
in the reference configuration, Cauchy stress is $\sigma = \frac{1}{J}FSF^T$,
so the surface path's old `J*` scaling was dimensionally/physically
inconsistent with volumetric change; the vol-field path already had this
right.

**Migration guide for existing cases.**
1. Remove `activeTension` and `rampTime` from `mechanicalProperties`.
2. Add `0/f0` (`volVectorField`) and `0/f0f` (`surfaceVectorField`) to the
   case directory. `f0` must be supplied as a unit vector — it is not
   normalized internally.
3. Ensure an electrophysiology model writes a `volScalarField` named `"Ta"`
   to the mesh registry at run-time.

---

### 3. `nonLinGeomTotalLagTotalDispSolid` — fvOptions body force

**Files:** `nonLinGeomTotalLagTotalDispSolid.C`, `nonLinGeomTotalLagTotalDispSolid.H`

**Motivation.** MMS (Method of Manufactured Solutions) verification for this
solid model requires an external body force supplied via `fvOptions`. This
was previously commented out (dead code) in both solver paths.

**What changed.** Rather than introduce a new sign/overload convention for
this solver, this PR activates the fvOptions body force using the exact
same pattern already active in `linGeomTotalDispSolid.C`: a private member
`ds_` — a dummy field dimensioned `force/volume/velocity` and uniformly
equal to `1.0` — added purely to satisfy the two-argument
`fvOptions()(rho, field)` overload's dimension checking (it does not scale
the body force numerically, since it is uniformly `1.0`). Both call sites
are guarded by `#ifdef OPENFOAM_COM`, matching the existing precedent.

**Segregated path** (`evolveImplicitSegregated`):

```cpp
fvVectorMatrix DEqn
(
    ...
  + rho()*g()
#ifdef OPENFOAM_COM
  + fvOptions()(ds_, D())
#endif
);
```

**SNES/PETSc path** (`formResidual`):

```cpp
#ifdef OPENFOAM_COM
// Add optional fvOptions, e.g. MMS body force
// Note that "source()" is already multiplied by the volumes
residual -= fvOptions()(ds_, const_cast<volVectorField&>(D))().source();
#endif
```

Note: `linGeomTotalDispSolid.C` is the only place in the codebase where this
fvOptions-in-residual pattern is currently active (`nonLinGeomUpdatedLagSolid.C`
still has the equivalent line commented out). This PR follows that existing
precedent rather than asserting an independently-verified sign convention;
the MMS spatial-convergence check below is the way to confirm the sign is
correct in practice.

---

## Testing

- [ ] `tutorials/Alltest` runs cleanly on macOS (`gsed` installed) and Linux
- [ ] `solids4Foam::convertCaseFormat()` and `convertCaseFormatFoamExtend()`
      work correctly on macOS
- [ ] Electromechanics case runs with externally supplied `Ta` field
- [ ] MMS spatial-convergence check for `nonLinGeomTotalLagTotalDispSolid`
      passes with the segregated solver, confirming the fvOptions body-force
      sign convention