### PR TITLE
Add release checklist issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -1,0 +1,36 @@
+---
+name: Release checklist
+about: Track the steps for a new solids4foam release
+title: "Release vX.Y checklist"
+labels: release
+assignees: ""
+---
+
+## Pre-release
+
+- [ ] All target PRs merged into `development`; CI green (`buildAndTest`, `buildAndRegressionTest`)
+- [ ] `./Alltest` and `./Alltest-regression` pass locally on each supported OpenFOAM/foam-extend version
+- [ ] Update `CITATION.cff` (`version`, `date-released`, and DOI if a new one is minted)
+- [ ] Update `CONTRIBUTORS.md` if new contributors since last release
+- [ ] Tutorial/README docs reflect any new features or breaking changes
+
+## Tag and publish
+
+- [ ] Merge `development` into `master`
+- [ ] Tag release on `master` (`vX.Y`) and push tag
+- [ ] Create GitHub Release from tag with release notes (**not a draft** — publish directly to avoid the Zenodo draft-release breakage from a past release)
+- [ ] Confirm Zenodo archive was created correctly from the GitHub Release (check the Zenodo record renders, metadata/DOI match `CITATION.cff`)
+
+## Docker images
+
+- [ ] Run `docker-release.yml` (workflow_dispatch) with the new version tag
+- [ ] Pull each pushed image (`openfoam-v2412`, `openfoam-v2312`, `openfoam-9`, `foam-extend-4.1`) and sanity-check it runs a tutorial
+
+## Website
+
+- [ ] Confirm `update-submodule.yml` ran on push to `development`/`master` and solids4foam.github.io picked up the new commit
+- [ ] Spot-check solids4foam.github.io renders correctly (no broken links/build)
+
+## Announce
+
+- [ ] Post release announcement (OpenFOAM/CFD forum, mailing list, etc., as applicable)

--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -12,6 +12,9 @@ assignees: ""
 - [ ] `./Alltest` and `./Alltest-regression` pass locally on each supported OpenFOAM/foam-extend version
 - [ ] Update `CITATION.cff` (`version`, `date-released`, and DOI if a new one is minted)
 - [ ] Update `CONTRIBUTORS.md` if new contributors since last release
+- [ ] Update `solids4foamVersion` in
+      `applications/scripts/solids4FoamUpdateCaseFileHeader.sh` and run the
+      script across all tutorial cases
 - [ ] Tutorial/README docs reflect any new features or breaking changes
 
 ## Tag and publish

--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -19,6 +19,7 @@ assignees: ""
 - [ ] Merge `development` into `master`
 - [ ] Tag release on `master` (`vX.Y`) and push tag
 - [ ] Create GitHub Release from tag with release notes (**not a draft** — publish directly to avoid the Zenodo draft-release breakage from a past release)
+- [ ] [Optional] Create/update `CHANGELOG.md` in `master` branch with a summary of the main changes since the last release, where this file should ideally provide the full history, one section per version, newest first, back to v1.0
 - [ ] Confirm Zenodo archive was created correctly from the GitHub Release (check the Zenodo record renders, metadata/DOI match `CITATION.cff`)
 
 ## Docker images


### PR DESCRIPTION
## Summary
- Adds a `.github/ISSUE_TEMPLATE/release-checklist.md` issue template covering pre-release, tag/publish, Docker images, website, and announcement steps
- Prompted by comparing against preCICE's automated release pipeline (tag-triggered draft release + Zenodo). Decided against automating the release itself here: a prior automated draft release broke the Zenodo archive for this repo, and solids4foam's ~6-month release cadence doesn't need preCICE's frequent-release automation
- Instead this gives a simple, editable checklist to open as a fresh issue each release cycle

## Test plan
- [ ] Confirm the template shows up under Issues → New issue in this repo
- [ ] Adjust checklist wording/steps as needed (e.g. specific announcement channels, Zenodo versioned DOI handling)