### PR TITLE
sphericalCavity: add tet/poly mesh option to Allrun

### DIFF
--- a/tutorials/solids/linearElasticity/sphericalCavity/0/D
+++ b/tutorials/solids/linearElasticity/sphericalCavity/0/D
@@ -53,14 +53,14 @@ boundaryField
     }
     cavity
     {
-        type            solidTraction;
-        traction        uniform ( 0 0 0 );
-        pressure        uniform 0;
+        type            analyticalSphericalCavityTraction;
+        farFieldTractionZ 1e6;
+        cavityRadius    0.2;
+        nu              0.3;
         value           uniform (0 0 0);
     }
     posX
     {
-        type            solidTraction;
         type            analyticalSphericalCavityTraction;
         farFieldTractionZ 1e6;
         cavityRadius    0.2;

--- a/tutorials/solids/linearElasticity/sphericalCavity/Allrun
+++ b/tutorials/solids/linearElasticity/sphericalCavity/Allrun
@@ -11,17 +11,22 @@ IFS=$'\n\t'
 usage() {
 cat <<'EOF'
 Usage:
-  ./Allrun [approach]
+  ./Allrun [approach] [mesh]
 
 Where [approach] is one of:
   petscSnes         (default)
   segregated
   highOrder
 
+Where [mesh] is one of:
+  tet               (default) tetrahedral mesh from gmsh
+  poly              polyhedral mesh via polyDualMesh
+
 Examples:
   ./Allrun
   ./Allrun petscSnes
   ./Allrun highOrder
+  ./Allrun petscSnes poly
 EOF
 }
 
@@ -50,6 +55,17 @@ case "$APPROACH" in
     segregated|petscSnes|highOrder) ;;
     *)
         echo "Error: Unknown approach '$APPROACH'"
+        usage
+        exit 1
+        ;;
+esac
+
+MESH="${2:-tet}"
+
+case "$MESH" in
+    tet|poly) ;;
+    *)
+        echo "Error: Unknown mesh '$MESH'"
         usage
         exit 1
         ;;
@@ -129,8 +145,14 @@ then
     # Create mesh with gmsh
     solids4Foam::runApplication gmsh -3 -format msh2 sphericalCavity.geo
     solids4Foam::runApplication gmshToFoam sphericalCavity.msh
-    solids4Foam::runApplication polyDualMesh 30 -overwrite
-    solids4Foam::runApplication combinePatchFaces 45 -overwrite
+
+    if [[ "$MESH" == "poly" ]]
+    then
+        echo "Converting the tetrahedral mesh to a polyhedral mesh"
+        solids4Foam::runApplication polyDualMesh 30 -overwrite
+        solids4Foam::runApplication combinePatchFaces 45 -overwrite
+    fi
+
     solids4Foam::runApplication changeDictionary
 
     # Move 0 back

--- a/tutorials/solids/linearElasticity/sphericalCavity/README.md
+++ b/tutorials/solids/linearElasticity/sphericalCavity/README.md
@@ -9,8 +9,9 @@ Prepared by Philip Cardiff and Ivan Batistić
 ## Tutorial Aims
 
 - Demonstrate how to perform a 3D linear-static stress analysis in solids4foam
-- Demonstrate the process of meshing using the Gmsh meshing utility and
-  OpenFOAM `polyDualMesh` utility
+- Demonstrate the process of meshing using the Gmsh meshing utility, with
+  optional conversion to a polyhedral mesh using the OpenFOAM `polyDualMesh`
+  utility
 - Demonstrates using the solids4foam solid solver based on the PETSc SNES
   nonlinear solver
 
@@ -47,7 +48,8 @@ This classic 3-D problem consists of a spherical cavity with radius $a = 0.2$ m
 
 ![-](images/sphericalCavity-geometry.png)
 
-**Figure 1: Spherical cavity case geometry and mesh (4 555 cells).**
+**Figure 1: Spherical cavity case geometry and polyhedral mesh (4 555 cells),
+as produced by the optional `poly` mesh option.**
 
 ---
 
@@ -158,7 +160,7 @@ The distribution of $zz$-component of stress field (`sigma[ZZ]`) is shown in
 The tutorial case is located at
 `solids4foam/tutorials/solids/linearElasticity/sphericalCavity`. The case can
 be run using the included `Allrun` script. The `Allrun` script optionally takes
-an argument that specifies the solution approach:
+a first argument that specifies the solution approach:
 
 ```bash
 ./Allrun             # Defaults to the PETSc SNES second-order approach [3]
@@ -166,19 +168,32 @@ an argument that specifies the solution approach:
 ./Allrun highOrder   # PETSc SNES high-order approach [4]
 ```
 
+and an optional second argument that specifies the mesh type:
+
+```bash
+./Allrun petscSnes tet   # Defaults to the tetrahedral mesh
+./Allrun petscSnes poly  # Polyhedral (dual) mesh
+```
+
 The `Allrun` script starts by updating the files in the case to match the
 selected approach; the following files are updated: `constant/solidProperties`,
 `system/fvSchemes`, and `system/fvSolution`. Subsequently, the tutorial-local
 library in the `src` directory is compiled, and the unstructured tetrahedral
-mesh is created using the Gmsh meshing utility, followed by conversion to its
-dual polyhedral representation using the OpenFOAM `polyDualMesh` utility:
+mesh is created using the Gmsh meshing utility. If the `poly` mesh type is
+selected, the tetrahedral mesh is then converted to its dual polyhedral
+representation using the OpenFOAM `polyDualMesh` utility:
 
 ```bash
    # Create mesh with gmsh
     solids4Foam::runApplication gmsh -3 -format msh2 sphericalCavity.geo
     solids4Foam::runApplication gmshToFoam sphericalCavity.msh
-    solids4Foam::runApplication polyDualMesh 30 -overwrite
-    solids4Foam::runApplication combinePatchFaces 45 -overwrite
+
+    if [[ "$MESH" == "poly" ]]
+    then
+        solids4Foam::runApplication polyDualMesh 30 -overwrite
+        solids4Foam::runApplication combinePatchFaces 45 -overwrite
+    fi
+
     solids4Foam::runApplication changeDictionary
 ```
 

--- a/tutorials/solids/linearElasticity/sphericalCavity/constant/solidProperties.highOrder
+++ b/tutorials/solids/linearElasticity/sphericalCavity/constant/solidProperties.highOrder
@@ -32,7 +32,7 @@ linearGeometryTotalDisplacementCoeffs
         displacement
         {
             // Polynomial order of displacement field
-            polynomialOrder 2;
+            polynomialOrder 3;
 
             // Extra cells in minimum size stencil
             faceStencilExtraCells 60;


### PR DESCRIPTION
## Summary

Adds an optional second argument to the `sphericalCavity` tutorial `Allrun` script to select the mesh type:

```bash
./Allrun petscSnes tet   # (default) tetrahedral mesh from gmsh
./Allrun petscSnes poly  # polyhedral mesh via polyDualMesh
```

`polyDualMesh` and `combinePatchFaces` now only run for `poly`. `changeDictionary` runs in both cases, since it sets the symmetry patch types that `gmshToFoam` writes as plain `patch`.

**Behaviour change:** a bare `./Allrun` previously always produced the polyhedral mesh; it now produces the tetrahedral mesh. Happy to flip the default to `poly` if that is preferred for the reference results.

## README

- Documents the new argument
- Notes the `polyDualMesh` conversion is optional
- Clarifies that Figure 1 shows the polyhedral mesh
- Passes `markdownlint`

## Also included

Two pre-existing working-tree changes in the same case, included at the author's request:

- `0/D`: `cavity` patch uses `analyticalSphericalCavityTraction`; duplicate `type` entry removed from `posX`
- `constant/solidProperties.highOrder`: `polynomialOrder` 2 -> 3

## Verification

- `bash -n Allrun` and argument parsing/usage/error paths exercised
- `markdownlint README.md` clean
- The case itself was **not** run, so the tet-mesh path is numerically untested

🤖 Generated with [Claude Code](https://claude.com/claude-code)