### PR TITLE
Fix sonicLiquidFluid tabulated acceleration fields

### DIFF
--- a/src/solids4FoamModels/fluidModels/sonicLiquidFluid/sonicLiquidFluid.esi.C
+++ b/src/solids4FoamModels/fluidModels/sonicLiquidFluid/sonicLiquidFluid.esi.C
@@ -284,6 +284,21 @@ sonicLiquidFluid::sonicLiquidFluid
         ),
         rhoO_ + psi_*p()
     ),
+    hRef_
+    (
+        IOobject
+        (
+            "hRef",
+            runTime.constant(),
+            mesh(),
+            IOobject::READ_IF_PRESENT,
+            IOobject::NO_WRITE
+        ),
+        dimensionedScalar(dimLength, 0)
+    ),
+    ghRef_(-mag(g())*hRef_),
+    gh_("gh", (g() & mesh().C()) - ghRef_),
+    ghf_("ghf", (g() & mesh().Cf()) - ghRef_),
     rAU_
     (
         IOobject

--- a/src/solids4FoamModels/fluidModels/sonicLiquidFluid/sonicLiquidFluid.esi.H
+++ b/src/solids4FoamModels/fluidModels/sonicLiquidFluid/sonicLiquidFluid.esi.H
@@ -83,6 +83,12 @@ class sonicLiquidFluid
         //- Fluid density
         volScalarField rho_;
 
+        //- Gravity related fields
+        uniformDimensionedScalarField hRef_;
+        dimensionedScalar ghRef_;
+        volScalarField gh_;
+        surfaceScalarField ghf_;
+
         //- Creates and initialises the momentum field rhoUf
         autoPtr<surfaceVectorField> rhoUf_;
 


### PR DESCRIPTION
## Summary

- register the `hRef`, `gh`, and `ghf` gravity fields in the OpenFOAM.com
  `sonicLiquidFluid` model
- allow `tabulatedAccelerationSource` to update those fields without failing
  object-registry lookups
- retain the existing optional `constant/hRef` input behavior

## Root cause

OpenFOAM.com's `tabulatedAccelerationSource` looks up `hRef`, `gh`, and `ghf`
when gravity is available. Unlike other fluid models, `sonicLiquidFluid` did
not create these fields, causing the source to abort at its first lookup.

## Validation

- `wmake libso src/solids4FoamModels` with OpenFOAM v2412
- one-step `3dTube` FSI run using `sonicLiquidFluid` with
  `tabulatedAccelerationSource` active
- `git diff --check`

Closes #20.
