### PR TITLE
Add v2512 docker release image and manual promote-to-latest workflow

### DIFF
--- a/.github/workflows/docker-promote-latest.yml
+++ b/.github/workflows/docker-promote-latest.yml
@@ -1,0 +1,46 @@
+name: Docker promote to latest (manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "solids4foam release version of the image to promote (e.g. v2.3)"
+        required: true
+        type: string
+      variant:
+        description: "OpenFOAM variant of the image to promote"
+        required: true
+        type: choice
+        options:
+          - openfoam-v2512
+          - openfoam-v2412
+          - openfoam-v2312
+          - openfoam-9
+          - foam-extend-4.1
+
+jobs:
+  promote:
+    runs-on: ubuntu-22.04
+
+    env:
+      REPO: solids4foam/solids4foam
+      SOURCE_TAG: ${{ inputs.version }}-${{ inputs.variant }}
+
+    steps:
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Check source image exists
+        run: docker buildx imagetools inspect "${REPO}:${SOURCE_TAG}"
+
+      - name: Point 'latest' at the chosen image
+        run: |
+          docker buildx imagetools create \
+            --tag "${REPO}:latest" \
+            "${REPO}:${SOURCE_TAG}"

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -16,6 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         image:
+          - { name: "openfoam-v2512", file: ".docker/Dockerfile.openfoamv2512" }
           - { name: "openfoam-v2412", file: ".docker/Dockerfile.openfoamv2412" }
           - { name: "openfoam-v2312", file: ".docker/Dockerfile.openfoamv2312" }
           - { name: "openfoam-9",     file: ".docker/Dockerfile.openfoam9" }


### PR DESCRIPTION
## Summary

- Add an `openfoam-v2512` image variant to the `docker-release.yml` build matrix. The PETSc-enabled base image (`philippic/openfoam-v2512:ubuntu-22.04-petsc-no-openmp-system-blas`) and `.docker/Dockerfile.openfoamv2512` already exist; this wires it into the release build so v2512 images are built and pushed alongside the others.
- Add `docker-promote-latest.yml`, a new manually-dispatched workflow that re-points the `latest` tag at an already-published image.

## Promote-to-latest workflow

- **Inputs**: `version` (free text, e.g. `v2.3`) and `variant` (constrained dropdown of the 5 known OpenFOAM variants, newest first).
- **Safety**: verifies the source image `solids4foam/solids4foam:<version>-<variant>` exists via `docker buildx imagetools inspect` before doing anything, so a typo fails fast instead of creating a broken `latest`.
- **Promotion**: uses `docker buildx imagetools create` to alias `latest` without pulling or rebuilding layers, preserving multi-arch manifests.

All Dockerfiles referenced by these workflows already use PETSc-enabled base images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)