### PR TITLE
Document and fix RBF mesh motion FSI setup

### DIFF
--- a/src/Allwmake
+++ b/src/Allwmake
@@ -8,7 +8,16 @@ then
 fi
 
 (cd blockCoupledSolids4FoamTools && ./Allwmake $targetType $* 2>&1 | tee log.Allwmake)
-(cd RBFMeshMotionSolver && ./Allwmake $targetType $* 2>&1 | tee log.Allwmake)
+
+if [[ -z "${S4F_NO_RBF:-}" ]]
+then
+    (cd RBFMeshMotionSolver && ./Allwmake $targetType $* 2>&1 | tee log.Allwmake)
+else
+    echo; echo "The S4F_NO_RBF variable is set: skipping RBFMeshMotionSolver"
+    echo "The RBFMeshMotionSolver mesh motion solver and the rbf"
+    echo "interfaceToInterfaceMapping will not be available"; echo
+fi
+
 (cd solids4FoamModels && ./Allwmake $targetType $* 2>&1 | tee log.Allwmake)
 
 if [[ ! -z "${S4F_USE_GFORTRAN+x}" ]]

--- a/src/RBFMeshMotionSolver/RBFMeshMotionSolver.C
+++ b/src/RBFMeshMotionSolver/RBFMeshMotionSolver.C
@@ -92,6 +92,7 @@ RBFMeshMotionSolver::RBFMeshMotionSolver
     nbPoints(0),
     faceCellCenters(true),
     cpu(false),
+    motionCentersSet_(false),
     corrector(false),
     k(0)
 {
@@ -364,6 +365,7 @@ void RBFMeshMotionSolver::setMotion(const Field<vectorField> & motion)
     }
 
     motionCenters = motion;
+    motionCentersSet_ = true;
 }
 
 void RBFMeshMotionSolver::updateMesh(const mapPolyMesh &)
@@ -375,16 +377,23 @@ void RBFMeshMotionSolver::solve()
 {
     assert(motionCenters.size() == mesh().boundaryMesh().size());
 
-    // Copy motionCentersField to motionCenters
-    forAll(accumulatedMotionCentersField_.boundaryField(), patchI)
+    if (!motionCentersSet_)
     {
-        motionCenters[patchI] =
-            accumulatedMotionCentersField_.boundaryField()[patchI]
-          - accumulatedMotionCentersField_.prevIter().boundaryField()[patchI];
+        // Copy motionCentersField to motionCenters
+        forAll(accumulatedMotionCentersField_.boundaryField(), patchI)
+        {
+            motionCenters[patchI] =
+                accumulatedMotionCentersField_.boundaryField()[patchI]
+              - accumulatedMotionCentersField_.prevIter().boundaryField()
+                [
+                    patchI
+                ];
+        }
     }
 
     // Update previous field
     accumulatedMotionCentersField_.storePrevIter();
+    motionCentersSet_ = false;
 
 
     /*

--- a/src/RBFMeshMotionSolver/RBFMeshMotionSolver.C
+++ b/src/RBFMeshMotionSolver/RBFMeshMotionSolver.C
@@ -210,12 +210,31 @@ RBFMeshMotionSolver::RBFMeshMotionSolver
     assert(rbfFunction);
 
     bool polynomialTerm = dict.lookupOrDefault("polynomial", false);
-    bool cpu = dict.lookupOrDefault("cpu", false);
-    this->cpu = dict.lookupOrDefault("fullCPU", false);
-    std::shared_ptr<rbf::RBFInterpolation> rbfInterpolator(new rbf::RBFInterpolation(rbfFunction, polynomialTerm, cpu));
 
-    if (this->cpu == true)
-        assert(cpu == true);
+    // The "cpu" option selects the memory-lean formulation, where the
+    // factorisation of the interpolation matrix is stored and back-substituted
+    // at each interpolation, instead of storing the explicit (dense)
+    // interpolation matrix.
+    // The "fullCPU" option additionally discards the factorisation after every
+    // mesh motion update, forcing the control point positions and the
+    // factorisation to be recomputed from the current (deformed) mesh. This is
+    // only meaningful for the "cpu" formulation, hence "fullCPU" implies "cpu".
+    this->cpu = dict.lookupOrDefault("fullCPU", false);
+    bool cpu = dict.lookupOrDefault("cpu", false);
+
+    if (this->cpu && !cpu)
+    {
+        if (dict.found("cpu"))
+        {
+            WarningInFunction
+                << "cpu is disabled but fullCPU is enabled: "
+                << "enabling cpu, as required by fullCPU" << endl;
+        }
+
+        cpu = true;
+    }
+
+    std::shared_ptr<rbf::RBFInterpolation> rbfInterpolator(new rbf::RBFInterpolation(rbfFunction, polynomialTerm, cpu));
 
     const bool coarsening =
         readBool(coeffDict.subDict("coarsening").lookup("enabled"));
@@ -292,6 +311,7 @@ RBFMeshMotionSolver::RBFMeshMotionSolver
     Info << "    interpolation function = " << function << endl;
     Info << "    interpolation polynomial term = " << polynomialTerm << endl;
     Info << "    interpolation cpu formulation = " << cpu << endl;
+    Info << "    interpolation full cpu formulation = " << this->cpu << endl;
     Info << "    coarsening = " << coarsening << endl;
     Info << "        coarsening tolerance = " << tol << endl;
     Info << "        coarsening reselection tolerance = " << tolLivePointSelection << endl;

--- a/src/RBFMeshMotionSolver/RBFMeshMotionSolver.H
+++ b/src/RBFMeshMotionSolver/RBFMeshMotionSolver.H
@@ -94,6 +94,8 @@ namespace Foam
             int nbPoints;
             bool faceCellCenters;
             bool cpu;
+            //- True when setMotion has supplied the current incremental motion
+            bool motionCentersSet_;
 
         public:
             // Runtime type information

--- a/src/RBFMeshMotionSolver/README.md
+++ b/src/RBFMeshMotionSolver/README.md
@@ -5,6 +5,25 @@ interpolation from selected boundary control points. It is intended for cases
 where the moving boundary displacement is known, for example the fluid mesh in
 a fluid-solid interaction case.
 
+## Building
+
+The library is built by default as part of `Allwmake`. It has no solids4foam
+dependencies of its own, so it can be excluded from the build by setting
+
+```bash
+export S4F_NO_RBF=1
+```
+
+before building. `solids4FoamModels` is then compiled with `-DS4F_NO_RBF` and
+does not link against `libRBFMeshMotionSolver`, which also removes the
+`RBFMeshMotionSolver` mesh motion solver and the `rbf`
+`interfaceToInterfaceMapping` from the runtime selection tables. Cases relying
+on either of these will stop with an unknown-type error listing the available
+selections.
+
+Setting or unsetting the variable does not invalidate objects compiled with the
+previous setting, so run `./Allwclean` before rebuilding when changing it.
+
 ## Example: `perpendicularFlap`
 
 The `perpendicularFlap` tutorial has a small two-dimensional fluid mesh and is a
@@ -87,10 +106,18 @@ functions require a positive `radius` entry in the `interpolation` dictionary.
 system. This can improve rigid-body-like motion reproduction, but it increases
 the dense system size.
 
-`cpu` stores the factorisation of the control-point system and evaluates the
-point interpolation matrix at each interpolation. With `cpu no`, the solver
-stores the full point interpolation matrix. `fullCPU yes` requires `cpu yes` and
-keeps more of the interpolation work out of the precomputed matrix path.
+`cpu` selects the memory-lean formulation: the factorisation of the
+control-point system is stored, and the point interpolation matrix is evaluated
+at each interpolation. With `cpu no`, the solver instead stores the explicit
+(dense) point interpolation matrix, which is faster per motion update but uses
+considerably more memory for large meshes.
+
+`fullCPU` additionally discards the factorisation after every motion update, so
+the control point positions and the factorisation are rebuilt from the current
+(deformed) mesh each time. This is the slowest and leanest option, and is only
+needed when the control point positions themselves change during the run.
+`fullCPU yes` implies `cpu yes`: setting `cpu no; fullCPU yes;` enables `cpu`
+and issues a warning.
 
 ## Coarsening Options
 

--- a/src/RBFMeshMotionSolver/README.md
+++ b/src/RBFMeshMotionSolver/README.md
@@ -1,0 +1,131 @@
+# RBF Mesh Motion Solver
+
+`RBFMeshMotionSolver` moves internal mesh points by radial basis function
+interpolation from selected boundary control points. It is intended for cases
+where the moving boundary displacement is known, for example the fluid mesh in
+a fluid-solid interaction case.
+
+## Example: `perpendicularFlap`
+
+The `perpendicularFlap` tutorial has a small two-dimensional fluid mesh and is a
+convenient starting point for testing the solver. The default tutorial keeps the
+finite-volume `velocityLaplacian` mesh motion solver enabled, but the following
+settings can be used in
+`tutorials/fluidSolidInteraction/perpendicularFlap/constant/fluid/dynamicMeshDict`
+with OpenFOAM.com:
+
+```cpp
+dynamicFvMesh dynamicMotionSolverFvMesh;
+
+"solver|motionSolver" RBFMeshMotionSolver;
+motionSolverLibs ("libRBFMeshMotionSolver.so");
+
+RBFMeshMotionSolverCoeffs
+{
+    staticPatches    (upperWall lowerWall);
+    movingPatches    (flap);
+    fixedPatches     (inlet outlet);
+
+    interpolation
+    {
+        function     TPS;
+        polynomial   no;
+        cpu          no;
+        fullCPU      no;
+    }
+
+    coarsening
+    {
+        enabled                 yes;
+        tol                     0.05;
+        minPoints               20;
+        maxPoints               200;
+        livePointSelection      yes;
+        tolLivePointSelection   0.05;
+        exportSelectedPoints    no;
+        twoPointSelection       no;
+        surfaceCorrection       no;
+    }
+}
+```
+
+When switching this tutorial to `RBFMeshMotionSolver`, remove or rename
+`0/fluid/pointMotionU`. If that field is present, the FSI mesh-motion code treats
+the case as a finite-volume mesh-motion case and does not pass the interface
+motion to the RBF solver.
+
+For foam-extend builds, the entries inside `RBFMeshMotionSolverCoeffs` are read
+directly from `dynamicMeshDict`, so omit the wrapper dictionary.
+
+These settings were checked with the `perpendicularFlap` case on OpenFOAM v2312
+for a short transient run. They are not intended to be universal optimum values;
+increase `maxPoints`, tighten the tolerances, and inspect mesh quality for larger
+or more distorted meshes.
+
+## Patch Lists
+
+`movingPatches` are the boundary patches whose displacement drives the mesh
+motion. In the flap case this is the fluid-side FSI patch, `flap`.
+
+`staticPatches` are included as zero-motion control points. Use these for walls
+or other boundaries that must anchor the interpolation.
+
+`fixedPatches` are enforced back to zero after interpolation. Use these for
+boundaries such as inlet and outlet patches where the mesh must remain fixed.
+
+Do not put the same patch in more than one of these lists. Empty, wedge, and
+processor patches should normally be omitted.
+
+## Interpolation Options
+
+`function` selects the radial basis function. Valid values are `TPS`,
+`WendlandC0`, `WendlandC2`, `WendlandC4`, and `WendlandC6`. The Wendland
+functions require a positive `radius` entry in the `interpolation` dictionary.
+`TPS` does not use `radius`.
+
+`polynomial` adds a constant and linear polynomial term to the interpolation
+system. This can improve rigid-body-like motion reproduction, but it increases
+the dense system size.
+
+`cpu` stores the factorisation of the control-point system and evaluates the
+point interpolation matrix at each interpolation. With `cpu no`, the solver
+stores the full point interpolation matrix. `fullCPU yes` requires `cpu yes` and
+keeps more of the interpolation work out of the precomputed matrix path.
+
+## Coarsening Options
+
+Coarsening reduces the number of boundary control points used by the dense RBF
+solve. This is useful for large boundary meshes, where using every moving and
+static face centre can become expensive.
+
+`enabled` switches coarsening on or off. With `enabled no`, all moving and static
+control points are used.
+
+`tol` is the relative error tolerance used by the greedy point selection. The
+selection stops when both the global 2-norm error and maximum point error are
+below this value, after at least `minPoints` have been selected, or when
+`maxPoints` is reached.
+
+`minPoints` and `maxPoints` bound the selected control-point count. For a larger
+mesh, raise `maxPoints` if the reported coarsening error remains high.
+
+`livePointSelection` recomputes the selected control points from the accumulated
+motion during the run. This is usually preferable for FSI cases because the
+important control points may change as the interface deforms.
+
+`tolLivePointSelection` controls when live point selection is reused. If the
+current selected points interpolate the accumulated boundary motion below this
+relative tolerance, the solver reuses them; otherwise it selects a new set.
+
+`exportSelectedPoints` writes the selected point coordinates to
+`rbf-coarsening-greedy-selection-*.txt` and `.csv` files for inspection.
+
+`twoPointSelection` may add a second point in the opposite error direction during
+each greedy selection step. This can improve selection for motions with opposing
+directions, at the cost of selecting points faster.
+
+`surfaceCorrection` applies an additional WendlandC2 correction based on the
+coarse interpolation error at the boundary. `ratioRadiusError` controls the
+correction radius as a multiple of the maximum boundary interpolation error and
+defaults to `10.0` when `surfaceCorrection` is enabled but `ratioRadiusError` is
+not specified.

--- a/src/solids4FoamModels/Make/options
+++ b/src/solids4FoamModels/Make/options
@@ -50,11 +50,19 @@ else
     VERSION_SPECIFIC_INC += -I../../ThirdParty/eigen3
 endif
 
+ifdef S4F_NO_RBF
+    VERSION_SPECIFIC_INC += -DS4F_NO_RBF
+    RBF_LIB =
+else
+    VERSION_SPECIFIC_INC += \
+        -I$(SOLIDS4FOAM_ROOT)/src/RBFMeshMotionSolver/lnInclude
+    RBF_LIB = -lRBFMeshMotionSolver
+endif
+
 EXE_INC = \
     -Wno-old-style-cast -Wno-deprecated-declarations \
     $(VERSION_SPECIFIC_INC) \
     -I$(SOLIDS4FOAM_ROOT)/src/blockCoupledSolids4FoamTools/lnInclude \
-    -I$(SOLIDS4FOAM_ROOT)/src/RBFMeshMotionSolver/lnInclude \
     -I$(LIB_SRC)/finiteVolume/lnInclude \
     -I$(LIB_SRC)/meshTools/lnInclude \
     -I$(LIB_SRC)/finiteArea/lnInclude \
@@ -113,4 +121,4 @@ LIB_LIBS = \
     -lmeshTools \
     -ltopoChangerFvMesh \
     -L$(FOAM_MODULE_LIBBIN) \
-    -lblockCoupledSolids4FoamTools -lRBFMeshMotionSolver
+    -lblockCoupledSolids4FoamTools $(RBF_LIB)

--- a/src/solids4FoamModels/fluidSolidInterfaces/fluidSolidInterface/fluidSolidInterface.C
+++ b/src/solids4FoamModels/fluidSolidInterfaces/fluidSolidInterface/fluidSolidInterface.C
@@ -34,7 +34,10 @@ License
 #include "ZoneIDs.H"
 #include "elasticWallPressureFvPatchScalarField.H"
 #include "movingWallPressureFvPatchScalarField.H"
-#include "RBFMeshMotionSolver.H"
+#include "addToRunTimeSelectionTable.H"
+#ifndef S4F_NO_RBF
+    #include "RBFMeshMotionSolver.H"
+#endif
 #include "FieldSumOp.H"
 #ifdef OPENFOAM_COM
     #include "dynamicMotionSolverFvMesh.H"
@@ -1034,7 +1037,7 @@ void Foam::fluidSolidInterface::moveFluidMesh()
         const bool fvMotionSolver =
             fluidMesh().foundObject<pointVectorField>("pointMotionU");
 
-#ifndef OPENFOAM_ORG
+#if !defined(OPENFOAM_ORG) && !defined(S4F_NO_RBF)
         // Check for RBF motion solver
         RBFMeshMotionSolver* rbfMotionSolverPtr = nullptr;
 #ifdef OPENFOAM_COM
@@ -1185,7 +1188,7 @@ void Foam::fluidSolidInterface::moveFluidMesh()
             }
         }
 #endif
-#ifndef OPENFOAM_ORG
+#if !defined(OPENFOAM_ORG) && !defined(S4F_NO_RBF)
         else if (rbfMotionSolverPtr)
         {
             // Prepare list of patch motions

--- a/src/solids4FoamModels/fluidSolidInterfaces/fluidSolidInterface/fluidSolidInterface.C
+++ b/src/solids4FoamModels/fluidSolidInterfaces/fluidSolidInterface/fluidSolidInterface.C
@@ -36,6 +36,9 @@ License
 #include "movingWallPressureFvPatchScalarField.H"
 #include "RBFMeshMotionSolver.H"
 #include "FieldSumOp.H"
+#ifdef OPENFOAM_COM
+    #include "dynamicMotionSolverFvMesh.H"
+#endif
 
 
 // * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
@@ -1033,14 +1036,39 @@ void Foam::fluidSolidInterface::moveFluidMesh()
 
 #ifndef OPENFOAM_ORG
         // Check for RBF motion solver
-        bool rbfMotionSolver = false;
+        RBFMeshMotionSolver* rbfMotionSolverPtr = nullptr;
+#ifdef OPENFOAM_COM
+        if (isA<dynamicMotionSolverFvMesh>(fluidMesh()))
+        {
+            motionSolver& motion =
+                const_cast<motionSolver&>
+                (
+                    refCast<const dynamicMotionSolverFvMesh>
+                    (
+                        fluidMesh()
+                    ).motion()
+                );
+
+            if (isA<RBFMeshMotionSolver>(motion))
+            {
+                rbfMotionSolverPtr = &refCast<RBFMeshMotionSolver>(motion);
+            }
+        }
+#else
         if (fluidMesh().foundObject<motionSolver>("dynamicMeshDict"))
         {
-            rbfMotionSolver = isA<RBFMeshMotionSolver>
-            (
-                fluidMesh().lookupObject<motionSolver>("dynamicMeshDict")
-            );
+            motionSolver& motion =
+                const_cast<motionSolver&>
+                (
+                    fluidMesh().lookupObject<motionSolver>("dynamicMeshDict")
+                );
+
+            if (isA<RBFMeshMotionSolver>(motion))
+            {
+                rbfMotionSolverPtr = &refCast<RBFMeshMotionSolver>(motion);
+            }
         }
+#endif
 #endif
 
         // Set motion on FSI interface
@@ -1158,7 +1186,7 @@ void Foam::fluidSolidInterface::moveFluidMesh()
         }
 #endif
 #ifndef OPENFOAM_ORG
-        else if (rbfMotionSolver)
+        else if (rbfMotionSolverPtr)
         {
             // Prepare list of patch motions
             Field<vectorField> motion(fluidMesh().boundaryMesh().size());
@@ -1195,10 +1223,7 @@ void Foam::fluidSolidInterface::moveFluidMesh()
 
             // Set motion field in RBF motion solver
             // Note: take displacement as opposed to velocity
-            const_cast<RBFMeshMotionSolver&>
-            (
-                fluidMesh().lookupObject<RBFMeshMotionSolver>("dynamicMeshDict")
-            ).setMotion(motion);
+            rbfMotionSolverPtr->setMotion(motion);
         }
 #endif
         else

--- a/src/solids4FoamModels/fluidSolidInterfaces/fluidSolidInterface/interfaceToInterfaceMapping/rbfInterfaceToInterfaceMapping/rbfInterfaceToInterfaceMapping.C
+++ b/src/solids4FoamModels/fluidSolidInterfaces/fluidSolidInterface/interfaceToInterfaceMapping/rbfInterfaceToInterfaceMapping/rbfInterfaceToInterfaceMapping.C
@@ -17,6 +17,8 @@ License
 
 \*---------------------------------------------------------------------------*/
 
+#ifndef S4F_NO_RBF
+
 #include "rbfInterfaceToInterfaceMapping.H"
 #include "addToRunTimeSelectionTable.H"
 #include "TPSFunction.H"
@@ -282,5 +284,7 @@ void rbfInterfaceToInterfaceMapping::transferPointsZoneToZone
 } // End namespace interfaceToInterfaceMappings
 
 } // End namespace Foam
+
+#endif // end of #ifndef S4F_NO_RBF
 
 // ************************************************************************* //

--- a/tutorials/fluidSolidInteraction/perpendicularFlap/constant/fluid/dynamicMeshDict
+++ b/tutorials/fluidSolidInteraction/perpendicularFlap/constant/fluid/dynamicMeshDict
@@ -26,30 +26,73 @@ dynamicFvMesh dynamicMotionSolverFvMesh;
 diffusivity quadratic inverseDistance (flap);
 
 // Settings for the RBF solver
+// See src/RBFMeshMotionSolver/README.md for further details
 // RBFMeshMotionSolverCoeffs
 // {
-//     staticPatches    (upperWall lowerWall);
+//     // Patches whose displacement drives the mesh motion, i.e. the fluid-side
+//     // FSI patch
 //     movingPatches    (flap);
+//
+//     // Patches included as zero-motion control points, which anchor the
+//     // interpolation
+//     staticPatches    (upperWall lowerWall);
+//
+//     // Patches reset to zero motion after the interpolation
 //     fixedPatches     (inlet outlet);
+//
+//     // A patch should appear in at most one of the three lists above; empty,
+//     // wedge and processor patches are omitted
 //
 //     interpolation
 //     {
+//         // Radial basis function: TPS, WendlandC0, WendlandC2, WendlandC4 or
+//         // WendlandC6; the Wendland functions also require a "radius" entry
 //         function     TPS;
+//
+//         // Add constant and linear polynomial terms to the interpolation;
+//         // improves rigid-body-like motion at the cost of a larger system
 //         polynomial   no;
+//
+//         // Store the factorisation of the control-point system rather than
+//         // the explicit interpolation matrix: slower, but much less memory
 //         cpu          no;
+//
+//         // Also rebuild the control point positions and the factorisation at
+//         // every motion update; implies "cpu"
 //         fullCPU      no;
 //     }
 //
 //     coarsening
 //     {
+//         // Select a subset of the boundary control points, rather than using
+//         // every moving and static face centre
 //         enabled                 yes;
+//
+//         // Relative error tolerance for the greedy point selection
 //         tol                     0.05;
+//
+//         // Bounds on the number of selected control points
 //         minPoints               20;
 //         maxPoints               200;
+//
+//         // Reselect the control points during the run from the accumulated
+//         // motion; usually preferable for FSI, as the interface deforms
 //         livePointSelection      yes;
+//
+//         // Reuse the current selection while it interpolates the accumulated
+//         // motion below this relative tolerance
 //         tolLivePointSelection   0.05;
+//
+//         // Write the selected point coordinates for inspection
 //         exportSelectedPoints    no;
+//
+//         // Add a second point in the opposite error direction at each greedy
+//         // selection step
 //         twoPointSelection       no;
+//
+//         // Apply a WendlandC2 correction based on the coarse interpolation
+//         // error at the boundary; "ratioRadiusError" (default 10.0) sets the
+//         // correction radius
 //         surfaceCorrection       no;
 //     }
 // }

--- a/tutorials/fluidSolidInteraction/perpendicularFlap/constant/fluid/dynamicMeshDict
+++ b/tutorials/fluidSolidInteraction/perpendicularFlap/constant/fluid/dynamicMeshDict
@@ -21,20 +21,38 @@ dynamicFvMesh dynamicMotionSolverFvMesh;
 "solver|motionSolver" velocityLaplacian; // finite volume solver
 //"solver|motionSolver" laplace; // finite element solver
 //"solver|motionSolver" RBFMeshMotionSolver; // radial basis function solver
+// motionSolverLibs ("libRBFMeshMotionSolver.so");
 
 diffusivity quadratic inverseDistance (flap);
 
 // Settings for the RBF solver
-// staticPatches    (top bottom left);
-// movingPatches    (interface);
-// fixedPatches     (inlet outlet);
-// interpolation
+// RBFMeshMotionSolverCoeffs
 // {
-//     function     TPS;
+//     staticPatches    (upperWall lowerWall);
+//     movingPatches    (flap);
+//     fixedPatches     (inlet outlet);
+//
+//     interpolation
+//     {
+//         function     TPS;
+//         polynomial   no;
+//         cpu          no;
+//         fullCPU      no;
+//     }
+//
+//     coarsening
+//     {
+//         enabled                 yes;
+//         tol                     0.05;
+//         minPoints               20;
+//         maxPoints               200;
+//         livePointSelection      yes;
+//         tolLivePointSelection   0.05;
+//         exportSelectedPoints    no;
+//         twoPointSelection       no;
+//         surfaceCorrection       no;
+//     }
 // }
-// coarsening
-// {
-//     enabled      no;
-// }
+// Remove 0/fluid/pointMotionU when switching this case to RBFMeshMotionSolver.
 
 // ************************************************************************* //


### PR DESCRIPTION
## Summary

- add RBFMeshMotionSolver README guidance with verified perpendicularFlap settings
- update the perpendicularFlap dynamicMeshDict commented RBF example with correct fluid patches
- detect RBFMeshMotionSolver correctly through dynamicMotionSolverFvMesh on OpenFOAM.com and preserve FSI-supplied incremental motion

Addresses #38.

## Verification

- source ~/bin/load-openfoam v2312 && wclean/wmake -j 12 libso in src/RBFMeshMotionSolver
- source ~/bin/load-openfoam v2312 && wclean/wmake -j 12 libso in src/solids4FoamModels
- short perpendicularFlap run with RBF enabled to endTime 0.02 reached End with no fatal errors
- npx markdownlint-cli2 src/RBFMeshMotionSolver/README.md