### PR TITLE
Fail cleanly for unsupported cyclicGgi patches

### DIFF
--- a/src/blockCoupledSolids4FoamTools/newLeastSquaresVolPointInterpolation/newLeastSquaresVolPointInterpolation.C
+++ b/src/blockCoupledSolids4FoamTools/newLeastSquaresVolPointInterpolation/newLeastSquaresVolPointInterpolation.C
@@ -133,7 +133,18 @@ void newLeastSquaresVolPointInterpolation::makePointFaces() const
                  == cyclicGgiPolyPatch::typeName
                 )
                 {
-                    cyclicGgiFaceSet.insert(faceID);
+                    FatalErrorIn
+                    (
+                        "newLeastSquaresVolPointInterpolation"
+                        "::makePointFaces() const"
+                    )
+                        << "cyclicGgi patches are not supported by "
+                        << "solids4Foam's least-squares vol-to-point "
+                        << "interpolation. Patch "
+                        << mesh().boundaryMesh()[patchID].name()
+                        << " uses type "
+                        << mesh().boundaryMesh()[patchID].type()
+                        << abort(FatalError);
                 }
 #endif
                 else if


### PR DESCRIPTION
## Summary
- fail immediately when foam-extend cyclicGgi patches are encountered in newLeastSquaresVolPointInterpolation
- include the unsupported patch name and type in the FatalError message

## Rationale
Issue #53 reports a segfault in the cyclicGgi path. cyclicGgi support is not planned, so this makes the unsupported path fail cleanly instead of proceeding into fragile interpolation addressing.

## Verification
- source ~/bin/load-openfoam v2312 && ./Allwclean
- source ~/bin/load-openfoam v2312 && ./Allwmake -j 12

The v2312 rebuild compiled the edited blockCoupledSolids4FoamTools library and libsolids4FoamModels. The full build stopped later in applications/test/leastSquaresS4fGrad due to an unrelated dependency on missing OpenFOAM-v2312 header scalarImpl.H.