### PR TITLE
Fix for OF9 functionObject output and high-order parallel MLS exchange 

### DIFF
--- a/src/solids4FoamModels/higherOrderHelpers/movingLeastSquaresStencil/movingLeastSquaresStencil.C
+++ b/src/solids4FoamModels/higherOrderHelpers/movingLeastSquaresStencil/movingLeastSquaresStencil.C
@@ -98,15 +98,16 @@ List<scalar> movingLeastSquaresStencil::calcFirstHaloDepth() const
         const label from = nbrs[i];
 
 #ifdef OPENFOAM_COM
-        if (pBufs.recvDataCount(from))
+        if (!pBufs.recvDataCount(from))
         {
-            UIPstream is(from, pBufs);
-
-            scalar lenN;
-            is >> lenN;
-            neighbourHaloDepth[from] = lenN;
+            continue;
         }
 #endif
+        UIPstream is(from, pBufs);
+
+        scalar lenN;
+        is >> lenN;
+        neighbourHaloDepth[from] = lenN;
     }
 
     // Return averaged first halo depth per processor

--- a/tutorials/solids/linearElasticity/cantilever2d/src/cantileverAnalyticalSolutionFunctionObject/cantileverAnalyticalSolution.C
+++ b/tutorials/solids/linearElasticity/cantilever2d/src/cantileverAnalyticalSolutionFunctionObject/cantileverAnalyticalSolution.C
@@ -348,6 +348,11 @@ bool Foam::cantileverAnalyticalSolution::execute(const bool forceWrite)
 bool Foam::cantileverAnalyticalSolution::execute()
 #endif
 {
+    if (time_.timeIndex() == time_.startTimeIndex())
+    {
+        return true;
+    }
+
     return writeData();
 }
 

--- a/tutorials/solids/linearElasticity/plateHole/src/plateHoleAnalyticalSolution/plateHoleAnalyticalSolution.C
+++ b/tutorials/solids/linearElasticity/plateHole/src/plateHoleAnalyticalSolution/plateHoleAnalyticalSolution.C
@@ -722,6 +722,11 @@ bool Foam::plateHoleAnalyticalSolution::start()
     bool Foam::plateHoleAnalyticalSolution::execute()
 #endif
 {
+    if (time_.timeIndex() == time_.startTimeIndex())
+    {
+        return true;
+    }
+
     return writeData();
 }
 

--- a/tutorials/solids/linearElasticity/pressurisedCylinder/src/pressurisedCylinderAnalyticalSolutionFunctionObject/pressurisedCylinderAnalyticalSolution.C
+++ b/tutorials/solids/linearElasticity/pressurisedCylinder/src/pressurisedCylinderAnalyticalSolutionFunctionObject/pressurisedCylinderAnalyticalSolution.C
@@ -509,6 +509,11 @@ bool Foam::pressurisedCylinderAnalyticalSolution::execute(const bool forceWrite)
 bool Foam::pressurisedCylinderAnalyticalSolution::execute()
 #endif
 {
+    if (time_.timeIndex() == time_.startTimeIndex())
+    {
+        return true;
+    }
+
     return writeData();
 }
 


### PR DESCRIPTION

  ## Pull Request Description

  This PR fixes two small issues affecting high-order tutorial runs:

  - Analytical tutorial function objects printed and wrote comparison fields once before the solver ran and then again after the solve.
 
  - OpenFOAM-9 parallel high-order runs could abort during MLS stencil setup because a processor halo-depth message was sent but not consumed.
  
  ## Changes Made

  - [x] **Bug Fix**: Consume the MLS halo-depth message in OpenFOAM.org/OF9 builds.
  - [x] **Bug Fix**: Suppress startup analytical function-object output before the first solver step.

  ### Summary of Changes

  - **Files Modified**:
    - `src/solids4FoamModels/higherOrderHelpers/movingLeastSquaresStencil/movingLeastSquaresStencil.C`
    - `tutorials/solids/linearElasticity/cantilever2d/src/cantileverAnalyticalSolutionFunctionObject/cantileverAnalyticalSolution.C`
    - `tutorials/solids/linearElasticity/plateHole/src/plateHoleAnalyticalSolution/plateHoleAnalyticalSolution.C`
    - `tutorials/solids/linearElasticity/pressurisedCylinder/src/pressurisedCylinderAnalyticalSolutionFunctionObject/
    pressurisedCylinderAnalyticalSolution.C`


 