### PR TITLE
changing solid model so sigmaActive doesnt lose spherical part -- als…

### DIFF
--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/GuccioneElastic/GuccioneElastic.C
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/GuccioneElastic/GuccioneElastic.C
@@ -831,7 +831,8 @@ void Foam::GuccioneElastic::correct(volSymmTensorField& sigma)
 
         // Convert the second Piola-Kirchhoff stress to the deviatoric Cauchy
         // stress
-        const volSymmTensorField s("s", dev(symm(F & S_ & FT)));
+        const volScalarField J("J", det(F));
+        const volSymmTensorField s("s", dev(symm(F & S_ & FT)/J));
 
         // Lookup pressure field
         const volScalarField& p =
@@ -1125,7 +1126,8 @@ void Foam::GuccioneElastic::correct(surfaceSymmTensorField& sigma)
 
         // Convert the second Piola-Kirchhoff stress to the deviatoric Cauchy
         // stress
-        const surfaceSymmTensorField sf("sf", dev(symm(Ff & Sf_ & FfT)));
+        const surfaceScalarField Jf("Jf", det(Ff));
+        const surfaceSymmTensorField sf("sf", dev(symm(Ff & Sf_ & FfT)/Jf));
 
         // Lookup pressure field
         const surfaceScalarField& pf =

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/electroMechanicalLaw/electroMechanicalLaw.C
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/electroMechanicalLaw/electroMechanicalLaw.C
@@ -34,6 +34,42 @@ namespace Foam
 }
 
 
+// * * * * * * * * * * * * Private Member Functions  * * * * * * * * * * * //
+
+void Foam::electroMechanicalLaw::checkFieldTa() const
+{
+    if (!fieldTaChecked_)
+    {
+        fieldTaChecked_ = true;
+        useFieldTa_ = mesh().foundObject<volScalarField>("Ta");
+
+        if (useFieldTa_)
+        {
+            Info<< "    electroMechanicalLaw: using field-based active tension"
+                << " (Ta volScalarField from objectRegistry)" << endl;
+        }
+        else if (mag(Ta_.value()) > SMALL)
+        {
+            Info<< "    electroMechanicalLaw: using constant active tension"
+                << " Ta = " << Ta_.value()
+                << " with rampTime = " << rampTime_ << endl;
+        }
+    }
+}
+
+
+Foam::dimensionedScalar Foam::electroMechanicalLaw::activeTension() const
+{
+    dimensionedScalar currentTa = Ta_;
+    if (mesh().time().value() < rampTime_)
+    {
+        currentTa = (mesh().time().value()/rampTime_)*Ta_;
+    }
+
+    return currentTa;
+}
+
+
 // * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
 
 // Construct from dictionary
@@ -126,32 +162,30 @@ Foam::tmp<Foam::volScalarField> Foam::electroMechanicalLaw::shearModulus() const
 }
 
 
-void Foam::electroMechanicalLaw::correct(volSymmTensorField& sigma)
+bool Foam::electroMechanicalLaw::hasActiveStress() const
 {
-    // Lazy check for field-based active tension
-    if (!fieldTaChecked_)
-    {
-        fieldTaChecked_ = true;
-        useFieldTa_ = mesh().foundObject<volScalarField>("Ta");
+    checkFieldTa();
 
-        if (useFieldTa_)
-        {
-            Info<< "    electroMechanicalLaw: using field-based active tension"
-                << " (Ta volScalarField from objectRegistry)" << endl;
-        }
-        else
-        {
-            Info<< "    electroMechanicalLaw: using constant active tension"
-                << " Ta = " << Ta_.value()
-                << " with rampTime = " << rampTime_ << endl;
-        }
+    if (useFieldTa_)
+    {
+        const volScalarField& Ta =
+            mesh().lookupObject<volScalarField>("Ta");
+
+        return max(mag(Ta)).value() > SMALL;
     }
 
-    // Calculate passive stress
-    passiveMechLawPtr_->correct(sigma);
+    return mag(activeTension().value()) > SMALL;
+}
+
+
+Foam::tmp<Foam::volSymmTensorField>
+Foam::electroMechanicalLaw::activeCauchyStress() const
+{
+    checkFieldTa();
 
     // Take a reference to the deformation gradient
-    const volTensorField& F = this->F();
+    const volTensorField& F =
+        const_cast<electroMechanicalLaw&>(*this).F();
 
     // Calculate the Jacobian of the deformation gradient
     const volScalarField J(det(F));
@@ -162,49 +196,54 @@ void Foam::electroMechanicalLaw::correct(volSymmTensorField& sigma)
         const volScalarField& Ta =
             mesh().lookupObject<volScalarField>("Ta");
 
-        // Add active stress: convert 2nd Piola-Kirchhoff to Cauchy
-        sigma += symm(F & (Ta*f0f0_) & F.T())/J;
+        // Convert active 2nd Piola-Kirchhoff stress to Cauchy stress
+        return tmp<volSymmTensorField>
+        (
+            new volSymmTensorField
+            (
+                IOobject
+                (
+                    "sigmaActive",
+                    mesh().time().timeName(),
+                    mesh(),
+                    IOobject::NO_READ,
+                    IOobject::NO_WRITE
+                ),
+                symm(F & (Ta*f0f0_) & F.T())/J
+            )
+        );
     }
-    else
-    {
-        // Constant active tension with optional ramp
-        dimensionedScalar currentTa = Ta_;
-        if (mesh().time().value() < rampTime_)
-        {
-            currentTa = (mesh().time().value()/rampTime_)*Ta_;
-        }
 
-        sigma += symm(F & (currentTa*f0f0_) & F.T())/J;
-    }
+    // Constant active tension with optional ramp
+    const dimensionedScalar currentTa = activeTension();
+
+    // Convert active 2nd Piola-Kirchhoff stress to Cauchy stress
+    return tmp<volSymmTensorField>
+    (
+        new volSymmTensorField
+        (
+            IOobject
+            (
+                "sigmaActive",
+                mesh().time().timeName(),
+                mesh(),
+                IOobject::NO_READ,
+                IOobject::NO_WRITE
+            ),
+            symm(F & (currentTa*f0f0_) & F.T())/J
+        )
+    );
 }
 
 
-void Foam::electroMechanicalLaw::correct(surfaceSymmTensorField& sigma)
+Foam::tmp<Foam::surfaceSymmTensorField>
+Foam::electroMechanicalLaw::activeCauchyStressf() const
 {
-    // Lazy check for field-based active tension (same as vol variant)
-    if (!fieldTaChecked_)
-    {
-        fieldTaChecked_ = true;
-        useFieldTa_ = mesh().foundObject<volScalarField>("Ta");
-
-        if (useFieldTa_)
-        {
-            Info<< "    electroMechanicalLaw: using field-based active tension"
-                << " (Ta volScalarField from objectRegistry)" << endl;
-        }
-        else
-        {
-            Info<< "    electroMechanicalLaw: using constant active tension"
-                << " Ta = " << Ta_.value()
-                << " with rampTime = " << rampTime_ << endl;
-        }
-    }
-
-    // Calculate passive stress
-    passiveMechLawPtr_->correct(sigma);
+    checkFieldTa();
 
     // Take a reference to the deformation gradient
-    const surfaceTensorField& F = this->Ff();
+    const surfaceTensorField& F =
+        const_cast<electroMechanicalLaw&>(*this).Ff();
 
     // Calculate the Jacobian of the deformation gradient
     const surfaceScalarField J(det(F));
@@ -217,19 +256,68 @@ void Foam::electroMechanicalLaw::correct(surfaceSymmTensorField& sigma)
 
         const surfaceScalarField Taf(fvc::interpolate(Ta));
 
-        // Add active stress: convert 2nd Piola-Kirchhoff to Cauchy
-        sigma += J*symm(F & (Taf*f0f0f_) & F.T());
+        // Convert active 2nd Piola-Kirchhoff stress to Cauchy stress
+        return tmp<surfaceSymmTensorField>
+        (
+            new surfaceSymmTensorField
+            (
+                IOobject
+                (
+                    "sigmaActivef",
+                    mesh().time().timeName(),
+                    mesh(),
+                    IOobject::NO_READ,
+                    IOobject::NO_WRITE
+                ),
+                (1.0/J)*symm(F & (Taf*f0f0f_) & F.T())
+            )
+        );
     }
-    else
-    {
-        // Constant active tension with optional ramp
-        dimensionedScalar currentTa = Ta_;
-        if (mesh().time().value() < rampTime_)
-        {
-            currentTa = (mesh().time().value()/rampTime_)*Ta_;
-        }
 
-        sigma += J*symm(F & (currentTa*f0f0f_) & F.T());
+    // Constant active tension with optional ramp
+    const dimensionedScalar currentTa = activeTension();
+
+    // Convert active 2nd Piola-Kirchhoff stress to Cauchy stress
+    return tmp<surfaceSymmTensorField>
+    (
+        new surfaceSymmTensorField
+        (
+            IOobject
+            (
+                "sigmaActivef",
+                mesh().time().timeName(),
+                mesh(),
+                IOobject::NO_READ,
+                IOobject::NO_WRITE
+            ),
+            (1.0/J)*symm(F & (currentTa*f0f0f_) & F.T())
+        )
+    );
+}
+
+
+void Foam::electroMechanicalLaw::correct(volSymmTensorField& sigma)
+{
+    // Calculate passive stress
+    passiveMechLawPtr_->correct(sigma);
+
+    if (hasActiveStress())
+    {
+        const tmp<volSymmTensorField> tSigmaActive = activeCauchyStress();
+        sigma += tSigmaActive();
+    }
+}
+
+
+void Foam::electroMechanicalLaw::correct(surfaceSymmTensorField& sigma)
+{
+    // Calculate passive stress
+    passiveMechLawPtr_->correct(sigma);
+
+    if (hasActiveStress())
+    {
+        const tmp<surfaceSymmTensorField> tSigmaActive = activeCauchyStressf();
+        sigma += tSigmaActive();
     }
 }
 

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/electroMechanicalLaw/electroMechanicalLaw.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/electroMechanicalLaw/electroMechanicalLaw.H
@@ -85,6 +85,12 @@ class electroMechanicalLaw
 
     // Private Member Functions
 
+        //- Check whether a field-based active tension should be used
+        void checkFieldTa() const;
+
+        //- Return the current ramped constant active tension
+        dimensionedScalar activeTension() const;
+
         //- Disallow default bitwise copy construct
         electroMechanicalLaw(const electroMechanicalLaw&);
 
@@ -128,6 +134,15 @@ public:
 
         //- Return the shear modulus field
         virtual tmp<volScalarField> shearModulus() const;
+
+        //- True if this law currently provides a non-zero active stress
+        bool hasActiveStress() const;
+
+        //- Return the active Cauchy stress
+        tmp<volSymmTensorField> activeCauchyStress() const;
+
+        //- Return the active Cauchy stress surface field
+        tmp<surfaceSymmTensorField> activeCauchyStressf() const;
 
         //- Calculate the stress
         virtual void correct(volSymmTensorField& sigma);

--- a/src/solids4FoamModels/solidModels/nonLinGeomTotalLagTotalDispSolid/nonLinGeomTotalLagTotalDispSolid.C
+++ b/src/solids4FoamModels/solidModels/nonLinGeomTotalLagTotalDispSolid/nonLinGeomTotalLagTotalDispSolid.C
@@ -27,6 +27,7 @@ License
 #include "symmetryFvPatchFields.H"
 #include "slipFvPatchFields.H"
 #include "compatibilityFunctions.H"
+#include "electroMechanicalLaw.H"
 
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
@@ -49,6 +50,146 @@ addToRunTimeSelectionTable
 
 
 // * * * * * * * * * * *  Private Member Functions * * * * * * * * * * * * * //
+
+
+void nonLinGeomTotalLagTotalDispSolid::applyMixedPressureStressSplit()
+{
+    static bool printedActiveStressPreservingSplit = false;
+
+    const PtrList<mechanicalLaw>& laws = mechanical();
+
+    if (laws.size() == 1)
+    {
+        if (isA<electroMechanicalLaw>(laws[0]))
+        {
+            const electroMechanicalLaw& activeLaw =
+                refCast<const electroMechanicalLaw>(laws[0]);
+
+            if (activeLaw.hasActiveStress())
+            {
+                if (!printedActiveStressPreservingSplit)
+                {
+                    Info<< "Using active-stress-preserving mixed pressure split"
+                        << endl;
+                    printedActiveStressPreservingSplit = true;
+                }
+
+                const tmp<volSymmTensorField> tSigmaActive =
+                    activeLaw.activeCauchyStress();
+                const volSymmTensorField& sigmaActive = tSigmaActive();
+
+                sigma() =
+                    dev(sigma() - sigmaActive) + sigmaActive - p()*I;
+                return;
+            }
+        }
+
+        sigma() = dev(sigma());
+        sigma() = sigma() - p()*I;
+        return;
+    }
+
+    bool hasActiveStress = false;
+    forAll(laws, lawI)
+    {
+        if (isA<electroMechanicalLaw>(laws[lawI]))
+        {
+            const electroMechanicalLaw& activeLaw =
+                refCast<const electroMechanicalLaw>(laws[lawI]);
+
+            if (activeLaw.hasActiveStress())
+            {
+                hasActiveStress = true;
+                break;
+            }
+        }
+    }
+
+    if (!hasActiveStress)
+    {
+        sigma() = dev(sigma());
+        sigma() = sigma() - p()*I;
+        return;
+    }
+
+    if (!printedActiveStressPreservingSplit)
+    {
+        Info<< "Using active-stress-preserving mixed pressure split" << endl;
+        printedActiveStressPreservingSplit = true;
+    }
+
+    PtrList<volSymmTensorField> subMeshSigmaActive(laws.size());
+
+    forAll(laws, lawI)
+    {
+        const fvMesh& lawMesh =
+            mechanical().solSubMeshes().subMeshes()[lawI].subMesh();
+
+        if (isA<electroMechanicalLaw>(laws[lawI]))
+        {
+            const electroMechanicalLaw& activeLaw =
+                refCast<const electroMechanicalLaw>(laws[lawI]);
+
+            if (activeLaw.hasActiveStress())
+            {
+                const tmp<volSymmTensorField> tSigmaActive =
+                    activeLaw.activeCauchyStress();
+
+                subMeshSigmaActive.set
+                (
+                    lawI,
+                    new volSymmTensorField(tSigmaActive())
+                );
+                continue;
+            }
+        }
+
+        subMeshSigmaActive.set
+        (
+            lawI,
+            new volSymmTensorField
+            (
+                IOobject
+                (
+                    "sigmaActive",
+                    lawMesh.time().timeName(),
+                    lawMesh,
+                    IOobject::NO_READ,
+                    IOobject::NO_WRITE
+                ),
+                lawMesh,
+                dimensionedSymmTensor
+                (
+                    "zero",
+                    dimPressure,
+                    symmTensor::zero
+                )
+            )
+        );
+    }
+
+    volSymmTensorField sigmaActive
+    (
+        IOobject
+        (
+            "sigmaActive",
+            runTime().timeName(),
+            mesh(),
+            IOobject::NO_READ,
+            IOobject::NO_WRITE
+        ),
+        mesh(),
+        dimensionedSymmTensor("zero", dimPressure, symmTensor::zero)
+    );
+
+    mechanical().solSubMeshes().mapSubMeshVolFields<symmTensor>
+    (
+        subMeshSigmaActive,
+        sigmaActive
+    );
+
+    sigma() = dev(sigma() - sigmaActive) + sigmaActive - p()*I;
+}
 
 
 void nonLinGeomTotalLagTotalDispSolid::predict()
@@ -84,7 +225,7 @@ void nonLinGeomTotalLagTotalDispSolid::predict()
         // p() = p().oldTime() + dpdt*runTime().deltaT()
         //     + 0.5*sqr(runTime().deltaT())*d2pdt2;
 
-        sigma() = dev(sigma()) - p()*I;
+        applyMixedPressureStressSplit();
     }
 }
 
@@ -876,7 +1017,7 @@ void nonLinGeomTotalLagTotalDispSolid::unpackSolution(const Vec x)
         p.correctBoundaryConditions();
 
         // Replace the pressure component of stress
-        sigma() = dev(sigma()) - p*I;
+        applyMixedPressureStressSplit();
     }
 }
 

--- a/src/solids4FoamModels/solidModels/nonLinGeomTotalLagTotalDispSolid/nonLinGeomTotalLagTotalDispSolid.H
+++ b/src/solids4FoamModels/solidModels/nonLinGeomTotalLagTotalDispSolid/nonLinGeomTotalLagTotalDispSolid.H
@@ -149,6 +149,9 @@ class nonLinGeomTotalLagTotalDispSolid
         //  previous time-steps
         void predict();
 
+        //- Apply the mixed pressure-displacement stress split
+        void applyMixedPressureStressSplit();
+
         //- Allocate the reciprocal of the bulk modulus
         void makeRKappa() const;
 


### PR DESCRIPTION
  
Preserve active stress in mixed pressure-displacement cardiac mechanics

## Changes

  - Fixed electroMechanicalLaw surface active-stress push-forward for constant active tension from J*... to (1.0/J)*....
  - Added electroMechanicalLaw::hasActiveStress(), activeCauchyStress(), and activeCauchyStressf().
  - Reused the active-stress helpers in both volume and surface correct(...) paths.
  - Added nonLinGeomTotalLagTotalDispSolid::applyMixedPressureStressSplit() and used it in predict() and PETSc unpackSolution(...).
  - Preserved passive/non-electromechanical behavior without requiring f0, f0f, Ta, activeTension, or active-stress fields.
  - Fixed GuccioneElastic pressure-displacement Cauchy conversion by dividing the pushed-forward stress by J/Jf.

