### PR TITLE
Documentation: surface the existing READMEs on the website

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,7 @@
+---
+sort: 2
+---
+
 # Contributing to solids4foam
 
 Thank you for considering contributing to **solids4foam**!

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ interactions in OpenFOAM.
 
 ## Where do I start?
 
-Please visit the [solids4foam website](https://solids4foam.github.io).
+Please visit the [solids4foam website](https://www.solids4foam.com).
 
 ## Disclaimer
 

--- a/applications/README.md
+++ b/applications/README.md
@@ -1,0 +1,39 @@
+---
+sort: 8
+---
+
+# Applications
+
+Everything that is compiled into an executable or is run from the shell lives
+in `applications`. There is one solver, a small set of mesh and case
+utilities, and a library of Bash functions used by the tutorials.
+
+---
+
+## Contents
+
+| Item | What it is |
+| ---- | ---------- |
+| [`solids4Foam`](https://www.solids4foam.com/documentation/applications/solids4Foam.html) | The solver. Solid, fluid and fluid-solid interaction analyses, with the physics selected at run time. |
+| [Utilities](https://www.solids4foam.com/documentation/applications/utilities.html) | Mesh and case pre- and post-processing: `abaqusMeshToFoam`, `addTinyPatch`, `foamMeshToAbaqus`, `perturbMeshPoints`, `projectPatchToSphere` and `splitPatch`. |
+| [`decomposeParMonolithic`](https://www.solids4foam.com/documentation/applications/decomposeParMonolithic.html) | Decomposes the regions of a monolithic multi-region case as one graph, so that the partitioning is consistent across regions. |
+| [`solids4FoamScripts.sh`](https://www.solids4foam.com/documentation/applications/scripts.html) | Bash functions used by the tutorial `Allrun` scripts, principally for making a case run on any OpenFOAM fork. |
+
+---
+
+## Building
+
+`applications/Allwmake` builds the solver, the utilities, the tests and the
+scripts; it is called in turn by the top-level `Allwmake`.
+`applications/Allwclean` removes the resulting executables and dependencies.
+
+```bash
+cd applications
+./Allwmake
+```
+
+---
+
+## Source
+
+[`applications`](https://github.com/solids4foam/solids4foam/tree/development/applications)

--- a/applications/scripts/README.md
+++ b/applications/scripts/README.md
@@ -244,7 +244,7 @@ is transformed into:
 ```
 
 **5.** If `sample` file is found in the `system/` directory and if the
-[OpenFOAM.org](OpenFOAM.org) version is used, `uniform` is replaced with
+[OpenFOAM.org](https://openfoam.org) version is used, `uniform` is replaced with
 `lineUniform`:
 
 ```c++
@@ -361,8 +361,9 @@ is transformed into:
     └── fvSolution
 ```
 
-**9.** In case the [OpenFOAM.com](OpenFOAM.com) version is used to solve solid
-mechanics or fluid-solid interaction problems, the `leastSquare` gradient method
+**9.** In case the [OpenFOAM.com](https://www.openfoam.com) version is used to
+solve solid mechanics or fluid-solid interaction problems, the `leastSquare`
+gradient method
 in `fvSchemes` file is replaced with `pointCellsLeastSquares` to account for
 boundary non-orthogonal corrections:
 
@@ -448,8 +449,8 @@ located.
 ## `solids4foam::caseDoesNotRunWithFoamExtend()`
 
 - **Function purpose**
-  This function gives an error if the [OpenFOAM.com](OpenFOAM.com) or
-  [OpenFOAM.org](OpenFOAM.org) version is not sourced/loaded.
+  This function gives an error if the [OpenFOAM.com](https://www.openfoam.com) or
+  [OpenFOAM.org](https://openfoam.org) version is not sourced/loaded.
 
 - **Function arguments**
   None

--- a/applications/scripts/README.md
+++ b/applications/scripts/README.md
@@ -1,5 +1,5 @@
 ---
-sort: 5
+sort: 4
 ---
 
 # Bash functions: `solids4FoamScripts.sh`

--- a/applications/solvers/solids4Foam/README.md
+++ b/applications/solvers/solids4Foam/README.md
@@ -1,0 +1,111 @@
+---
+sort: 1
+---
+
+# `solids4Foam` solver
+
+`solids4Foam` is the single solver application provided by solids4foam. It is
+used for solid mechanics, fluid dynamics and fluid-solid interaction analyses
+alike: the physics, the discretisation and the solution algorithm are all
+selected at run time, so the same executable runs every case in the toolbox.
+
+---
+
+## Usage
+
+```bash
+solids4Foam                 # serial
+mpirun -np 4 solids4Foam -parallel   # parallel
+```
+
+The type of analysis is set by `constant/physicsProperties`:
+
+```c++
+type    solid;    // solid | fluid | fluidSolidInteraction
+```
+
+Each choice then reads its own dictionary:
+
+| `type` | Dictionary | Base class |
+| ------ | ---------- | ---------- |
+| `solid` | `constant/solidProperties` | `solidModel` |
+| `fluid` | `constant/fluidProperties` | `fluidModel` |
+| `fluidSolidInteraction` | `constant/fsiProperties` | `fluidSolidInterface` |
+
+---
+
+## The solver code
+
+The solver is deliberately thin; it contains no details of the physics or the
+discretisation. Its source is
+[`applications/solvers/solids4Foam/solids4Foam.C`](https://github.com/solids4foam/solids4foam/blob/development/applications/solvers/solids4Foam/solids4Foam.C):
+
+```c++
+int main(int argc, char *argv[])
+{
+#   include "setRootCase.H"
+#   include "createTime.H"
+#   include "solids4FoamWriteHeader.H"
+
+    // Create the general physics class
+    autoPtr<physicsModel> physics = physicsModel::New(runTime);
+
+    while (runTime.run())
+    {
+        // Update deltaT, if desired, before moving to the next step
+        physics().setDeltaT(runTime);
+
+        runTime++;
+
+        if (physics().printInfo())
+        {
+            Info<< "Time = " << runTime.timeName() << nl << endl;
+        }
+
+        // Solve the mathematical model
+        physics().evolve();
+
+        // Let the physics model know the end of the time-step has been reached
+        physics().updateTotalFields();
+
+        if (runTime.outputTime())
+        {
+            physics().writeFields(runTime);
+        }
+
+        if (physics().printInfo())
+        {
+            Info<< "ExecutionTime = " << runTime.elapsedCpuTime() << " s"
+                << "  ClockTime = " << runTime.elapsedClockTime() << " s"
+                << nl << endl;
+        }
+    }
+
+    physics().end();
+
+    Info<< nl << "End" << nl << endl;
+
+    return(0);
+}
+```
+
+A run-time selectable `physicsModel` object encapsulates the specifics, and
+virtual functions such as `evolve()` tell that object to solve its governing
+equations for the current time step. Adding a new solid model, fluid model or
+coupling scheme therefore requires no change to the solver.
+
+The `physicsModel` base class has three derived families:
+
+- `solidModel`, see
+  [solid models](https://www.solids4foam.com/documentation/solid-models/);
+- `fluidModel`, see
+  [fluid models](https://www.solids4foam.com/documentation/fluid-models/);
+- `fluidSolidInterface`, which itself creates one `fluidModel` and one
+  `solidModel`, see
+  [fluid-solid interfaces](https://www.solids4foam.com/documentation/fluid-solid-interfaces/).
+
+---
+
+## Source
+
+[`applications/solvers/solids4Foam`](https://github.com/solids4foam/solids4foam/tree/development/applications/solvers/solids4Foam)

--- a/applications/utilities/README.md
+++ b/applications/utilities/README.md
@@ -1,5 +1,5 @@
 ---
-sort: 4
+sort: 2
 ---
 
 # Utilities

--- a/applications/utilities/decomposeParMonolithic/README.md
+++ b/applications/utilities/decomposeParMonolithic/README.md
@@ -1,3 +1,7 @@
+---
+sort: 3
+---
+
 # `decomposeParMonolithic`
 
 Coupled multi-region decomposition utility for monolithic FSI cases.

--- a/src/solids4FoamModels/README.md
+++ b/src/solids4FoamModels/README.md
@@ -1,4 +1,8 @@
-# solids4FoamModels
+---
+sort: 9
+---
+
+# Under the hood: `solids4FoamModels`
 
 This directory holds the sources of `libsolids4FoamModels`, the main
 solids4foam library. It is built by the `Allwmake` script in this directory,
@@ -32,16 +36,16 @@ The available models differ in whether the geometry is linear or nonlinear,
 whether a total or updated Lagrangian formulation is used, whether the
 discretisation is cell-centred or vertex-centred, and whether the solution
 algorithm is segregated, coupled or explicit. They are described in
-[`solidModels/README.md`](solidModels/README.md).
+[solid models](https://www.solids4foam.com/documentation/solid-models/).
 
 A **fluid model** solves the flow equations, using either a solver built on
 the standard OpenFOAM ones or a solver specific to solids4foam; see
-[`fluidModels/README.md`](fluidModels/README.md).
+[fluid models](https://www.solids4foam.com/documentation/fluid-models/).
 
 A **fluid-solid interface** owns one fluid model and one solid model and
 implements the partitioned coupling algorithm between them, for example fixed
 relaxation, Aitken or IQN-ILS. See
-[`fluidSolidInterfaces/README.md`](fluidSolidInterfaces/README.md).
+[fluid-solid interfaces](https://www.solids4foam.com/documentation/fluid-solid-interfaces/).
 
 ### Material behaviour
 
@@ -72,14 +76,14 @@ uses it, so the two can be varied independently:
   crack propagation;
 - `functionObjects`: run-time post-processing, and the analytical solutions
   used by the tutorials; see
-  [`functionObjects/README.md`](functionObjects/README.md).
+  [function objects](https://www.solids4foam.com/documentation/function-objects/).
 
 ### Adding a class
 
 New classes follow the usual OpenFOAM run-time selection pattern: derive from
 the relevant base class, add the `TypeName` and `addToRunTimeSelectionTable`
 entries, and add the source to the canonical list described below. Please also
-see [`CONTRIBUTING.md`](../../CONTRIBUTING.md).
+see [the contributing guide](https://www.solids4foam.com/documentation/under-the-hood/contributing.html).
 
 ---
 

--- a/src/solids4FoamModels/fluidModels/README.md
+++ b/src/solids4FoamModels/fluidModels/README.md
@@ -1,5 +1,5 @@
 ---
-sort: 4
+sort: 5
 ---
 
 # Fluid models

--- a/src/solids4FoamModels/fluidSolidInterfaces/README.md
+++ b/src/solids4FoamModels/fluidSolidInterfaces/README.md
@@ -1,5 +1,5 @@
 ---
-sort: 2
+sort: 6
 ---
 
 # Fluid-solid coupling schemes: `fluidSolidInterfaces`

--- a/src/solids4FoamModels/functionObjects/README.md
+++ b/src/solids4FoamModels/functionObjects/README.md
@@ -1,5 +1,5 @@
 ---
-sort: 6
+sort: 7
 ---
 
 # Function Objects

--- a/src/solids4FoamModels/numerics/stabilisationModels/README.md
+++ b/src/solids4FoamModels/numerics/stabilisationModels/README.md
@@ -1,3 +1,7 @@
+---
+sort: 1
+---
+
 # Stabilisation Models
 
 This directory contains runtime-selectable stabilisation models used by
@@ -7,7 +11,7 @@ oscillations in scalar and vector fields.
 ## Design Overview
 
 The common base class is
-[`stabilisationModel`](./stabilisationModel/stabilisationModel.H).
+[`stabilisationModel`](https://github.com/solids4foam/solids4foam/blob/development/src/solids4FoamModels/numerics/stabilisationModels/stabilisationModel/stabilisationModel.H).
 
 Each concrete stabilisation model is responsible for:
 
@@ -55,7 +59,7 @@ The currently available model types in this directory are:
   volumetric strain (see below)
 
 `RhieChow` is implemented as a helper under
-[`diffStencilLaplacianStab/RhieChowStab`](./diffStencilLaplacianStab/RhieChowStab).
+[`diffStencilLaplacianStab/RhieChowStab`](https://github.com/solids4foam/solids4foam/blob/development/src/solids4FoamModels/numerics/stabilisationModels/diffStencilLaplacianStab/RhieChowStab).
 
 ## Usage Pattern
 
@@ -71,7 +75,7 @@ The intended solver-side usage is:
    `vectorJacobian(...)` to obtain an approximate implicit contribution.
 
 For example, in
-[`linGeomTotalDispSolid.C`](../../solidModels/linGeomTotalDispSolid/linGeomTotalDispSolid.C),
+[`linGeomTotalDispSolid.C`](https://github.com/solids4foam/solids4foam/blob/development/src/solids4FoamModels/solidModels/linGeomTotalDispSolid/linGeomTotalDispSolid.C),
 the momentum stabilisation is updated before its face contribution is added to
 the traction.
 
@@ -188,10 +192,10 @@ vector is:
 faceVector_f = scaleFactor * C(mode) * [tr(gradD_f_future) - tr(gradD_f_old)] * n_f
 ```
 
-Four modes are available, selected via the `mode` entry:
+Five modes are available, selected via the `mode` entry:
 
 | mode | C(mode) | Vanishes as |
-|---|---|---|
+| --- | --- | --- |
 | `physicalDamping` | `tau/deltaT` | never — permanent physical damping |
 | `firstOrderTemporal` | `1` | O(deltaT) |
 | `secondOrderTemporal` | `deltaT` | O(deltaT^2) |

--- a/src/solids4FoamModels/numerics/stabilisationModels/README.md
+++ b/src/solids4FoamModels/numerics/stabilisationModels/README.md
@@ -189,7 +189,9 @@ strain `tr(gradD)` rather than spatial oscillations.  The face stabilisation
 vector is:
 
 ```text
-faceVector_f = scaleFactor * C(mode) * [tr(gradD_f_future) - tr(gradD_f_old)] * n_f
+faceVector_f =
+    scaleFactor * C(mode)
+  * [tr(gradD_f_future) - tr(gradD_f_old)] * n_f
 ```
 
 Five modes are available, selected via the `mode` entry:

--- a/src/solids4FoamModels/solidModels/README.md
+++ b/src/solids4FoamModels/solidModels/README.md
@@ -1,5 +1,5 @@
 ---
-sort: 3
+sort: 2
 ---
 
 # Solid models

--- a/src/solids4FoamModels/solidModels/README.md
+++ b/src/solids4FoamModels/solidModels/README.md
@@ -350,9 +350,9 @@ finite volume discretisation unless stated otherwise.
   - `thermalLinGeomSolid`: solves for the temperature $$T$$ (`T`) and total
     displacement $$\boldsymbol{d}$$ (`D`), where outer iterations ensure
     convergence of the temperature-displacement coupling in a segregated manner.
-  - `thermalSolid`: solves for the temperature $$T$$ (`T`) and total
-    displacement $$\boldsymbol{d}$$ (`D`) with strongly coupled momentum and
-    heat equations using a segregated approach.
+  - `thermalSolid`: solves the heat equation for the temperature $$T$$ (`T`)
+    only; no momentum equation is solved and the solid does not deform. It
+    provides the solid side of conjugate heat transfer.
   - `poroLinGeomSolid`: solves for the pore-pressure $$p$$ (`p`) and total
     displacement $$\boldsymbol{d}$$ (`D`), where outer iterations ensure
     convergence of the pressure-displacement coupling in a segregated manner,
@@ -370,8 +370,7 @@ finite volume discretisation unless stated otherwise.
     this solver currently works best with triangular and tetrahedral grids.
 
   - `kirchhoffPlateSolid`: this model solves the Kirchhoff plate equations using
-    a segregated finite area method; _currently only available with
-    foam-extend_.
+    a segregated finite area method; _requires OpenFOAM.com v2412 or newer_.
 
 - **Nonlinear geometry solid models**
 
@@ -389,5 +388,10 @@ finite volume discretisation unless stated otherwise.
     the increment of displacement $$\Delta \boldsymbol{d}$$ (`DD`).
   - `vertexCentredNonLinGeomTotalLagSolid`: a vertex-centred total Lagrangian
     nonlinear geometry approach which solves for the total displacement at the
-    mesh vertices/points (`pointD`); supports Newton-Raphson, segregated and
+    mesh vertices/points (`pointD`); supports Newton-Raphson (PETSc SNES) and
     explicit solution algorithms.
+  - `coupledPressureDisplacementSolid`: a block-coupled mixed formulation for
+    incompressible and nearly incompressible solids, solving the increments of
+    displacement $$\Delta \boldsymbol{d}$$ (`DD`) and hydrostatic pressure
+    $$\Delta p$$ (`Dp`) in a single system; _currently only available with
+    foam-extend_.

--- a/src/solids4FoamModels/solidModels/coupledPressureDisplacementSolid/README.md
+++ b/src/solids4FoamModels/solidModels/coupledPressureDisplacementSolid/README.md
@@ -1,0 +1,273 @@
+---
+sort: 9
+---
+
+# coupledPressureDisplacementSolid
+
+This page documents the block-coupled pressure-displacement solid model. The
+runtime type is:
+
+```text
+coupledPressureDisplacementSolid
+```
+
+The model is aimed at **incompressible and nearly incompressible** solids,
+where a displacement-only formulation locks. It solves the displacement
+increment `DD` and the hydrostatic pressure increment `Dp` together in one
+block system of four unknowns per cell, in an updated-Lagrangian frame with
+the mesh moved to the current configuration.
+
+```warning
+This model is **only available with foam-extend**. It is listed in
+`Make/files.foamextend` but not in `Make/files.openfoam`, so it does not exist
+at all in OpenFOAM.com and OpenFOAM.org builds. Its tutorials call
+`solids4Foam::caseOnlyRunsWithFoamExtend`.
+```
+
+---
+
+## User Guide
+
+### What this model solves
+
+`coupledPressureDisplacementSolid`:
+
+- assembles a `volVector4Field` unknown, `DDDp`, holding the three components
+  of the displacement increment `DD` plus the pressure increment `Dp`;
+- inserts the momentum equation at rows 0-2 and the pressure equation at row
+  3, with the two coupling blocks — the pressure gradient in the momentum
+  equation, and the displacement divergence in the pressure equation —
+  inserted implicitly;
+- uses a Rhie-Chow-style flux `phi` to avoid pressure-velocity decoupling on
+  a collocated mesh, with an optional consistent variant;
+- moves the mesh to the current configuration each outer iteration when
+  `nonLinear` is enabled;
+- supports both first-order Euler and backward temporal schemes, and a
+  steady-state mode.
+
+The pressure unknown is what distinguishes this from the other coupled model,
+[coupledUnsLinGeomLinearElasticSolid](https://www.solids4foam.com/documentation/solid-models/coupledUnsLinGeomLinearElasticSolid.html):
+that one is displacement-only and linear-elastic, this one is a general
+finite-strain mixed formulation.
+
+### Supported solution algorithms
+
+There is a single block-coupled path. This model does not read
+`solutionAlgorithm`.
+
+### Model options
+
+| Entry | Default | Description |
+| --- | --- | --- |
+| `nonLinear` | `true` | Nonlinear geometry and mesh motion |
+| `K` | `0` | Mass-proportional damping coefficient |
+| `consistentRhieChow` | `false` | Consistent Rhie-Chow correction |
+| `composite` | `false` | Composite-material mode |
+| `stdDispGrad` | `true` | Standard displacement-gradient evaluation |
+| `debug` | `false` | Extra per-iteration solver output |
+| `writeConvergenceData` | `false` | Write `convergData.dat` in the case |
+| `solutionTolerance` | inherited | Used here as a _relative_ tolerance |
+
+`K` has dimensions `[0 0 -1 0 0 0 0]`. `consistentRhieChow` allocates extra
+interpolated face fields when enabled.
+
+```warning
+As in `unsNonLinGeomTotalLagSolid`, `solutionTolerance` is used as a relative
+tolerance in this model, not an absolute one.
+```
+
+`K` is unusual in that it is re-read from the dictionary inside
+`updateTotalFields()`, so it can be changed while a case is running — useful
+for ramping damping down as a quasi-static solution settles.
+
+The relevant inherited `solidModel` entries are:
+
+| Entry | Default | Relevance |
+| --- | --- | --- |
+| `nCorrectors` | `10000` | Maximum number of outer correctors |
+| `alternativeTolerance` | `1e-07` | Secondary convergence tolerance |
+| `materialTolerance` | `1e-05` | Mechanical-law convergence tolerance |
+| `infoFrequency` | `100` | Frequency for solver progress output |
+| `restart` | `false` | Writes extra fields needed for a consistent restart |
+| `stabilisation` | auto-created | Both sub-dictionaries are used |
+| `cellDisplacements` | optional | Internal-cell displacement constraints |
+
+The stabilisation sub-models accept a `scaleFactorJacobian` alongside
+`scaleFactor`, so the stabilisation used when forming the block matrix can
+differ from the one used in the residual. Setting both to zero, as the
+`heartTissueBeam` tutorial does, disables stabilisation entirely; the comment
+there notes that momentum stabilisation contributes to `sigmaHyd`
+oscillations.
+
+### Required input files
+
+Because the model is incremental and mixed, the fields differ from the other
+solid models:
+
+- `DD`, the displacement increment, with the boundary conditions;
+- `Dp`, the pressure increment (`MUST_READ`);
+- `pointDD`, usually `calculated`;
+- any material-specific fields, such as a fibre direction `f0`;
+- `constant/solidProperties`, `constant/mechanicalProperties`, `constant/g`.
+
+Note that `D` and `p` are outputs, accumulated from `DD` and `Dp`.
+
+### Recommended dictionary setup
+
+Example for `constant/solidProperties`:
+
+```text
+solidModel coupledPressureDisplacementSolid;
+
+coupledPressureDisplacementSolidCoeffs
+{
+    nCorrectors             2000;
+    solutionTolerance       1e-7;
+    alternativeTolerance    1e-06;
+    materialTolerance       1e-05;
+    infoFrequency           1;
+
+    stabilisation
+    {
+        momentum
+        {
+            type                laplacian;
+            scaleFactor         0;
+            scaleFactorJacobian 0;
+        }
+
+        pressure
+        {
+            type                laplacian;
+            scaleFactor         0;
+            scaleFactorJacobian 0;
+        }
+    }
+
+    nonLinear             true;
+    debug                 false;
+
+    consistentRhieChow    false;
+    composite             false;
+    stdDispGrad           true;
+
+    restart               true;
+
+    K                     K [0 0 -1 0 0 0 0] 150;
+
+    writeConvergenceData  true;
+}
+```
+
+The block system is solved with a `DDDp` solver in `fvSolution`, not with
+separate `DD` and `Dp` solvers:
+
+```text
+solvers
+{
+    DDDp
+    {
+        solver BiCGStab;
+
+        preconditioner
+        {
+            preconditioner Cholesky;
+        }
+    }
+}
+```
+
+### Boundary conditions
+
+Displacement boundaries are set on `DD`. The type designed for this model is
+`tractionPressureDisplacement`, which applies a traction consistently with the
+pressure unknown; `symmetryPlane` and the standard fixed-displacement types
+also work. Pressure boundaries on `Dp` are usually `zeroGradient`.
+
+### Field glossary
+
+- `DDDp`: the block unknown; components 0-2 are `DD`, component 3 is `Dp`.
+- `DD`, `D`: displacement increment and accumulated total displacement.
+- `Dp`, `p`: pressure increment and accumulated pressure.
+- `DU`: velocity increment.
+- `phi`: the Rhie-Chow flux increment.
+- `delta`, `weights`: geometric quantities cached across the mesh motion,
+  written with `AUTO_WRITE` so restarts are consistent.
+- `force`: the assembled surface force used in the momentum equation.
+- `pointDD`, `pointD`, `U`, `sigma`: as for the other incremental models.
+
+---
+
+## Developer Notes
+
+### Class role
+
+`coupledPressureDisplacementSolid` inherits directly from `solidModel`. The
+key design choices are:
+
+- `DD` is the primary solution variable (`DDisRequired()` is called), with
+  `Dp` as a coupled second unknown;
+- the block matrix is a foam-extend `fvBlockMatrix<vector4>`, which is why the
+  class is foam-extend-only;
+- the mesh is moved to the current configuration inside the iteration when
+  `nonLinear` is set, so the formulation is updated-Lagrangian in effect while
+  the equations are assembled in total-Lagrangian form on the reference
+  points, kept in `refPoints_`.
+
+The implementation is split across a set of `.H` include files —
+`calcPhi.H`, `calcTraction.H`, `calcForce.H`, `completeMomentumEqAssembly.H`,
+`addBlockCoupledBC.H`, `finalizeMomentumEqn.H`, `updateAD.H`,
+`solidContinuityErrs.H` and others — which are `#include`d directly into
+`evolve()`. This keeps `evolve()` readable but means the control flow is
+spread over a dozen files.
+
+### `evolve()`
+
+Each outer iteration:
+
+1. computes the tangential and normal parts of the displacement-increment
+   gradient at faces, and the traction (`calcTraction.H`);
+2. assembles the momentum equation as a Laplacian in `DD` with explicit
+   corrections for the tangential gradient, the nonlinear force correction and
+   the old-time force, plus the temporal terms — Euler, backward or
+   steady-state — and the optional `K` damping;
+3. inserts it into the block matrix at row 0, completes the assembly with the
+   normal-derivative term, applies the block-coupled boundary corrections, and
+   inserts the pressure-gradient coupling block at (0, 3);
+4. moves the mesh to the current configuration if `nonLinear`;
+5. computes the Rhie-Chow flux (`calcPhi.H`), assembles the pressure equation
+   as `Sp(rKappa, Dp) - laplacian(rADf, Dp) + div(phi)`, inserts it at row 3,
+   and inserts the displacement-divergence coupling block at (3, 0);
+6. solves the block system, retrieves `DD` and `Dp`, corrects their boundary
+   conditions, updates the flux and reports the continuity errors;
+7. accumulates `D = D.oldTime() + DD` and `p = p.oldTime() + Dp`.
+
+### `updateTotalFields()`
+
+Refreshes `impKf_` from the mechanical law, re-reads `K` from the dictionary,
+and — when `nonLinear` is set — updates the accumulated configuration. This is
+the hook that makes `K` adjustable mid-run.
+
+### Extension points
+
+- the pressure equation and `calcPhi.H` if a different
+  pressure-velocity coupling is wanted;
+- `completeMomentumEqAssembly.H` for changes to the implicit momentum terms;
+- `addBlockCoupledBC.H` for a new block-aware boundary condition.
+
+The `composite` and `consistentRhieChow` switches guard code paths that are
+less exercised than the defaults; treat them as experimental.
+
+---
+
+## Tutorials
+
+Cases that select `coupledPressureDisplacementSolid`, all foam-extend only:
+
+- `solids/hyperelasticity/heartTissueBeam`
+- `solids/hyperelasticity/ratCarotid`
+- `solids/hyperelasticity/idealisedVentricle`
+- `solids/hyperelasticity/cylindricalPressureVessel`, in its
+  `caseOptions/pressureDisplacement` variants
+- `solids/linearElasticity/plateHole`, in its
+  `caseOptions/pressureDisplacement` variant

--- a/src/solids4FoamModels/solidModels/coupledUnsLinGeomLinearElasticSolid/README.md
+++ b/src/solids4FoamModels/solidModels/coupledUnsLinGeomLinearElasticSolid/README.md
@@ -1,0 +1,216 @@
+---
+sort: 10
+---
+
+# coupledUnsLinGeomLinearElasticSolid
+
+This page documents the block-coupled linear-elastic solid model. The runtime
+type is:
+
+```text
+coupledUnsLinearGeometryLinearElastic
+```
+
+The model assumes small strains and small rotations and solves the momentum
+equation for the total displacement `D` with a **block-coupled** methodology:
+all three displacement components are solved simultaneously in one linear
+system, rather than segregated component by component. Because linear
+elasticity with linear boundary conditions gives a linear problem, no outer
+iteration is required at all — one linear solve per time step is the answer.
+
+The method is described in:
+
+P. Cardiff, Z. Tukovic, H. Jasak and A. Ivankovic (2016), _A block-coupled
+finite volume methodology for linear elasticity and unstructured meshes_,
+Computers and Structures, 175, 100-122,
+[10.1016/j.compstruc.2016.07.004](https://doi.org/10.1016/j.compstruc.2016.07.004).
+
+```warning
+This model is **only available with foam-extend**. On OpenFOAM.com and
+OpenFOAM.org builds the class compiles, but `evolve()` calls `notImplemented`
+and the run aborts. It relies on foam-extend's `BlockLduMatrix` machinery and
+on `src/blockCoupledSolids4FoamTools`.
+```
+
+---
+
+## User Guide
+
+### What this model solves
+
+`coupledUnsLinGeomLinearElasticSolid`:
+
+- assembles the linear-geometry momentum equation directly as a block matrix,
+  with the Laplacian, Laplacian-transpose and Laplacian-trace terms of
+  `div(sigma)` all treated implicitly;
+- solves for total displacement `D` in a single block solve per time step;
+- uses the `uns` face-Gauss gradient, so the discretisation matches
+  [unsLinGeomSolid](https://www.solids4foam.com/documentation/solid-models/unsLinGeomSolid.html);
+- reads `mu` and `lambda` once at construction from the mechanical law.
+
+The advantage over the segregated models is convergence: the inter-component
+coupling that segregated solvers defer to the outer iterations is here inside
+the matrix, which matters most on high-aspect-ratio and bending-dominated
+problems. The cost is memory and a larger, denser linear system.
+
+### Restrictions
+
+The constructor enforces two hard restrictions:
+
+- exactly **one** material — multi-material cases abort;
+- the mechanical law must be `linearElastic` — any other law aborts.
+
+The linear definition of stress is hard-coded into the block assembly, so
+these are not incidental limits. Equation under-relaxation is also disabled:
+if `fvSolution` relaxes `DEqn`, the run aborts.
+
+### Supported solution algorithms
+
+There is a single block-coupled path and no outer loop. This model does not
+read `solutionAlgorithm`, `nCorrectors` or the convergence tolerances.
+
+### Model options
+
+`coupledUnsLinGeomLinearElasticSolid` reads no entries of its own, and the
+inherited iteration controls do not apply. The coefficients sub-dictionary
+must still be present, but it may be empty:
+
+```text
+solidModel       coupledUnsLinearGeometryLinearElastic;
+
+coupledUnsLinearGeometryLinearElasticCoeffs
+{}
+```
+
+### Linear solver setup
+
+The block system is solved with a `blockD` solver selected from `fvSolution`,
+_not_ with an ordinary `D` solver:
+
+```text
+solvers
+{
+    blockD
+    {
+        solver              EigenSparseLU;
+    }
+}
+```
+
+The block solvers available come from
+`src/blockCoupledSolids4FoamTools/BlockLduSolvers`.
+
+### Boundary conditions
+
+Standard solids4foam patch types do not work here: the boundary conditions are
+inserted directly into the block matrix, so they need block-aware
+implementations. Use the `block*` patch types from
+`src/blockCoupledSolids4FoamTools/blockFvPatchVectorFields`:
+
+| Patch type | Purpose |
+| --- | --- |
+| `blockFixedDisplacement` | Prescribed displacement |
+| `blockFixedDisplacementZeroShear` | Normal displacement fixed, zero shear |
+| `blockFixedGradient` | Prescribed displacement gradient |
+| `blockSolidTraction` | Prescribed traction and pressure |
+| `blockSolidVelocity` | Prescribed velocity |
+| `blockGlobalSolid` | Global patch, used for coupling |
+
+A symmetry plane is handled by `blockFixedDisplacementZeroShear`; there is no
+block-aware `symmetry` type.
+
+### Required input files
+
+- `D` in the time directory, with `block*` boundary conditions;
+- `constant/solidProperties`;
+- `constant/mechanicalProperties`, selecting a single `linearElastic` law;
+- `constant/g`;
+- a `blockD` entry in `fvSolution`.
+
+### Field glossary
+
+- `D`, `DD`: total and incremental displacement.
+- `pointD`, `pointDD`: displacement at mesh points.
+- `grad(D)`, `grad(DD)`: displacement gradients.
+- `sigma`: symmetric stress tensor, evaluated once per time step from the
+  mechanical law.
+- `U`: velocity field, computed as `ddt(D)`.
+- `solutionVec`: the block solution vector, written with `AUTO_WRITE`. It has
+  one entry per _variable_ of the extended mesh, which includes boundary
+  unknowns as well as cells, so it is longer than the cell count.
+
+---
+
+## Developer Notes
+
+### Class role
+
+`coupledUnsLinGeomLinearElasticSolid` inherits directly from `solidModel`, and
+holds a `solidPolyMesh` (`extendedMesh_`) alongside the ordinary `fvMesh`. The
+extended mesh carries the larger addressing needed by the block system, in
+which boundary faces as well as cells are unknowns.
+
+- `D` is the primary solution variable;
+- `nonLinGeom()` returns `LINEAR_GEOMETRY`;
+- `muf_` and `lambdaf_` are surface fields, set once at construction, which is
+  why only `linearElastic` is permitted.
+
+Everything inside `evolve()` is guarded by `#ifdef FOAMEXTEND`.
+
+### Construction
+
+The constructor writes a banner citing the reference paper, calls
+`DisRequired()`, then validates the mechanical model: one law, and that law
+`linearElastic`. It casts the law and copies `mu()` and `lambda()` into
+`muf_` and `lambdaf_`. On foam-extend it also builds `extendedMesh_` and the
+`solutionVec_` field, sized from `extendedMesh_.nVariables()`.
+
+### `evolve()`
+
+There is no loop. Each time step:
+
+1. clear the extended mesh's cached global coefficients;
+2. build an empty `BlockLduMatrix<vector>` and zero its diagonal and
+   off-diagonals;
+3. assemble three separate block matrices through `BlockFvm::laplacian`,
+   `BlockFvm::laplacianTranspose` and `BlockFvm::laplacianTrace`, and add
+   their diagonal, off-diagonal and processor-coupling contributions together
+   by hand — a `BlockFvMatrix` class would tidy this up;
+4. insert the boundary-condition equations with
+   `extendedMesh_.insertBoundaryConditions()`;
+5. add the transient and gravity terms via `extendedMesh_.addFvMatrix()` with
+   `rho*d2dt2(D) - rho*g`;
+6. abort if `DEqn` under-relaxation is requested;
+7. solve with the `blockD` solver and copy the result back into `D` through
+   `extendedMesh_.copySolutionVector()`;
+8. under-relax `D`, interpolate to `pointD`, and evaluate `grad(D)` — twice,
+   because fixed-displacement boundaries need the patch internal field to set
+   `snGrad` on the gradient's boundary;
+9. update `DD`, `grad(DD)`, `sigma`, `pointDD` and `U`.
+
+The non-orthogonal correction of the Laplacian is treated implicitly, which is
+one of the advantages the block approach has over the segregated models.
+
+### Extension points
+
+- the three `BlockFvm` terms if a different stress form is wanted; note that
+  removing the `linearElastic` restriction means these must become functions
+  of the mechanical law rather than of fixed `mu` and `lambda` fields;
+- `solidPolyMesh::insertBoundaryConditions()` for a new block patch type.
+
+There is commented-out code in `evolve()` that would enforce zero normal
+displacement on symmetry patches at the point level; the note there suggests a
+`blockSymmetry` boundary condition as the proper fix.
+
+---
+
+## Tutorials
+
+No tutorial selects `coupledUnsLinearGeometryLinearElastic` by default, since
+it needs foam-extend. Three cases ship a ready-made `unsCoupled` variant —
+`constant/solidProperties.unsCoupled`, `0/D.unsCoupled` and
+`system/fvSolution.unsCoupled`:
+
+- `solids/linearElasticity/cantilever2d`
+- `solids/linearElasticity/narrowTmember`
+- `solids/linearElasticity/ellipticPlate`

--- a/src/solids4FoamModels/solidModels/kirchhoffPlateSolid/README.md
+++ b/src/solids4FoamModels/solidModels/kirchhoffPlateSolid/README.md
@@ -1,0 +1,234 @@
+---
+sort: 15
+---
+
+# kirchhoffPlateSolid
+
+This page documents the Kirchhoff thin-plate solid model. The runtime type is:
+
+```text
+kirchhoffPlate
+```
+
+Unlike every other solid model in solids4foam, this one does not discretise a
+three-dimensional continuum. It solves the Kirchhoff plate equations on a
+**finite area** mesh — a two-dimensional surface mesh — for the transverse
+deflection `w` and the moment sum `M`. The formulation is the rotation-free
+one of Torlak (2006), which splits the fourth-order plate equation into two
+coupled second-order equations so that standard Laplacian discretisations can
+be used.
+
+```warning
+This model requires a **finite area** mesh and OpenFOAM.com **v2412 or newer**.
+The shipped tutorial explicitly excludes OpenFOAM.org and foam-extend. The
+class itself is compiled for all forks, but the finite-area machinery it needs
+is not available everywhere.
+```
+
+---
+
+## User Guide
+
+### What this model solves
+
+The plate equations are split as:
+
+```text
+M equation:  rho*h*d2dt2(w) = laplacian(M) + p
+w equation:  laplacian(bendingStiffness, w) + M = 0
+```
+
+where `w` is the transverse (out-of-plane) deflection, `M` is the moment sum,
+`p` is the net transverse pressure, `h` is the plate thickness, `rho` is the
+density, and the bending stiffness is
+
+```text
+bendingStiffness = E*h^3/(12*(1 - nu^2))
+```
+
+The two equations are solved segregated, one after the other, inside an outer
+loop. The rotation field `theta = -grad(w)` is updated each iteration and used
+by the clamped boundary condition.
+
+### Restrictions
+
+The constructor enforces:
+
+- exactly **one** material — multi-material cases abort;
+- the mechanical law must be `linearElastic`, from which `rho`, `E` and `nu`
+  are read once at construction.
+
+Beyond that:
+
+- `tractionBoundarySnGrad()` is `notImplemented`, so ordinary solid traction
+  boundary conditions cannot be used;
+- the stress field `sigma` is never calculated, and its write option is
+  switched to `NO_WRITE` at the end of `evolve()`;
+- the volume mesh must be exactly one cell thick, with two opposite patches of
+  equal face count. The constructor locates the finite-area patch and its
+  shadow patch automatically, and aborts if the mesh does not satisfy this.
+
+### Supported solution algorithms
+
+A single segregated implicit loop over the two scalar equations. There is a
+commented-out sketch in the source for solving them block-coupled, which is
+not implemented. This model does not read `solutionAlgorithm`.
+
+### Model options
+
+| Entry | Dimensions | Description |
+| --- | --- | --- |
+| `plateThickness` | `[0 1 0 0 0 0 0]` | Plate thickness `h`; required |
+
+`plateThickness` is read with `lookup()`, so the model fails at construction if
+it is missing.
+
+The relevant inherited `solidModel` entries are:
+
+| Entry | Default | Relevance |
+| --- | --- | --- |
+| `nCorrectors` | `10000` | Maximum number of outer correctors |
+| `solutionTolerance` | `1e-06` | Primary convergence tolerance, `w` and `M` |
+| `alternativeTolerance` | `1e-07` | Secondary convergence tolerance |
+| `infoFrequency` | `100` | Frequency for solver progress output |
+
+Tight tolerances are usual here; the shipped tutorial uses `1e-10` for both.
+
+### Required input files
+
+Because the primary fields live on the finite-area mesh, the case layout is
+different from the other solid models:
+
+- `0/finite-area/w`, `0/finite-area/M` and `0/finite-area/p`, all `MUST_READ`;
+- `0/finite-area/D`, normally `calculated`, since it is mapped from `w`;
+- `system/finite-area/faMeshDefinition`, `faSchemes` and `faSolution`;
+- `constant/solidProperties`;
+- `constant/mechanicalProperties`, selecting a single `linearElastic` law;
+- `constant/g` and `constant/dynamicMeshDict`.
+
+The finite-area mesh is generated with `makeFaMesh` before running
+`solids4Foam`.
+
+### Recommended dictionary setup
+
+Minimal example for `constant/solidProperties`:
+
+```text
+solidModel     kirchhoffPlate;
+
+kirchhoffPlateCoeffs
+{
+    plateThickness       plateThickness [0 1 0 0 0 0 0] 0.1;
+
+    nCorrectors          1000;
+    solutionTolerance    1e-10;
+    alternativeTolerance 1e-10;
+}
+```
+
+`faSchemes` and `faSolution` provide the schemes and linear solvers for `w`
+and `M`; the ordinary `fvSchemes` and `fvSolution` are still read but the plate
+equations do not use them.
+
+### Boundary conditions
+
+The boundary conditions are finite-area patch fields on `w` and `M`, not the
+usual `fvPatchField` types. Two are provided by this model:
+
+| Patch type | Field | Purpose |
+| --- | --- | --- |
+| `clampedMoment` | `M` | Clamped edge; sets the moment from the rotation |
+| `freeEdgeDisplacement` | `w` | Free edge |
+
+A simply supported edge is `fixedValue` on `M` with `fixedValue` on `w`; a
+symmetry edge is `zeroGradient` on both. The transverse pressure `p` is
+normally `zeroGradient` on all edges, with its internal field setting the
+load.
+
+### Field glossary
+
+Finite-area fields, on the surface mesh:
+
+- `w`: transverse deflection; primary unknown.
+- `M`: moment sum; primary unknown.
+- `p`: net transverse pressure load.
+- `theta`: rotation, `-grad(w)`.
+
+Volume fields, mapped from the above onto the single-layer volume mesh so that
+ordinary post-processing tools can read them:
+
+- `wVf`, `MVf`, `pVf`, `thetaVf`: the mapped counterparts.
+- `D`: displacement, mapped from `w*faceAreaNormals`, i.e. the deflection
+  applied along the plate normal.
+- `pointD`, `pointDD`, `DD`, `U`: derived from `D` as usual.
+
+`sigma` exists but is never calculated and is not written.
+
+---
+
+## Developer Notes
+
+### Class role
+
+`kirchhoffPlateSolid` inherits from `solidModel` and holds a `faMesh`
+(`aMesh_`) built from the volume mesh. It satisfies the `solidModel` interface
+by mapping its finite-area solution onto the volume fields the rest of
+solids4foam expects.
+
+- `nonLinGeom()` returns `LINEAR_GEOMETRY`;
+- the primary unknowns are `w_` and `M_`, not `D`;
+- `D` is an output, reconstructed from `w`.
+
+### Construction
+
+The constructor builds `aMesh_`, reads `w`, `M` and `p` on the area mesh
+(`MUST_READ`) and creates their volume counterparts, creates `theta` and
+`gradTheta`, and reads `plateThickness`. It then validates the mechanical
+model — one law, and that law `linearElastic` — extracts `rho`, `E` and `nu`,
+and forms `bendingStiffness_`.
+
+`calcAreaPatches()` identifies the finite-area patch and, from the first cell,
+the opposite "shadow" patch by finding the face whose normal is most
+anti-parallel. It aborts if the two patches do not have equal face counts,
+which is the check that the mesh is one cell thick.
+
+### `evolve()`
+
+An outer mesh-update loop wrapping an inner equation loop. Each inner
+iteration:
+
+1. assembles and solves the `M` equation. `fac::d2dt2` is not available, so
+   the second time derivative is formed manually as
+   `(fac::ddt(w) - fac::ddt(w.oldTime()))/deltaT`, and all terms are moved to
+   the left-hand side because `==` is not supported for `faScalarMatrix` here;
+2. relaxes and solves the `w` equation
+   `fam::laplacian(bendingStiffness, w) + M`;
+3. updates `theta = -fac::grad(w)` and `gradTheta`, the latter being used for
+   the non-orthogonal correction in the clamped boundary condition.
+
+After convergence, `M`, `w`, `theta` and `p` are mapped to their volume
+counterparts with `mapAreaFieldToSingleLayerVolumeField()`, `D` is built as
+`w*aMesh_.faceAreaNormals()` and mapped, and `pointD`, `DD`, `pointDD` and `U`
+follow. Finally `sigma().writeOpt()` is set to `NO_WRITE`.
+
+### Extension points
+
+- the commented-out block-coupled branch in `evolve()`, which would solve `w`
+  and `M` simultaneously as a `BlockLduSystem<vector2, vector2>`; this is
+  sketched but not implemented;
+- `setTraction()` and the finite-area patch fields for new edge conditions;
+- `tractionBoundarySnGrad()`, currently `notImplemented`, if the model is ever
+  to participate in fluid-solid interaction.
+
+Extending this class to Mindlin-Reissner plates would mean carrying the
+rotations as independent unknowns rather than deriving them from `grad(w)`.
+
+---
+
+## Tutorials
+
+Cases that select `kirchhoffPlate`:
+
+- `solids/beamsPlatesShells/squarePlate` — a clamped square plate under
+  uniform pressure, compared against an analytical solution built by the
+  case's own `squarePlateAnalyticalSolution` utility.

--- a/src/solids4FoamModels/solidModels/linGeomTotalDispSolid/README.md
+++ b/src/solids4FoamModels/solidModels/linGeomTotalDispSolid/README.md
@@ -37,15 +37,15 @@ can be treated as undeformed for the governing equations.
 
 ### Supported solution algorithms
 
-The `solutionAlgorithm` entry in `solidModelCoeffs` selects how the equations
-are solved:
+The `solutionAlgorithm` entry in the coefficients sub-dictionary selects how
+the equations are solved:
 
 | Value | Meaning | Notes |
 | --- | --- | --- |
 | `implicitSegregated` | Default segregated solve | Recommended |
 | `PETScSNES` | Nonlinear solve via PETSc SNES | Requires PETSc |
 | `explicit` | Explicit time integration | Time-step limited by stability |
-| `implicitCoupled` | Not implemented for this model | Do not select this value |
+| `implicitCoupled` | Not implemented here | Do not select this value |
 
 The runtime type name for this class is `linearGeometryTotalDisplacement`.
 
@@ -114,7 +114,7 @@ Minimal example for `constant/solidProperties`:
 ```text
 solidModel        linearGeometryTotalDisplacement;
 
-solidModelCoeffs
+linearGeometryTotalDisplacementCoeffs
 {
     solutionAlgorithm   implicitSegregated;
 
@@ -165,7 +165,7 @@ If `solvePressure` is enabled, add:
 
 If `solutionAlgorithm` is `PETScSNES`, also ensure the case provides the PETSc
 options file expected by `optionsFile` (default name: `petscOptions`), unless
-you override that name in `solidModelCoeffs`.
+you override that name in the coefficients sub-dictionary.
 
 ### Required fields and boundary conditions
 

--- a/src/solids4FoamModels/solidModels/linGeomTotalDispSolid/README.md
+++ b/src/solids4FoamModels/solidModels/linGeomTotalDispSolid/README.md
@@ -1,3 +1,7 @@
+---
+sort: 1
+---
+
 # linGeomTotalDispSolid
 
 This page documents the linear-geometry total-displacement solid model.

--- a/src/solids4FoamModels/solidModels/nonLinGeomTotalLagTotalDispSolid/README.md
+++ b/src/solids4FoamModels/solidModels/nonLinGeomTotalLagTotalDispSolid/README.md
@@ -40,8 +40,8 @@ is not valid.
 
 ### Supported solution algorithms
 
-The `solutionAlgorithm` entry in `solidModelCoeffs` selects how the equations
-are solved:
+The `solutionAlgorithm` entry in the coefficients sub-dictionary selects how
+the equations are solved:
 
 | Value | Meaning | Notes |
 | --- | --- | --- |
@@ -103,7 +103,7 @@ Minimal example for `constant/solidProperties`:
 ```text
 solidModel        nonLinearGeometryTotalLagrangianTotalDisplacement;
 
-solidModelCoeffs
+nonLinearGeometryTotalLagrangianTotalDisplacementCoeffs
 {
     solutionAlgorithm    implicitSegregated;
 
@@ -148,7 +148,7 @@ If `solvePressure` is enabled, add:
 
 If `solutionAlgorithm` is `PETScSNES`, also ensure the case provides the PETSc
 options file expected by `optionsFile` (default name: `petscOptions`), unless
-you override that name in `solidModelCoeffs`.
+you override that name in the coefficients sub-dictionary.
 
 ### Required fields and boundary conditions
 

--- a/src/solids4FoamModels/solidModels/nonLinGeomTotalLagTotalDispSolid/README.md
+++ b/src/solids4FoamModels/solidModels/nonLinGeomTotalLagTotalDispSolid/README.md
@@ -1,3 +1,7 @@
+---
+sort: 2
+---
+
 # nonLinGeomTotalLagTotalDispSolid
 
 This page documents the nonlinear total-Lagrangian total-displacement solid

--- a/src/solids4FoamModels/solidModels/nonLinGeomUpdatedLagSolid/README.md
+++ b/src/solids4FoamModels/solidModels/nonLinGeomUpdatedLagSolid/README.md
@@ -1,3 +1,7 @@
+---
+sort: 3
+---
+
 # nonLinGeomUpdatedLagSolid
 
 This page documents the nonlinear updated-Lagrangian incremental-displacement

--- a/src/solids4FoamModels/solidModels/nonLinGeomUpdatedLagSolid/README.md
+++ b/src/solids4FoamModels/solidModels/nonLinGeomUpdatedLagSolid/README.md
@@ -42,8 +42,8 @@ is not valid and mesh motion between time steps is part of the formulation.
 
 ### Supported solution algorithms
 
-The `solutionAlgorithm` entry in `solidModelCoeffs` selects how the equations
-are solved:
+The `solutionAlgorithm` entry in the coefficients sub-dictionary selects how
+the equations are solved:
 
 | Value | Meaning | Notes |
 | --- | --- | --- |
@@ -104,7 +104,7 @@ Minimal example for `constant/solidProperties`:
 ```text
 solidModel        nonLinearGeometryUpdatedLagrangian;
 
-solidModelCoeffs
+nonLinearGeometryUpdatedLagrangianCoeffs
 {
     solutionAlgorithm    implicitSegregated;
 
@@ -149,7 +149,7 @@ If `solvePressure` is enabled, add:
 
 If `solutionAlgorithm` is `PETScSNES`, also ensure the case provides the PETSc
 options file expected by `optionsFile` (default name: `petscOptions`), unless
-you override that name in `solidModelCoeffs`.
+you override that name in the coefficients sub-dictionary.
 
 ### Required fields and boundary conditions
 

--- a/src/solids4FoamModels/solidModels/poroLinGeomSolid/README.md
+++ b/src/solids4FoamModels/solidModels/poroLinGeomSolid/README.md
@@ -1,0 +1,229 @@
+---
+sort: 14
+---
+
+# poroLinGeomSolid
+
+This page documents the poroelastic linear-geometry solid model. The runtime
+type is:
+
+```text
+poroLinearGeometry
+```
+
+The model assumes small strains and small rotations. It solves a pore-pressure
+equation for `p` and the linear momentum equation for total displacement `D`
+inside one outer loop, so that the pressure-displacement coupling is converged
+within each time step.
+
+The approach follows `elastoPlasticBiotFoam` from Tian Tang's miniGeotechFoam
+toolbox. See:
+
+- T. Tang, O. Hededal and P. Cardiff (2014), _On finite volume method
+  implementation of poro-elasto-plasticity soil model_, International Journal
+  for Numerical and Analytical Methods in Geomechanics,
+  [10.1002/nag.2361](https://doi.org/10.1002/nag.2361).
+- T. Tang and O. Hededal (2014), _Simulation of pore pressure accumulation
+  under cyclic loading using finite volume method_, Proceedings of NUMGE14,
+  Volume 2, pages 1301-1306.
+
+---
+
+## User Guide
+
+### What this model solves
+
+`poroLinGeomSolid`:
+
+- solves the pore-pressure equation
+  `(porosity*rKprime)*ddt(p) + div(U) == (k/gammaWater)*laplacian(p)`,
+  where `rKprime` is the reciprocal of the equivalent bulk modulus of the pore
+  fluid;
+- solves the linear-geometry momentum equation for `D`;
+- alternates the two equations inside a single outer loop, and requires both
+  to converge before the time step ends;
+- couples the two through `div(U)`, the volumetric strain rate that appears as
+  a source in the pressure equation.
+
+```warning
+The pore pressure enters the momentum equation only through the mechanical
+law. Pair this model with `poroMechanicalLaw`, which subtracts the effective
+pore pressure from the total stress; the momentum equation itself has no
+explicit `p` term.
+```
+
+### Supported solution algorithms
+
+This model implements a single, segregated implicit algorithm. It does not
+read `solutionAlgorithm`, and there is no PETSc SNES or explicit path.
+
+### Model options
+
+These five entries are **required** — they are read with `lookup()`, so the
+model fails at construction if any is missing:
+
+| Entry | Dimensions | Description |
+| --- | --- | --- |
+| `hydraulicConductivity` | `[0 1 -1 0 0 0 0]` | Darcy hydraulic conductivity |
+| `waterSpecificWeight` | `[1 -2 -2 0 0 0 0]` | Pore fluid specific weight |
+| `porosity` | `[0 0 0 0 0 0 0]` | Porosity of the solid skeleton |
+| `degreeOfSaturation` | `[0 0 0 0 0 0 0]` | Degree of saturation, 0 to 1 |
+| `waterBulkModulus` | `[1 -1 -2 0 0 0 0]` | Bulk modulus of the pore fluid |
+
+From the last two the model forms
+
+```text
+rKprime = saturation/KWater + (1 - saturation)/1e5 Pa
+```
+
+which is the compressibility of a partially saturated pore fluid; the
+`1e5 Pa` is a hard-coded atmospheric pressure.
+
+The relevant inherited `solidModel` entries are:
+
+| Entry | Default | Relevance |
+| --- | --- | --- |
+| `nCorrectors` | `10000` | Maximum number of outer correctors |
+| `solutionTolerance` | `1e-06` | Primary convergence tolerance, `p` and `D` |
+| `alternativeTolerance` | `1e-07` | Secondary convergence tolerance |
+| `materialTolerance` | `1e-05` | Mechanical-law convergence tolerance |
+| `relaxationMethod` | `fixed` | Under-relaxation method (`fixed`, `aitken`) |
+| `infoFrequency` | `100` | Frequency for solver progress output |
+| `stabilisation` | auto-created if absent | `momentum` sub-dictionary is used |
+| `cellDisplacements` | optional | Internal-cell displacement constraints |
+
+### Required input files
+
+- `p` and `D` in the time directory;
+- `constant/solidProperties`;
+- `constant/mechanicalProperties`, normally selecting `poroMechanicalLaw`;
+- `constant/g`.
+
+`p` is `MUST_READ`, so a case that omits it will fail at construction.
+
+### Recommended dictionary setup
+
+Minimal example for `constant/solidProperties`:
+
+```text
+solidModel     poroLinearGeometry;
+
+poroLinearGeometryCoeffs
+{
+    nCorrectors          1000;
+    solutionTolerance    1e-06;
+    alternativeTolerance 1e-07;
+    materialTolerance    1e-05;
+    infoFrequency        100;
+
+    hydraulicConductivity hydraulicConductivity [0 1 -1 0 0 0 0] 0.001;
+    porosity              porosity [0 0 0 0 0 0 0] 0.2;
+    waterSpecificWeight   waterSpecificWeight [1 -2 -2 0 0 0 0] 1e+04;
+    degreeOfSaturation    degreeOfSaturation [0 0 0 0 0 0 0] 0.99;
+    waterBulkModulus      waterBulkModulus [1 -1 -2 0 0 0 0] 2e+09;
+}
+```
+
+`fvSchemes` must provide `laplacian(DD,D)` and a default `laplacian` entry for
+the pressure equation, and `fvSolution` must provide solvers for `p` and `D`.
+
+### Boundary conditions
+
+Displacement boundaries use the standard solids4foam patch types. Pore
+pressure uses the usual OpenFOAM scalar patch types: `fixedValue` for a
+drained boundary, `zeroGradient` for an undrained one.
+
+Note that on a traction boundary the `pressure` entry is the mechanical
+traction pressure, not the pore pressure; the two are independent.
+
+### Field glossary
+
+- `p`: pore pressure; primary hydraulic unknown, written each output time.
+- `grad(p)`: pore-pressure gradient.
+- `D`, `DD`: total and incremental displacement.
+- `pointD`, `pointDD`: displacement at mesh points.
+- `grad(D)`, `grad(DD)`: displacement gradients.
+- `sigma`: symmetric stress tensor; with `poroMechanicalLaw` this is the total
+  stress, i.e. effective stress minus the pore-pressure contribution.
+- `U`: velocity field, computed as `ddt(D)`; the `div(U)` term is what couples
+  the momentum equation back into the pressure equation.
+
+---
+
+## Developer Notes
+
+### Class role
+
+`poroLinGeomSolid` inherits directly from `solidModel`. The key design choices
+are:
+
+- `D` is the primary solution variable (`solutionD()` returns `D()`);
+- `nonLinGeom()` returns `LINEAR_GEOMETRY`;
+- the momentum equation is the same deferred-correction Laplacian form used by
+  `linGeomTotalDispSolid`, with the momentum stabilisation term applied
+  explicitly;
+- the poroelastic coupling is one-directional in each equation:
+  displacement enters the pressure equation through `div(U)`, and pressure
+  enters the momentum equation only through the mechanical law's stress.
+
+### Construction
+
+The constructor calls the base `solidModel` constructor, reads `p`
+(`MUST_READ`), creates `grad(p)`, reads the five required poroelastic
+properties, forms `rKprime_`, and forces creation of `p.oldTime()`. The
+implicit stiffness fields `impK_`, `impKf_` and `rImpK_` come from the
+mechanical law.
+
+### `evolve()`
+
+Each outer iteration:
+
+1. stores `p`, assembles and solves the pressure equation, relaxes `p`, and
+   updates `grad(p)`;
+2. stores `D`, updates the momentum stabilisation, assembles
+
+   ```text
+   rho*d2dt2(D) == laplacian(impKf, D) - fvc::laplacian(impKf, D)
+                 + fvc::div(sigma) + rho*g + impK*stabilisation
+   ```
+
+   then relaxes and solves it, and under-relaxes `D`;
+3. updates `DD`, `grad(D)`, `grad(DD)`, then `U` — which the next pressure
+   equation consumes — and `sigma`;
+4. refreshes `impKf_` from the mechanical law every tenth iteration. `impK_`
+   and `rImpK_` are deliberately _not_ refreshed, because they are used by the
+   traction boundary conditions.
+
+The loop exits through the private `converged()` overload, which checks both
+`p` and `D`, or when `iCorr` reaches `nCorrectors`. Afterwards `pointD` and
+`pointDD` are updated once. `evolve()` always returns `true`.
+
+### Traction boundary treatment
+
+`tractionBoundarySnGrad()` is the standard linear-geometry form,
+
+```text
+((traction - n*pressure) - (n & (sigma - impK*gradD)))*rImpK
+```
+
+evaluated with the cell-centred stress and gradient.
+
+### Extension points
+
+- `evolve()` for a different coupling strategy between the two equations;
+- the private `converged()` overload if a different convergence criterion is
+  needed.
+
+The poroelastic properties are currently read as uniform `dimensionedScalar`
+values from `solidProperties`. Spatially varying properties, or a
+nonlinear permeability, would need those members to become fields.
+
+---
+
+## Tutorials
+
+Cases that select `poroLinearGeometry`:
+
+- `solids/poroelasticity/stripFooting`
+- `solids/poroelasticity/rodAndSeabed`
+- `solids/poroelasticity/suctionCaission`

--- a/src/solids4FoamModels/solidModels/thermalLinGeomSolid/README.md
+++ b/src/solids4FoamModels/solidModels/thermalLinGeomSolid/README.md
@@ -1,0 +1,221 @@
+---
+sort: 11
+---
+
+# thermalLinGeomSolid
+
+This page documents the coupled thermal linear-geometry solid model. The
+runtime type is:
+
+```text
+thermalLinearGeometry
+```
+
+The model assumes small strains and small rotations, and solves the energy
+equation for temperature `T` and the linear momentum equation for total
+displacement `D` inside one outer loop, so that the temperature-displacement
+coupling is converged within each time step.
+
+The stress is computed by the run-time selectable mechanical law.
+
+---
+
+## User Guide
+
+### What this model solves
+
+`thermalLinGeomSolid`:
+
+- solves the transient heat equation
+  `rhoC*ddt(T) == laplacian(k, T) + (sigma && grad(U))`, i.e. including the
+  mechanical work term;
+- solves the linear-geometry momentum equation for `D`;
+- alternates the two equations inside a single outer loop, and requires both
+  to converge before the time step ends;
+- takes `C` and `k` from a `thermalModel`, configured in
+  `constant/thermalProperties`;
+- exposes the interface that thermal fluid-solid interaction uses to set
+  patch temperature and heat flux.
+
+```warning
+The momentum equation does not include a thermal-expansion term by itself.
+To get thermal stresses, select a mechanical law that consumes the temperature
+field, such as `thermoMechanicalLaw`. Without one, the temperature solution
+has no effect on the displacement.
+```
+
+### Supported solution algorithms
+
+This model implements a single, segregated implicit algorithm. It does not
+read `solutionAlgorithm`, and there is no PETSc SNES or explicit path.
+
+### Model options
+
+| Entry | Default | Description |
+| --- | --- | --- |
+| `absoluteTemperatureTolerance` | `1e-06` | Convergence threshold on `T` |
+
+`absoluteTemperatureTolerance` is an absolute change in degrees: once the
+temperature stops moving by more than this between outer iterations, the
+thermal loop is considered converged.
+
+The relevant inherited `solidModel` entries are:
+
+| Entry | Default | Relevance |
+| --- | --- | --- |
+| `nCorrectors` | `10000` | Maximum number of outer correctors |
+| `solutionTolerance` | `1e-06` | Primary convergence tolerance, `T` and `D` |
+| `alternativeTolerance` | `1e-07` | Secondary convergence tolerance |
+| `materialTolerance` | `1e-05` | Mechanical-law convergence tolerance |
+| `relaxationMethod` | `fixed` | Under-relaxation method (`fixed`, `aitken`) |
+| `infoFrequency` | `100` | Frequency for solver progress output |
+| `stabilisation` | auto-created if absent | `momentum` sub-dictionary is used |
+| `cellDisplacements` | optional | Internal-cell displacement constraints |
+
+Convergence requires the temperature _and_ the displacement residuals to be
+satisfied, and at least two outer iterations are always performed.
+
+### Required input files
+
+- `T` and `D` in the time directory;
+- `constant/solidProperties`;
+- `constant/thermalProperties`, providing the `thermal` sub-dictionary;
+- `constant/mechanicalProperties`;
+- `constant/g`.
+
+`T` is `MUST_READ`, so a case that omits it will fail at construction.
+
+Example `constant/thermalProperties`:
+
+```text
+thermal
+{
+    type            constant;
+    C               C [0 2 -2 -1 0 0 0] 434;
+    k               k [1 1 -3 -1 0 0 0] 250;
+}
+```
+
+### Recommended dictionary setup
+
+Minimal example for `constant/solidProperties`:
+
+```text
+solidModel        thermalLinearGeometry;
+
+thermalLinearGeometryCoeffs
+{
+    nCorrectors                  10000;
+    solutionTolerance            1e-06;
+    alternativeTolerance         1e-07;
+    materialTolerance            1e-05;
+    absoluteTemperatureTolerance 1e-06;
+    infoFrequency                100;
+}
+```
+
+`fvSchemes` must provide `laplacian(k,T)` and `laplacian(DD,D)` entries, and
+`fvSolution` must provide solvers for `T` and `D`.
+
+### Boundary conditions
+
+Displacement boundaries use the standard solids4foam patch types. Temperature
+boundaries use the usual OpenFOAM scalar patch types, plus:
+
+- `thermalRobin`, which carries both a temperature and a heat flux and is the
+  type required on a thermal fluid-solid interface. Calling
+  `setTemperatureAndHeatFlux()` on any other patch type is a fatal error.
+- `thermalConvection`, for a convective heat-transfer boundary.
+
+### Field glossary
+
+- `T`: temperature; primary thermal unknown, written each output time.
+- `grad(T)`: temperature gradient, used to report the heat flux.
+- `heatFlux`: `-k*grad(T)`, constructed and written by `writeFields()`.
+- `D`, `DD`: total and incremental displacement.
+- `pointD`, `pointDD`: displacement at mesh points.
+- `grad(D)`, `grad(DD)`: displacement gradients.
+- `sigma`: symmetric stress tensor.
+- `U`: velocity field, computed as `ddt(D)`.
+- `rhoC`: product of density and specific heat capacity.
+
+Each write also prints the maximum and minimum temperature and the maximum
+magnitude of the heat flux.
+
+---
+
+## Developer Notes
+
+### Class role
+
+`thermalLinGeomSolid` inherits directly from `solidModel` and adds a
+`thermalModel` member. The key design choices are:
+
+- `D` is the primary solution variable (`solutionD()` returns `D()`);
+- `nonLinGeom()` returns `LINEAR_GEOMETRY`;
+- the momentum equation is the same deferred-correction Laplacian form used by
+  `linGeomTotalDispSolid`, with the momentum stabilisation term applied
+  explicitly;
+- the heat equation and the momentum equation share one outer loop, which is
+  what distinguishes this model from
+  [weakThermalLinGeomSolid](https://www.solids4foam.com/documentation/solid-models/weakThermalLinGeomSolid.html).
+
+### Construction
+
+The constructor calls the base `solidModel` constructor and `DisRequired()`,
+constructs the `thermalModel` from the mesh, builds `rhoC_` as
+`thermal.C()*mechanical().rho()` and `k_` from `thermal.k()`, reads `T`
+(`MUST_READ`) and creates `grad(T)`, reads `absoluteTemperatureTolerance`, and
+takes `impK_`, `impKf_` and `rImpK_` from the mechanical law. It then forces
+creation of `T.oldTime()`.
+
+### `evolve()`
+
+Each outer iteration:
+
+1. stores `T` for under-relaxation, assembles and solves the heat equation
+   including the `sigma && grad(U)` work term, relaxes `T`, and updates
+   `grad(T)`;
+2. stores `D`, updates the momentum stabilisation, assembles
+
+   ```text
+   rho*d2dt2(D) == laplacian(impKf, D) - fvc::laplacian(impKf, D)
+                 + fvc::div(sigma) + rho*g + impK*stabilisation
+   ```
+
+   then relaxes and solves it, and under-relaxes `D`;
+3. updates `DD`, `U`, `grad(D)`, `grad(DD)` and `sigma`;
+4. refreshes `impKf_` from the mechanical law every tenth iteration, to help
+   convergence when the material stiffness changes. `impK_` and `rImpK_` are
+   deliberately _not_ refreshed, because they are used by the traction
+   boundary conditions.
+
+The loop exits through the private `converged()` overload, which checks both
+`T` and `D`, or when `iCorr` reaches `nCorrectors`. Afterwards `pointD`, `DD`
+and `pointDD` are updated once.
+
+### Thermal fluid-solid interaction interface
+
+`setTemperatureAndHeatFlux()` and `setEqInterHeatTransferCoeff()` write into a
+`thermalRobin` patch field, and `faceZoneTemperature()`,
+`faceZoneHeatFlux()` and `faceZoneHeatTransferCoeff()` read the corresponding
+quantities back out on a global face zone. These are the hooks used by the
+thermal fluid-solid interfaces.
+
+### Extension points
+
+- `evolve()` for a different coupling strategy between the two equations;
+- the private `converged()` overload if a different convergence criterion is
+  needed;
+- `writeFields()` for extra derived thermal output.
+
+---
+
+## Tutorials
+
+Cases that select `thermalLinearGeometry`:
+
+- `solids/thermoelasticity/hotCylinder`
+- `solids/thermoelasticity/hotSphere`
+- `solids/thermoelasticity/slabCooling`
+- `thermoFluidSolidInteraction/hotTJunction`

--- a/src/solids4FoamModels/solidModels/thermalSolid/README.md
+++ b/src/solids4FoamModels/solidModels/thermalSolid/README.md
@@ -1,0 +1,201 @@
+---
+sort: 13
+---
+
+# thermalSolid
+
+This page documents the heat-conduction-only solid model. The runtime type is:
+
+```text
+thermalSolid
+```
+
+The model solves the transient heat equation for temperature `T` in a solid
+region. It does **not** solve a momentum equation, and the displacement field
+stays at its initial value. It exists to provide the solid side of conjugate
+heat transfer, where a fluid model exchanges temperature and heat flux with a
+rigid solid.
+
+---
+
+## User Guide
+
+### What this model solves
+
+`thermalSolid`:
+
+- solves `rhoC*ddt(T) == laplacian(k, T)`, with no source terms;
+- takes `C` and `k` from a `thermalModel`, configured in
+  `constant/thermalProperties`;
+- implements the `setTemperatureAndHeatFlux()`,
+  `setEqInterHeatTransferCoeff()`, `faceZoneTemperature()`,
+  `faceZoneHeatFlux()` and `faceZoneHeatTransferCoeff()` interface used by the
+  thermal fluid-solid interfaces;
+- returns a zero surface-normal gradient from `tractionBoundarySnGrad()`, so
+  traction boundary conditions have no effect.
+
+```warning
+No mechanical equation is solved. If you need the deformation as well as the
+temperature, use
+[thermalLinGeomSolid](https://www.solids4foam.com/documentation/solid-models/thermalLinGeomSolid.html)
+for a strongly coupled solve, or
+[weakThermalLinGeomSolid](https://www.solids4foam.com/documentation/solid-models/weakThermalLinGeomSolid.html)
+for a one-way coupled one.
+```
+
+### Supported solution algorithms
+
+This model implements a single, segregated implicit loop for the heat
+equation. It does not read `solutionAlgorithm`.
+
+### Model options
+
+| Entry | Default | Description |
+| --- | --- | --- |
+| `absoluteTemperatureTolerance` | `1e-06` | Convergence threshold on `T` |
+
+`absoluteTemperatureTolerance` is an absolute change in degrees: once the
+temperature stops moving by more than this between outer iterations, the
+thermal loop is considered converged.
+
+The relevant inherited `solidModel` entries are:
+
+| Entry | Default | Relevance |
+| --- | --- | --- |
+| `nCorrectors` | `10000` | Maximum number of correctors |
+| `solutionTolerance` | `1e-06` | Primary convergence tolerance |
+| `alternativeTolerance` | `1e-07` | Secondary convergence tolerance |
+| `infoFrequency` | `100` | Frequency for solver progress output |
+
+The mechanical options inherited from `solidModel` are read but have no
+effect, since no momentum equation is assembled.
+
+### Required input files
+
+- `T` and `D` in the time directory;
+- `constant/solidProperties`;
+- `constant/thermalProperties`, providing the `thermal` sub-dictionary;
+- `constant/mechanicalProperties`, which is still needed because the density
+  is taken from the mechanical law when forming `rhoC`;
+- `constant/g`.
+
+`T` is `MUST_READ`, so a case that omits it will fail at construction.
+
+Example `constant/thermalProperties`:
+
+```text
+thermal
+{
+    type            constant;
+    C               C [0 2 -2 -1 0 0 0] 434;
+    k               k [1 1 -3 -1 0 0 0] 250;
+}
+```
+
+### Recommended dictionary setup
+
+Minimal example for `constant/solidProperties`, as used on the solid side of a
+conjugate heat transfer case:
+
+```text
+solidModel        thermalSolid;
+
+thermalSolidCoeffs
+{
+    nCorrectors                  10000;
+    solutionTolerance            1e-06;
+    alternativeTolerance         1e-07;
+    absoluteTemperatureTolerance 1e-06;
+    infoFrequency                100;
+}
+```
+
+`fvSchemes` must provide a `laplacian(k,T)` entry, and `fvSolution` must
+provide a solver for `T`.
+
+### Boundary conditions
+
+Temperature boundaries use the usual OpenFOAM scalar patch types, plus:
+
+- `thermalRobin`, which carries both a temperature and a heat flux and is the
+  type required on a thermal fluid-solid interface. Calling
+  `setTemperatureAndHeatFlux()` on any other patch type is a fatal error.
+- `thermalConvection`, for a convective heat-transfer boundary.
+
+Displacement boundary conditions may be present but are not solved for.
+
+### Field glossary
+
+- `T`: temperature; the only field this model solves for.
+- `grad(T)`: temperature gradient, used to report the heat flux.
+- `heatFlux`: `-k*grad(T)`, constructed and written by `writeFields()`.
+- `rhoC`: product of density and specific heat capacity.
+
+Each write also prints the maximum and minimum temperature and the maximum
+magnitude of the heat flux.
+
+---
+
+## Developer Notes
+
+### Class role
+
+`thermalSolid` inherits directly from `solidModel` and adds a `thermalModel`
+member. It is the minimal solid model: it satisfies the `solidModel` interface
+but leaves the mechanical part inert.
+
+- `nonLinGeom()` returns `LINEAR_GEOMETRY`;
+- `solutionD()` returns `D()`, but `D` is never solved for;
+- `tractionBoundarySnGrad()` returns a zero field of patch size.
+
+The header's `Description` block, inherited from `thermalLinGeomSolid`, still
+mentions a strongly coupled momentum equation; the implementation solves the
+heat equation only.
+
+### Construction
+
+The constructor calls the base `solidModel` constructor, constructs the
+`thermalModel` from the mesh, builds `rhoC_` as
+`thermal.C()*mechanical().rho()` and `k_` from `thermal.k()`, reads `T`
+(`MUST_READ`), creates `grad(T)`, reads `absoluteTemperatureTolerance`, and
+forces creation of `T.oldTime()`.
+
+Note that `DisRequired()` is not called, consistent with the absence of a
+momentum solve.
+
+### `evolve()`
+
+A single loop on the heat equation: store `T`, relax and solve
+`rhoC*ddt(T) - laplacian(k, T)`, relax `T`, update `grad(T)`. On OpenFOAM.com
+builds the solver-performance dictionary is cleared each iteration, to avoid an
+expensive copy of the residual history when many correctors run. The loop
+exits through the private `converged()` overload or when `iCorr` reaches
+`nCorrectors`. `evolve()` always returns `true`.
+
+### Conjugate heat transfer interface
+
+`setTemperatureAndHeatFlux()` and `setEqInterHeatTransferCoeff()` write into a
+`thermalRobin` patch field; `faceZoneTemperature()`, `faceZoneHeatFlux()` and
+`faceZoneHeatTransferCoeff()` read the corresponding quantities back out on a
+global face zone. These are the hooks the thermal fluid-solid interfaces call
+each coupling iteration.
+
+### Extension points
+
+- `evolve()` if the heat equation needs source terms;
+- the private `converged()` overload for a different convergence criterion.
+
+If a mechanical solve is ever wanted here, prefer `thermalLinGeomSolid`
+instead of extending this class.
+
+---
+
+## Tutorials
+
+Cases that select `thermalSolid`:
+
+- `thermoFluidSolidInteraction/flowOverHeatedPlate`
+- `thermoFluidSolidInteraction/thermalCavity`
+
+In both, `thermalSolid` is the solid region of a conjugate heat transfer
+simulation, and the solid does not deform.

--- a/src/solids4FoamModels/solidModels/unsLinGeomSolid/README.md
+++ b/src/solids4FoamModels/solidModels/unsLinGeomSolid/README.md
@@ -1,0 +1,220 @@
+---
+sort: 4
+---
+
+# unsLinGeomSolid
+
+This page documents the unstructured linear-geometry total-displacement solid
+model. The runtime type is:
+
+```text
+unsLinearGeometry
+```
+
+The model assumes small strains and small rotations, and solves for the total
+displacement field `D`. It differs from
+[linGeomTotalDispSolid](https://www.solids4foam.com/documentation/solid-models/linGeomTotalDispSolid.html)
+in how the gradient is calculated: the "uns" prefix stands for
+_unstructured_, and indicates that the face tangential gradient is calculated
+using a face-Gauss approach rather than from the cell-centred gradient. This
+is more accurate on unstructured meshes, at extra cost per iteration.
+
+The stress is computed by the run-time selectable mechanical law.
+
+---
+
+## User Guide
+
+### What this model solves
+
+`unsLinGeomSolid`:
+
+- solves the linear momentum equation in linear-geometry form;
+- uses total displacement `D` as the primary unknown;
+- stores the stress and the displacement gradient as _surface_ fields
+  (`sigmaf` and `grad(D)f`), evaluated directly at the faces;
+- solves the momentum equation with a segregated implicit algorithm only;
+- uses the selected mechanical law to calculate stress.
+
+The model is suitable when changes in geometry are small enough that the mesh
+can be treated as undeformed, and when the mesh is unstructured enough that
+the face-Gauss gradient is worth its extra cost.
+
+### Supported solution algorithms
+
+This model implements a single, segregated implicit algorithm. It does not
+read `solutionAlgorithm`, and there is no PETSc SNES or explicit path. Use
+`linGeomTotalDispSolid` if you need those.
+
+### Model options
+
+`unsLinGeomSolid` adds no options of its own. The relevant entries in
+`unsLinearGeometryCoeffs` are the inherited `solidModel` ones:
+
+| Entry | Default | Relevance |
+| --- | --- | --- |
+| `nCorrectors` | `10000` | Maximum number of outer correctors |
+| `solutionTolerance` | `1e-06` | Primary convergence tolerance |
+| `alternativeTolerance` | `1e-07` | Secondary convergence tolerance |
+| `materialTolerance` | `1e-05` | Mechanical-law convergence tolerance |
+| `relaxationMethod` | `fixed` | Under-relaxation method (`fixed`, `aitken`) |
+| `infoFrequency` | `100` | Frequency for solver progress output |
+| `writeResidualField` | `false` | Writes a residual field during output |
+| `residualFile` | `false` | Writes `residual.dat` in the case directory |
+| `cellDisplacements` | optional | Internal-cell displacement constraints |
+
+The under-relaxation factor for `D` itself is set in `fvSolution` under
+`relaxationFactors/equations`, as for the other segregated solid models.
+
+```note
+`dampingCoeff` is read by the base class but is not applied by this model's
+momentum equation.
+```
+
+### Recommended dictionary setup
+
+Minimal example for `constant/solidProperties`:
+
+```text
+solidModel        unsLinearGeometry;
+
+unsLinearGeometryCoeffs
+{
+    nCorrectors          10000;
+    solutionTolerance    1e-06;
+    alternativeTolerance 1e-07;
+    materialTolerance    1e-05;
+    infoFrequency        100;
+}
+```
+
+The momentum equation is assembled with the name `laplacian(DD,D)`, so
+`fvSchemes` must provide a `laplacian(DD,D)` entry, and `fvSolution` must
+provide a solver for `D`.
+
+### Required fields and boundary conditions
+
+At minimum, the model expects:
+
+- `D` in the time directory;
+- `solidProperties` in `constant`;
+- `g` in `constant`;
+- a `mechanicalProperties` configuration for the chosen material law.
+
+Traction boundaries are handled through `tractionBoundarySnGrad()`, which
+returns the surface-normal gradient consistent with the face stress `sigmaf`
+and the face implicit stiffness. All the standard solids4foam displacement and
+traction patch types apply.
+
+### Field glossary
+
+- `D`: total displacement field at cell centres.
+- `pointD`, `pointDD`: total and incremental displacement at mesh points.
+- `grad(D)`: cell-centre gradient of `D`.
+- `grad(D)f`: face gradient of `D`, computed with the face-Gauss approach.
+- `sigma`: cell-centre symmetric stress tensor.
+- `sigmaf`: face symmetric stress tensor; this is the field the momentum
+  equation actually uses.
+- `U`: velocity field, computed as `ddt(D)`.
+
+`sigmaf` is written with `AUTO_WRITE`, so it appears in the time directories.
+
+---
+
+## Developer Notes
+
+### Class role
+
+`unsLinGeomSolid` is the face-gradient counterpart of
+`linGeomTotalDispSolid`. The key design choices are:
+
+- `D` is the primary solution variable (`solutionD()` returns `D()`);
+- `nonLinGeom()` returns `LINEAR_GEOMETRY`, so the geometry is fixed;
+- the stress used in the momentum equation is the _surface_ field `sigmaf_`,
+  not an interpolation of the cell-centred `sigma`;
+- stress is delegated to `mechanicalModel`.
+
+The class inherits directly from `solidModel`.
+
+### Construction
+
+The constructor:
+
+1. calls the base `solidModel` constructor and `DisRequired()`;
+2. creates `sigmaf_` (`AUTO_WRITE`) and `gradDf_` (`NO_WRITE`);
+3. takes `impK_`, `impKf_` from the mechanical law and stores `rImpK_`, the
+   reciprocal used on every traction boundary evaluation;
+4. calls `fvm::d2dt2(D())` purely to force creation of the old-time fields;
+5. evaluates the boundary conditions and the gradient once, so that a restart
+   starts from a consistent `grad(D)f`;
+6. stores the old times of `gradDf_` and `sigmaf_`.
+
+### `evolve()`
+
+A single outer loop:
+
+- store `D` for under-relaxation and residual calculation;
+- assemble the momentum equation
+
+  ```text
+  rho*d2dt2(D) == laplacian(impKf, D) - fvc::laplacian(impKf, D)
+                + fvc::div(Sf & sigmaf) + rho*g
+  ```
+
+  i.e. an implicit Laplacian with a deferred correction that recovers the
+  original divergence of stress at convergence;
+- relax the linear system, apply `solidModel::setCellDisps()`, and solve;
+- under-relax `D` with `relaxField()`;
+- interpolate `D` to `pointD` and update `grad(D)` and `grad(D)f` through
+  `mechanical().grad()`;
+- update `sigmaf` and `sigma` from the mechanical law.
+
+The loop exits through the base-class `converged()` helper, or when `iCorr`
+reaches `nCorrectors`. Afterwards `pointDD` and `U` are updated once.
+
+Note that `DD` and `grad(DD)` are deliberately not updated inside the loop;
+the corresponding lines are commented out in the source.
+
+### Traction boundary treatment
+
+`tractionBoundarySnGrad()` returns
+
+```text
+((traction - n*pressure) - (n & (sigma - impK*gradD)))*rImpK
+```
+
+evaluated with the _face_ stress and gradient. The `impK*gradD` term removes
+the part of the traction that the implicit Laplacian already accounts for, so
+that the boundary condition is consistent with the deferred-correction split
+used in `evolve()`.
+
+### Extension points
+
+- `evolve()` if a different outer-iteration strategy is needed;
+- `tractionBoundarySnGrad()` if the deferred-correction split changes.
+
+Because the class holds face fields as its primary state, any new algorithm
+must keep `sigmaf_` and `gradDf_` up to date, not just their cell-centred
+counterparts.
+
+---
+
+## Tutorials
+
+No tutorial selects `unsLinearGeometry` by default. It is offered as a
+commented alternative in several linear-elasticity and contact cases, which
+are the natural places to try it:
+
+- `solids/linearElasticity/patchTest`
+- `solids/linearElasticity/plateHole`
+- `solids/linearElasticity/ellipticPlate`
+- `solids/linearElasticity/narrowTmember`
+- `solids/linearElasticity/punch`
+- `solids/linearElasticity/flatEndedRigidIndenter`
+- `solids/linearElasticity/rigidCylinderContactBrick`
+- `solids/linearElasticity/slidingFrictionBall`
+- `solids/multiMaterial/layeredPipe`
+- `solids/abaqusUMATs/plateHoleTotalDispUMAT`
+
+Swap the `solidModel` entry in `constant/solidProperties` to switch a case
+over; no other case settings need to change.

--- a/src/solids4FoamModels/solidModels/unsNonLinGeomTotalLagSolid/README.md
+++ b/src/solids4FoamModels/solidModels/unsNonLinGeomTotalLagSolid/README.md
@@ -1,0 +1,238 @@
+---
+sort: 5
+---
+
+# unsNonLinGeomTotalLagSolid
+
+This page documents the unstructured nonlinear total-Lagrangian
+total-displacement solid model. The runtime type is:
+
+```text
+unsNonLinearGeometryTotalLagrangian
+```
+
+The model assumes finite strains and rotations and solves for the total
+displacement field `D` in the total-Lagrangian frame, so the mesh is not
+moved. It is the nonlinear-geometry counterpart of
+[unsLinGeomSolid](https://www.solids4foam.com/documentation/solid-models/unsLinGeomSolid.html):
+the "uns" prefix indicates that the face tangential gradient is calculated
+with a face-Gauss approach rather than from the cell-centred gradient.
+
+The stress is computed by the run-time selectable mechanical law.
+
+---
+
+## User Guide
+
+### What this model solves
+
+`unsNonLinGeomTotalLagSolid`:
+
+- solves the momentum equation in total-Lagrangian form;
+- uses total displacement `D` as the primary unknown;
+- carries the kinematics as _surface_ fields — `Ff`, `Finvf`, `Jf` — as well
+  as the cell-centred `F`, `Finv`, `J`;
+- uses the surface stress `sigmaf` in the momentum equation;
+- solves with a segregated implicit algorithm only;
+- can fall back to a linear-geometry equation when the outer iterations
+  diverge (see below).
+
+The model is appropriate when deformation is large enough that linear geometry
+is not valid, and the mesh is unstructured enough to warrant the face-Gauss
+gradient.
+
+### Supported solution algorithms
+
+This model implements a single, segregated implicit algorithm. It does not
+read `solutionAlgorithm`, and there is no PETSc SNES or explicit path. Use
+[nonLinGeomTotalLagTotalDispSolid](https://www.solids4foam.com/documentation/solid-models/nonLinGeomTotalLagTotalDispSolid.html)
+if you need those.
+
+### Model options
+
+| Entry | Default | Description |
+| --- | --- | --- |
+| `nonLinear` | `true` | Allow the automatic linear fallback |
+| `debug` | `false` | Extra per-iteration solver output |
+| `solutionTolerance` | inherited | Used here as a _relative_ tolerance |
+
+```warning
+`solutionTolerance` has a different meaning in this model. It is used as a
+relative tolerance: the convergence target is the largest relative momentum
+residual seen so far, multiplied by `solutionTolerance`, floored at the base
+class `solutionTolerance`. A value that works for the other solid models may
+converge sooner or later here.
+```
+
+The relevant inherited `solidModel` entries are:
+
+| Entry | Default | Relevance |
+| --- | --- | --- |
+| `nCorrectors` | `10000` | Maximum number of outer correctors |
+| `materialTolerance` | `1e-05` | Mechanical-law convergence tolerance |
+| `dampingCoeff` | `0` | Adds `dampingCoeff*rho*ddt(D)` to the equation |
+| `relaxationMethod` | `fixed` | Under-relaxation method (`fixed`, `aitken`) |
+| `infoFrequency` | `100` | Frequency for solver progress output |
+| `cellDisplacements` | optional | Internal-cell displacement constraints |
+
+### The linear fallback
+
+Nonlinear geometry can drive the outer iterations into a state where the
+deformation gradient becomes unphysical. After each update the model calls
+`checkEnforceLinear(Jf_)`; if the relative Jacobian indicates divergence, the
+`enforceLinear` flag is set and the nonlinear part of the divergence-of-stress
+term is replaced by its linear-geometry equivalent for the remainder of the
+time step. The traction boundary condition switches to its linear form at the
+same time.
+
+When this happens, `evolve()` returns `false`, which signals the calling solver
+to reduce the time step and try again. If `nonLinear` is set to `false`, the
+check is skipped and the model runs without the fallback.
+
+### Recommended dictionary setup
+
+Minimal example for `constant/solidProperties`:
+
+```text
+solidModel        unsNonLinearGeometryTotalLagrangian;
+
+unsNonLinearGeometryTotalLagrangianCoeffs
+{
+    nonLinear            yes;
+
+    nCorrectors          10000;
+    solutionTolerance    1e-06;
+    materialTolerance    1e-05;
+    infoFrequency        100;
+}
+```
+
+The momentum equation is assembled with the name `laplacian(DD,D)`, so
+`fvSchemes` must provide a `laplacian(DD,D)` entry, and `fvSolution` must
+provide a solver for `D`.
+
+### Required fields and boundary conditions
+
+At minimum, the model expects:
+
+- `D` in the time directory;
+- `solidProperties` in `constant`;
+- `g` in `constant`;
+- a `mechanicalProperties` configuration for the chosen material law.
+
+Traction boundaries are handled through `tractionBoundarySnGrad()`, which uses
+the deformed-configuration normal `J*Finv.T() & n` from Nanson's relation, or
+the reference normal `n` when the linear fallback is active.
+
+### Field glossary
+
+- `D`, `DD`: total and incremental displacement at cell centres.
+- `pointD`, `pointDD`: total and incremental displacement at mesh points.
+- `grad(D)`, `grad(DD)`: cell-centre gradients.
+- `grad(D)f`: face gradient of `D`, computed with the face-Gauss approach.
+- `F`, `Finv`, `J`: total deformation gradient, its inverse and Jacobian at
+  cell centres.
+- `Ff`, `Finvf`, `Jf`: the same quantities at faces; these are the ones the
+  momentum equation uses.
+- `sigma`, `sigmaf`: cell-centre and face stress.
+- `U`: velocity field, computed as `ddt(D)`.
+
+The cell-centred `F`, `Finv`, `J` and `sigma` are updated once at the end of
+`evolve()`, for post-processing and for the mechanical law's cell-centred
+interface; the loop itself runs entirely on the face fields.
+
+---
+
+## Developer Notes
+
+### Class role
+
+`unsNonLinGeomTotalLagSolid` is the total-Lagrangian, face-gradient member of
+the family. The key design choices are:
+
+- `D` is the primary solution variable (`solutionD()` returns `D()`);
+- `nonLinGeom()` returns `TOTAL_LAGRANGIAN`, so the mesh is never moved;
+- the momentum equation is written on the reference mesh, with
+  `Jf*Finvf.T() & Sf` mapping the reference face areas to the deformed
+  configuration;
+- stress is delegated to `mechanicalModel`.
+
+The class name in the header's `Class` tag is `nonLinGeomTotalLagSolid`, which
+is a historical leftover; the actual class is `unsNonLinGeomTotalLagSolid`.
+
+### Construction
+
+The constructor:
+
+1. calls the base `solidModel` constructor and `DisRequired()`;
+2. creates `sigmaf_`, `gradDf_` and the kinematic fields, all of which are
+   `READ_IF_PRESENT` so that a restart picks them up;
+3. takes `impK_`, `impKf_` from the mechanical law and stores `rImpK_`;
+4. reads `nonLinear`, `debug` and the relative `solutionTolerance`;
+5. on restart, recomputes `grad(D)`, `grad(D)f`, `Ff`, `Finvf` and `Jf` from
+   `D` and calls `mechanical().setRestart()`.
+
+### `evolve()`
+
+A single outer loop:
+
+- reset `enforceLinear` and store `D` for under-relaxation;
+- assemble the momentum equation
+
+  ```text
+  rho*d2dt2(D) == laplacian(impKf, D) - fvc::laplacian(impKf, D)
+                + fvc::div((Jf*Finvf.T() & Sf) & sigmaf) + rho*g
+  ```
+
+  i.e. an implicit Laplacian with a deferred correction that recovers the
+  total-Lagrangian divergence of stress at convergence;
+- add damping if `dampingCoeff` is non-zero;
+- if `enforceLinear` is set, add the difference between the nonlinear and
+  linear divergence terms, which cancels the nonlinear contribution;
+- relax the linear system, apply `solidModel::setCellDisps()`, and solve;
+- under-relax `D`, then update `pointD`, `grad(D)`, `grad(D)f`, `grad(DD)`,
+  `Ff`, `Finvf` and `Jf`;
+- call `checkEnforceLinear(Jf_)` unless the fallback is already active or
+  `nonLinear` is `false`;
+- update `sigmaf` and evaluate the relative residual.
+
+Convergence is checked against `maxRes*relativeTol_`, floored at the base-class
+`solutionTolerance`; the first iteration is always followed by a second. After
+the loop, `U`, `F`, `Finv`, `J`, `sigma`, `DD` and `pointDD` are updated once.
+
+`evolve()` returns `false` if the linear fallback was triggered, and `true`
+otherwise.
+
+### Traction boundary treatment
+
+`tractionBoundarySnGrad()` has two branches. In the nonlinear branch the
+traction and pressure are applied on the deformed normal:
+
+```text
+((traction - nCurrent*pressure) - (nCurrent & sigma) + (n & (impK*gradD)))*rImpK
+```
+
+with `nCurrent = J*Finv.T() & n`. In the `enforceLinear` branch, `nCurrent` is
+replaced by the reference normal `n`. In both cases the `impK*gradD` term
+removes the part of the traction that the implicit Laplacian already accounts
+for.
+
+### Extension points
+
+- `evolve()` for a different outer-iteration or fallback strategy;
+- `tractionBoundarySnGrad()` if the deferred-correction split changes.
+
+As with `unsLinGeomSolid`, the face fields are the primary state: any new
+algorithm must keep `sigmaf_`, `gradDf_`, `Ff_`, `Finvf_` and `Jf_`
+consistent, not just their cell-centred counterparts.
+
+---
+
+## Tutorials
+
+No tutorial selects `unsNonLinearGeometryTotalLagrangian` by default. The
+finite-strain cases that exercise the sibling models —
+`solids/hyperelasticity/cantileverBeam`,
+`solids/hyperelasticity/cylindricalPressureVessel` and
+`solids/elastoplasticity/cooksMembrane` — are the natural places to try it, by
+changing the `solidModel` entry in `constant/solidProperties`.

--- a/src/solids4FoamModels/solidModels/unsNonLinGeomUpdatedLagSolid/README.md
+++ b/src/solids4FoamModels/solidModels/unsNonLinGeomUpdatedLagSolid/README.md
@@ -1,0 +1,237 @@
+---
+sort: 6
+---
+
+# unsNonLinGeomUpdatedLagSolid
+
+This page documents the unstructured nonlinear updated-Lagrangian
+incremental-displacement solid model. The runtime type is:
+
+```text
+unsNonLinearGeometryUpdatedLagrangian
+```
+
+The model assumes finite strains and rotations and solves for the increment of
+displacement `DD`. The mesh is moved at the end of each time step, so the
+governing equations are written in the updated configuration. It is the
+updated-Lagrangian counterpart of
+[unsLinGeomSolid](https://www.solids4foam.com/documentation/solid-models/unsLinGeomSolid.html):
+the "uns" prefix indicates that the face tangential gradient is calculated
+with a face-Gauss approach rather than from the cell-centred gradient.
+
+The stress is computed by the run-time selectable mechanical law.
+
+---
+
+## User Guide
+
+### What this model solves
+
+`unsNonLinGeomUpdatedLagSolid`:
+
+- solves the momentum equation in updated-Lagrangian form;
+- uses the displacement increment `DD` as the primary unknown, and recovers
+  `D` as `D.oldTime() + DD`;
+- carries the kinematics as _surface_ fields — `relFf`, `relFinvf`, `relJf`,
+  `Ff`, `Jf` — as well as their cell-centred counterparts;
+- uses the surface stress `sigmaf` in the momentum equation;
+- maintains its own density field `rho`, updated as `rho.oldTime()/relJ`;
+- moves the mesh at the end of each time step;
+- solves with a segregated implicit algorithm only.
+
+The model is appropriate when deformation is large enough that linear geometry
+is not valid and mesh motion between time steps is part of the formulation.
+
+### Supported solution algorithms
+
+This model implements a single, segregated implicit algorithm. It does not
+read `solutionAlgorithm`, and there is no PETSc SNES or explicit path. Use
+[nonLinGeomUpdatedLagSolid](https://www.solids4foam.com/documentation/solid-models/nonLinGeomUpdatedLagSolid.html)
+if you need those.
+
+### Model options
+
+`unsNonLinGeomUpdatedLagSolid` adds no options of its own. Unlike its
+total-Lagrangian sibling it has no `nonLinear` switch and no automatic linear
+fallback, and `solutionTolerance` keeps its usual absolute meaning. The
+relevant entries in `unsNonLinearGeometryUpdatedLagrangianCoeffs` are the
+inherited `solidModel` ones:
+
+| Entry | Default | Relevance |
+| --- | --- | --- |
+| `nCorrectors` | `10000` | Maximum number of outer correctors |
+| `solutionTolerance` | `1e-06` | Primary convergence tolerance |
+| `alternativeTolerance` | `1e-07` | Secondary convergence tolerance |
+| `materialTolerance` | `1e-05` | Mechanical-law convergence tolerance |
+| `relaxationMethod` | `fixed` | Under-relaxation method (`fixed`, `aitken`) |
+| `infoFrequency` | `100` | Frequency for solver progress output |
+| `writeResidualField` | `false` | Writes a residual field during output |
+| `residualFile` | `false` | Writes `residual.dat` in the case directory |
+| `cellDisplacements` | optional | Internal-cell displacement constraints |
+
+```note
+`dampingCoeff` is read by the base class but is not applied by this model's
+momentum equation.
+```
+
+### Recommended dictionary setup
+
+Minimal example for `constant/solidProperties`:
+
+```text
+solidModel        unsNonLinearGeometryUpdatedLagrangian;
+
+unsNonLinearGeometryUpdatedLagrangianCoeffs
+{
+    nCorrectors          10000;
+    solutionTolerance    1e-06;
+    alternativeTolerance 1e-07;
+    materialTolerance    1e-05;
+    infoFrequency        100;
+}
+```
+
+The momentum equation is assembled with the name `laplacian(DDD,DD)`, so
+`fvSchemes` must provide a `laplacian(DDD,DD)` entry, and `fvSolution` must
+provide a solver for `DD`.
+
+### Required fields and boundary conditions
+
+Because this model is incremental, the boundary conditions are specified on
+`DD`, not on `D`:
+
+- `DD` in the time directory;
+- `solidProperties` in `constant`;
+- `g` in `constant`;
+- a `mechanicalProperties` configuration for the chosen material law.
+
+The base class enforces this through `DDisRequired()`. Traction boundaries are
+handled through `tractionBoundarySnGrad()`, which uses the deformed normal
+`relJ*relFinv.T() & n` obtained from Nanson's relation between the updated and
+deformed configurations.
+
+### Field glossary
+
+- `DD`: displacement increment at cell centres; the primary unknown.
+- `D`: total displacement, recovered as `D.oldTime() + DD`.
+- `pointDD`, `pointD`: incremental and total displacement at mesh points.
+- `grad(DD)`, `grad(D)`: cell-centre gradients.
+- `grad(DD)f`: face gradient of `DD`, computed with the face-Gauss approach.
+- `relF`, `relFinv`, `relJ`: relative deformation gradient, its inverse and
+  relative Jacobian, mapping the updated to the deformed configuration.
+- `F`, `J`: total deformation gradient and Jacobian, accumulated as
+  `relF & F.oldTime()` and `relJ*J.oldTime()`.
+- `relFf`, `relFinvf`, `relJf`, `Ff`, `Jf`: the same quantities at faces;
+  these are the ones the momentum equation uses.
+- `rho`: density in the current configuration, updated as `rho.oldTime()/relJ`.
+- `sigma`, `sigmaf`: cell-centre and face stress.
+- `U`: velocity field, computed as `ddt(D)`.
+
+---
+
+## Developer Notes
+
+### Class role
+
+`unsNonLinGeomUpdatedLagSolid` is the updated-Lagrangian, face-gradient member
+of the family. The key design choices are:
+
+- `DD` is the primary solution variable (`solutionD()` returns `DD()`, and
+  `incremental()` returns `true`);
+- `nonLinGeom()` returns `UPDATED_LAGRANGIAN`;
+- `movingMesh()` returns `true`, so the base class expects the mesh to be
+  moved once per time step;
+- the momentum equation is written on the updated mesh, with
+  `relJf*relFinvf.T() & Sf` mapping the updated face areas to the deformed
+  configuration;
+- stress is delegated to `mechanicalModel`.
+
+The class name in the header's `Class` tag is `nonLinGeomUpdatedLagSolid`,
+which is a historical leftover; the actual class is
+`unsNonLinGeomUpdatedLagSolid`.
+
+### Construction
+
+The constructor:
+
+1. calls the base `solidModel` constructor and `DDisRequired()`;
+2. creates `sigmaf_`, `gradDDf_`, the relative and total kinematic fields, and
+   its own `rho_`, all `READ_IF_PRESENT` so that a restart picks them up;
+3. takes `impK_`, `impKf_` from the mechanical law and stores `rImpK_`;
+4. on restart, recomputes `grad(DD)`, `grad(DD)f`, `relFf`, `relFinvf`, `Ff`,
+   `relJf` and `Jf`, stores the old times of `Ff` and `Jf`, and calls
+   `mechanical().setRestart()`.
+
+### `evolve()`
+
+A single outer loop:
+
+- store `DD` for under-relaxation and residual calculation;
+- assemble the momentum equation
+
+  ```text
+  d2dt2(rho, DD) + fvc::d2dt2(rho, D.oldTime())
+      == laplacian(impKf, DD) - fvc::laplacian(impKf, DD)
+       + fvc::div((relJf*relFinvf.T() & Sf) & sigmaf) + rho*g
+  ```
+
+  i.e. an implicit Laplacian with a deferred correction that recovers the
+  updated-Lagrangian divergence of stress at convergence;
+- relax the linear system, apply `solidModel::setCellDisps()`, and solve;
+- under-relax `DD`, then update `pointDD`, `grad(DD)`, `grad(DD)f`, `relFf`,
+  `relFinvf`, `Ff`, `relJf` and `Jf`;
+- update `sigmaf` from the mechanical law.
+
+The loop exits through the base-class `converged()` helper, or when `iCorr`
+reaches `nCorrectors`. After the loop, the cell-centred `relF`, `relFinv`,
+`F`, `relJ`, `J` and `sigma` are updated once, then `D`, `grad(D)`, `pointD`
+and `U`.
+
+`evolve()` always returns `true`; there is no divergence fallback in this
+model.
+
+### `updateTotalFields()`
+
+Called once per time step by the base class after `evolve()`. It:
+
+1. updates the density as `rho = rho.oldTime()/relJ`;
+2. moves the mesh by `pointDD` through `moveMesh()`, so that the next time
+   step starts in the new updated configuration;
+3. calls `solidModel::updateTotalFields()`.
+
+This is the step that makes the formulation updated- rather than
+total-Lagrangian, and it is why `movingMesh()` must return `true`.
+
+### Traction boundary treatment
+
+`tractionBoundarySnGrad()` applies the traction and pressure on the deformed
+normal `nCurrent = relJ*relFinv.T() & n`, where `n` is the normal in the
+updated configuration, and subtracts the `impK*gradDD` term that the implicit
+Laplacian already accounts for.
+
+### Extension points
+
+- `evolve()` for a different outer-iteration strategy;
+- `updateTotalFields()` if the mesh-motion or density update changes;
+- `tractionBoundarySnGrad()` if the deferred-correction split changes.
+
+As with the other `uns` models, the face fields are the primary state: any new
+algorithm must keep `sigmaf_`, `gradDDf_`, `relFf_`, `relFinvf_`, `Ff_`,
+`relJf_` and `Jf_` consistent, not just their cell-centred counterparts.
+
+---
+
+## Tutorials
+
+Cases that select `unsNonLinearGeometryUpdatedLagrangian`:
+
+- `solids/hyperelasticity/cantileverBeam`
+
+It is offered as a commented alternative in several further finite-strain
+cases, which are the natural places to try it:
+
+- `solids/hyperelasticity/cylindricalPressureVessel`
+- `solids/hyperelasticity/longWall`
+- `solids/elastoplasticity/cooksMembrane`
+- `solids/elastoplasticity/pipeCrush`
+- `solids/elastoplasticity/cylinderCrush`

--- a/src/solids4FoamModels/solidModels/vertexCentredLinGeomSolid/README.md
+++ b/src/solids4FoamModels/solidModels/vertexCentredLinGeomSolid/README.md
@@ -1,0 +1,255 @@
+---
+sort: 7
+---
+
+# vertexCentredLinGeomSolid
+
+This page documents the vertex-centred linear-geometry solid model. The
+runtime type is:
+
+```text
+vertexCentredLinearGeometry
+```
+
+The model assumes small strains and small rotations and solves for the total
+displacement at the mesh **points**, `pointD`, rather than at cell centres.
+The governing equations are integrated over a _dual_ mesh, which is
+constructed automatically from the primary mesh by `meshDualiser`. The linear
+system couples all displacement components implicitly and is solved with
+PETSc SNES.
+
+The method is described in
+[10.13140/RG.2.2.22896.33283](https://doi.org/10.13140/RG.2.2.22896.33283).
+
+```note
+This model works best on triangular and tetrahedral grids. It requires PETSc
+for the implicit path.
+```
+
+---
+
+## User Guide
+
+### What this model solves
+
+`vertexCentredLinGeomSolid`:
+
+- solves the linear momentum equation in linear-geometry form over the dual
+  mesh, with the primary unknown at the mesh points;
+- computes the displacement gradient and the stress at the **dual mesh faces**
+  (`dualGradDf`, `dualSigmaf`), through a `dualMechanicalModel`;
+- assembles the exact material tangent into the Jacobian by default, giving
+  Newton-Raphson convergence;
+- enforces displacement boundary conditions as fixed degrees of freedom rather
+  than through patch-field manipulation;
+- also offers an explicit central-difference path.
+
+Being vertex-centred, it avoids the checkerboarding and the stabilisation
+terms that the cell-centred segregated models need, at the cost of a larger
+implicit system and a dependency on PETSc.
+
+### Supported solution algorithms
+
+The `solutionAlgorithm` entry selects the path:
+
+| Value | Meaning | Notes |
+| --- | --- | --- |
+| `PETScSNES` | Newton-Raphson via PETSc SNES | The intended path |
+| `explicit` | Explicit time integration | Time-step limited by stability |
+| `implicitSegregated` | Not implemented | Fatal error; use `PETScSNES` |
+| `implicitCoupled` | Not implemented | Fatal error; use `PETScSNES` |
+
+```warning
+The base-class default is `implicitSegregated`, which this model rejects with
+a fatal error. Every case **must** set `solutionAlgorithm` explicitly.
+```
+
+### Model options
+
+| Entry | Default | Description |
+| --- | --- | --- |
+| `zeta` | `1.0` | Compact edge gradient fraction |
+| `zetaImplicit` | `zeta` | The `zeta` used to form the Jacobian |
+| `approximateJacobian` | `false` | Compact Laplacian instead of the tangent |
+| `compactImplicitStencil` | none | Compact stencil for that Jacobian |
+| `fixedDofScale` | see below | Scaling of the constraint equations |
+| `predictor` | `false` | Predict `pointD` at a new time step |
+| `predictorMethod` | `linear` | `linear` or `quadratic` predictor |
+| `optionsFile` | `petscOptions` | PETSc options file name |
+| `stopOnPetscError` | `true` | Stop if PETSc reports an error |
+
+`zeta` is the compact edge gradient fraction: `0` is more accurate but more
+prone to oscillations, `1` is less accurate but more robust. It is the entry
+most worth tuning, and the shipped tutorial uses `0.1`. `zetaImplicit`
+defaults to `zeta`, and lets the Jacobian use a different value from the
+residual.
+
+`compactImplicitStencil` has no default and is only read when
+`approximateJacobian` is enabled, in which case it must be present.
+
+`fixedDofScale` defaults to `average(impK)*sqrt(gAverage(magSf))`, so that the
+constraint equations are conditioned like the momentum equations.
+
+The `linear` predictor assumes constant velocity over the step; `quadratic`
+assumes constant acceleration.
+
+The relevant inherited `solidModel` entries are:
+
+| Entry | Default | Relevance |
+| --- | --- | --- |
+| `solutionAlgorithm` | `implicitSegregated` | Must be overridden, see above |
+| `solvePressure` | `false` | Adds pressure as an extra unknown per point |
+| `infoFrequency` | `100` | Frequency for solver progress output |
+
+The block size of the PETSc system is 2 in 2-D and 3 in 3-D, or 3 and 4
+respectively when `solvePressure` is enabled.
+
+### Recommended dictionary setup
+
+Minimal example for `constant/solidProperties`:
+
+```text
+solidModel     vertexCentredLinearGeometry;
+
+vertexCentredLinearGeometryCoeffs
+{
+    // Solution algorithm (PETScSNES, explicit)
+    solutionAlgorithm PETScSNES;
+
+    // Use the exact Jacobian or a small-stencil approximation
+    approximateJacobian no;
+
+    // Compact edge discretisation fraction
+    // 0 -> more accurate but oscillations more likely
+    // 1 -> less accurate but oscillations less likely
+    zeta            0.1;
+}
+```
+
+A `petscOptions` file must be present in the case directory, unless the name is
+overridden with `optionsFile`.
+
+### Required fields and boundary conditions
+
+The boundary conditions are set on `pointD`, a `pointVectorField`, not on the
+cell-centred `D`. Displacement constraints become fixed degrees of freedom in
+the linear system.
+
+The point patch types provided by solids4foam are:
+
+| Patch type | Purpose |
+| --- | --- |
+| `pointSolidTraction` | Prescribed traction and pressure |
+| `pointNormalDisplacement` | Prescribed normal displacement |
+| `pointFixedDisplacementZeroShear` | Normal displacement fixed, zero shear |
+| `pointFixedRotation` | Prescribed rotation about an axis |
+| `pointLinearSpatialDisplacement` | Displacement varying linearly in space |
+| `pointSolidForce` | Prescribed force |
+| `pointSolidContact` | Contact |
+| `componentMixed` | Mixed per-component condition |
+
+Ordinary `fixedValue` and `zeroGradient` point patch types work as usual.
+
+```warning
+`tractionBoundarySnGrad()` is `notImplemented` for this model, as is
+`solutionD()`; both are cell-centred concepts. Do not expect cell-centred
+traction boundary conditions to work.
+```
+
+### Field glossary
+
+- `pointD`: total displacement at the mesh points; the primary unknown.
+- `pointDD`: point displacement increment, `pointD - pointD.oldTime()`.
+- `pointU`, `pointA`: point velocity and acceleration.
+- `pointRho`: point density.
+- `pointVol`: dual cell volume associated with each point. On a processor
+  boundary this is the local contribution only.
+- `pointGlobalVol`: the same, with processor-boundary contributions summed.
+- `pointDivSigma`: divergence of stress at each point; the residual of the
+  momentum equation.
+- `dualGradDf`, `dualSigmaf`: displacement gradient and stress at the dual
+  mesh faces.
+- `D`, `sigma`: cell-centred fields, interpolated from the point fields for
+  post-processing.
+
+### Explicit path
+
+With `solutionAlgorithm explicit`, `setDeltaT()` computes the stable time step
+from the elastic wave speed and the dual mesh `deltaCoeffs`, scaled by `maxCo`
+from `controlDict` (default `0.1`).
+
+---
+
+## Developer Notes
+
+### Class role
+
+`vertexCentredLinGeomSolid` inherits from `solidModel` and, when PETSc is
+available, from `foamPetscSnesHelper`. The key design choices are:
+
+- the unknowns live at points, so `solutionD()` is `notImplemented`;
+- the dual mesh comes from the base class's `dualMesh()` and
+  `dualMeshMap()`, built by `meshDualiser`;
+- constitutive evaluation goes through a `dualMechanicalModel`, which maps
+  dual faces back to primary cells so that ordinary mechanical laws can be
+  reused unchanged;
+- displacement constraints are held as `fixedDofs_`, `fixedDofValues_` and
+  `fixedDofDirections_`, all sized by the number of points, rather than being
+  applied through patch fields.
+
+### Construction
+
+The constructor initialises the PETSc SNES helper with `pointD` as the
+solution field and `solutionLocation::POINTS`, builds the
+`dualMechanicalModel`, computes `blockSize_`, allocates the fixed-degree-of-
+freedom lists, and reads `fixedDofScale` — whose default is derived from the
+average implicit stiffness and the mesh size, so that the constraint equations
+are conditioned like the momentum equations.
+
+### PETSc SNES path
+
+`evolveSnes()` drives `foamPetscSnesHelper`, which calls back into:
+
+- `initialiseSolution()` and `initialiseJacobian()` to size the vector and set
+  the matrix's non-zero structure;
+- `formResidual()`, which extracts `pointD` from the solution vector, corrects
+  the boundary conditions, computes `dualGradDf` via `vfvc::fGrad` with
+  `zeta`, evaluates `dualSigmaf`, and assembles `pointDivSigma`;
+- `formJacobian()`, which either adds the exact linearisation of `div(sigma)`
+  through `vfvm::divSigma` using the material tangent from
+  `materialTangentFaceField()`, or — when `approximateJacobian` is set — adds
+  a compact Laplacian through `vfvm::laplacian` with `zetaImplicit` and
+  `dualImpKf()`.
+
+Fixed degrees of freedom are removed from the system through
+`fixedDofRowsIS()`, a PETSc index set built from `fixedDofs_`.
+
+The exact Jacobian gives quadratic convergence but is more expensive to form;
+the approximate one is cheaper per iteration and needs more of them.
+
+### Explicit path implementation
+
+`evolveExplicit()` advances `pointU` and `pointD` with a central-difference
+update, using `pointDivSigma` and `pointGlobalVol`. `setDeltaT()` handles
+stability.
+
+### Extension points
+
+- `formResidual()` and `formJacobian()` for a different discretisation;
+- `setFixedDofs()` for a new kind of displacement constraint;
+- `enforceTractionBoundaries()` for a new traction-style point patch.
+
+Note the distinction between `pointVol_` and `pointGlobalVol_`: use the global
+one wherever a physical volume is needed, and the local one only where
+processor-local partial sums are correct.
+
+---
+
+## Tutorials
+
+No tutorial selects `vertexCentredLinearGeometry` by default. Two cases are
+set up for it:
+
+- `solids/linearElasticity/cantilever2d`, which ships
+  `constant/solidProperties.vertexCentred` alongside its other variants;
+- `solids/linearElasticity/wobblyNewton`, where it is a commented alternative.

--- a/src/solids4FoamModels/solidModels/vertexCentredNonLinGeomTotalLagSolid/README.md
+++ b/src/solids4FoamModels/solidModels/vertexCentredNonLinGeomTotalLagSolid/README.md
@@ -1,0 +1,239 @@
+---
+sort: 8
+---
+
+# vertexCentredNonLinGeomTotalLagSolid
+
+This page documents the vertex-centred nonlinear total-Lagrangian solid model.
+The runtime type is:
+
+```text
+vertexCentredNonLinTotalLagGeometry
+```
+
+The model assumes finite strains and rotations and solves for the total
+displacement at the mesh **points**, `pointD`, in the total-Lagrangian frame,
+so the mesh is not moved. As with
+[vertexCentredLinGeomSolid](https://www.solids4foam.com/documentation/solid-models/vertexCentredLinGeomSolid.html),
+the governing equations are integrated over a dual mesh built automatically by
+`meshDualiser`, and the implicit system is solved with PETSc SNES.
+
+```note
+This model works best on triangular and tetrahedral grids. It requires PETSc
+for the implicit path.
+```
+
+---
+
+## User Guide
+
+### What this model solves
+
+`vertexCentredNonLinGeomTotalLagSolid`:
+
+- solves the momentum equation in total-Lagrangian form over the dual mesh,
+  with the primary unknown at the mesh points;
+- carries the kinematics at the **dual mesh faces** — `dualFf`, `dualFinvf`,
+  `dualJf` — alongside `dualGradDf` and `dualSigmaf`;
+- assembles the material tangent _and_, optionally, the geometric stiffness
+  into the Jacobian;
+- can add pressure as an extra unknown per point, for near-incompressible
+  materials;
+- enforces displacement boundary conditions as fixed degrees of freedom;
+- also offers an explicit central-difference path.
+
+### Supported solution algorithms
+
+The `solutionAlgorithm` entry selects the path:
+
+| Value | Meaning | Notes |
+| --- | --- | --- |
+| `PETScSNES` | Newton-Raphson via PETSc SNES | The intended path |
+| `explicit` | Explicit time integration | Time-step limited by stability |
+| `implicitSegregated` | Not implemented | Fatal error; use `PETScSNES` |
+| `implicitCoupled` | Not implemented | Fatal error; use `PETScSNES` |
+
+```warning
+The base-class default is `implicitSegregated`, which this model rejects with
+a fatal error. Every case **must** set `solutionAlgorithm` explicitly.
+```
+
+### Model options
+
+| Entry | Default | Description |
+| --- | --- | --- |
+| `useGeometricStiffness` | none | Geometric stiffness in the Jacobian |
+| `zeta` | `1.0` | Compact edge gradient fraction |
+| `zetaImplicit` | `zeta` | The `zeta` used to form the Jacobian |
+| `approximateJacobian` | `false` | Compact Laplacian instead of the tangent |
+| `compactImplicitStencil` | none | Compact stencil for that Jacobian |
+| `tangentEps` | `1e-10` | Geometric stiffness perturbation size |
+| `fixedDofScale` | see below | Scaling of the constraint equations |
+| `predictor` | `false` | Predict `pointD` at a new time step |
+| `predictorMethod` | `linear` | `linear` or `quadratic` predictor |
+| `optionsFile` | `petscOptions` | PETSc options file name |
+| `stopOnPetscError` | `true` | Stop if PETSc reports an error |
+
+`zeta` is the compact edge gradient fraction: `0` is more accurate but more
+prone to oscillations, `1` is less accurate but more robust. It is the entry
+most worth tuning, and the shipped tutorial uses `0.1`. `zetaImplicit`
+defaults to `zeta`, and lets the Jacobian use a different value from the
+residual.
+
+`compactImplicitStencil` has no default and is only read when
+`approximateJacobian` is enabled, in which case it must be present.
+
+`fixedDofScale` defaults to `average(impK)*sqrt(gAverage(magSf))`, so that the
+constraint equations are conditioned like the momentum equations.
+
+The `linear` predictor assumes constant velocity over the step; `quadratic`
+assumes constant acceleration.
+
+`useGeometricStiffness` is read with `lookup()`, so it has no default and the
+model fails at construction if it is missing. Including the geometric
+stiffness costs one Jacobian assembly pass but usually pays for itself in
+Newton iterations on strongly nonlinear problems.
+
+The relevant inherited `solidModel` entries are:
+
+| Entry | Default | Relevance |
+| --- | --- | --- |
+| `solutionAlgorithm` | `implicitSegregated` | Must be overridden, see above |
+| `solvePressure` | `false` | Adds pressure as an extra unknown per point |
+| `infoFrequency` | `100` | Frequency for solver progress output |
+
+The block size of the PETSc system is 2 in 2-D and 3 in 3-D, or 3 and 4
+respectively when `solvePressure` is enabled.
+
+### Recommended dictionary setup
+
+Minimal example for `constant/solidProperties`:
+
+```text
+solidModel     vertexCentredNonLinTotalLagGeometry;
+
+vertexCentredNonLinTotalLagGeometryCoeffs
+{
+    // Solution algorithm (PETScSNES, explicit)
+    solutionAlgorithm     PETScSNES;
+
+    // Include the geometric stiffness in the Jacobian
+    useGeometricStiffness yes;
+
+    // Use the exact Jacobian or a small-stencil approximation
+    approximateJacobian   no;
+
+    // Compact edge discretisation fraction
+    // 0 -> more accurate but oscillations more likely
+    // 1 -> less accurate but oscillations less likely
+    zeta                  0.1;
+}
+```
+
+A `petscOptions` file must be present in the case directory, unless the name is
+overridden with `optionsFile`.
+
+### Required fields and boundary conditions
+
+The boundary conditions are set on `pointD`, a `pointVectorField`, not on the
+cell-centred `D`. The available point patch types are the same as for the
+linear-geometry vertex-centred model:
+
+| Patch type | Purpose |
+| --- | --- |
+| `pointSolidTraction` | Prescribed traction and pressure |
+| `pointNormalDisplacement` | Prescribed normal displacement |
+| `pointFixedDisplacementZeroShear` | Normal displacement fixed, zero shear |
+| `pointFixedRotation` | Prescribed rotation about an axis |
+| `pointLinearSpatialDisplacement` | Displacement varying linearly in space |
+| `pointSolidForce` | Prescribed force |
+| `pointSolidContact` | Contact |
+| `componentMixed` | Mixed per-component condition |
+
+```warning
+`tractionBoundarySnGrad()` is `notImplemented` for this model, as is
+`solutionD()`; both are cell-centred concepts.
+```
+
+### Field glossary
+
+- `pointD`: total displacement at the mesh points; the primary unknown.
+- `pointP`: point pressure, when `solvePressure` is enabled.
+- `pointDD`, `pointU`, `pointA`, `pointRho`: point increment, velocity,
+  acceleration and density.
+- `pointVol`, `pointGlobalVol`: dual cell volume per point, local and with
+  processor-boundary contributions summed.
+- `pointDivSigma`: divergence of stress at each point; the momentum residual.
+- `dualGradDf`, `dualSigmaf`: displacement gradient and stress at the dual
+  faces.
+- `dualFf`, `dualFinvf`, `dualJf`: total deformation gradient, its inverse and
+  Jacobian at the dual faces.
+- `dualPf`, `volP`: pressure at the dual faces and at cell centres.
+- `D`, `sigma`: cell-centred fields, interpolated for post-processing.
+
+### Explicit path
+
+With `solutionAlgorithm explicit`, `setDeltaT()` computes the stable time step
+from the elastic wave speed and the dual mesh `deltaCoeffs`, scaled by `maxCo`
+from `controlDict` (default `0.1`).
+
+---
+
+## Developer Notes
+
+### Class role
+
+`vertexCentredNonLinGeomTotalLagSolid` inherits from `solidModel` and, when
+PETSc is available, from `foamPetscSnesHelper`. It is the finite-strain
+counterpart of `vertexCentredLinGeomSolid` and shares its structure: dual
+mesh, `dualMechanicalModel`, fixed degrees of freedom, and a PETSc SNES
+driver.
+
+- `nonLinGeom()` returns `TOTAL_LAGRANGIAN`, so the mesh is never moved;
+- the unknowns live at points, so `solutionD()` is `notImplemented`;
+- the extra state relative to the linear model is the dual-face kinematics and
+  the optional pressure unknown.
+
+### PETSc SNES path
+
+`evolveSnes()` drives `foamPetscSnesHelper`, which calls back into:
+
+- `formResidual()`, which extracts `pointD` (and `pointP` when solving
+  pressure) from the solution vector, corrects the boundary conditions,
+  computes `dualGradDf` via `vfvc::fGrad` with `zeta`, forms `dualFf`,
+  `dualFinvf` and `dualJf`, evaluates `dualSigmaf`, and assembles
+  `pointDivSigma` on the deformed dual areas `J*Finv.T() & Sf0`;
+- `formJacobian()`, which adds either the exact linearisation of `div(sigma)`
+  through `vfvm::divSigma` using `materialTangentFaceField()`, or a compact
+  Laplacian through `vfvm::laplacian` when `approximateJacobian` is set, and
+  then — if `useGeometricStiffness` is enabled — the geometric stiffness.
+
+### Geometric stiffness
+
+`geometricStiffnessField()` builds the contribution to the tangent that comes
+from the deformed area vector `gamma = J*F^-T & Sf0` changing with the
+displacement. It is formed **numerically**: for each of the nine components of
+`gradD` in turn, the component is perturbed by `tangentEps`, `F`, `Finv`, `J`
+and the deformed `Sf` are recomputed, and the tangent column is the finite
+difference `(SfPerturb - SfRef)/eps`.
+
+Because it is a finite difference, `tangentEps` trades truncation error
+against round-off. The default `1e-10` suits displacement gradients of order
+one; on problems with very small or very large strains it may need adjusting.
+
+### Extension points
+
+- `formResidual()` and `formJacobian()` for a different discretisation;
+- `geometricStiffnessField()` if an analytical geometric tangent is derived,
+  which would remove the `tangentEps` sensitivity;
+- `setFixedDofs()` and `enforceTractionBoundaries()` for new point patch
+  types.
+
+---
+
+## Tutorials
+
+No tutorial currently selects `vertexCentredNonLinTotalLagGeometry`. The
+finite-strain cases under `solids/hyperelasticity` are the natural place to
+try it, but note that they use cell-centred `D` boundary conditions, so the
+`0/pointD` field and its point patch types have to be set up first.

--- a/src/solids4FoamModels/solidModels/weakThermalLinGeomSolid/README.md
+++ b/src/solids4FoamModels/solidModels/weakThermalLinGeomSolid/README.md
@@ -1,0 +1,210 @@
+---
+sort: 12
+---
+
+# weakThermalLinGeomSolid
+
+This page documents the weakly coupled thermal linear-geometry solid model.
+The runtime type is:
+
+```text
+weakThermalLinearGeometry
+```
+
+The model assumes small strains and small rotations. It solves the energy
+equation for temperature `T` to convergence, then solves the momentum equation
+for total displacement `D` once, with no outer iterations between the two.
+This one-way coupling is what "weak" refers to.
+
+The stress is computed by the run-time selectable mechanical law.
+
+---
+
+## User Guide
+
+### What this model solves
+
+`weakThermalLinGeomSolid`:
+
+- solves the transient heat equation `rhoC*ddt(T) == laplacian(k, T)`, with no
+  mechanical work term;
+- then hands over to
+  [linGeomTotalDispSolid](https://www.solids4foam.com/documentation/solid-models/linGeomTotalDispSolid.html)
+  for the momentum equation, from which it inherits;
+- takes `C` and `k` from a `thermalModel`, configured in
+  `constant/thermalProperties`.
+
+Use this model when the temperature field drives the deformation but the
+deformation does not appreciably change the temperature field, which covers
+most thermoelastic problems. Use
+[thermalLinGeomSolid](https://www.solids4foam.com/documentation/solid-models/thermalLinGeomSolid.html)
+if the coupling needs to be converged within each time step.
+
+```warning
+As for the other thermal solid models, the momentum equation does not include
+a thermal-expansion term by itself. To get thermal stresses, select a
+mechanical law that consumes the temperature field, such as
+`thermoMechanicalLaw`.
+```
+
+### Supported solution algorithms
+
+The heat equation is always solved with a segregated implicit loop. The
+momentum equation is solved by `linGeomTotalDispSolid`, so the
+`solutionAlgorithm` entry applies to it as usual: `implicitSegregated`
+(default), `PETScSNES` or `explicit`.
+
+### Model options
+
+| Entry | Default | Description |
+| --- | --- | --- |
+| `absoluteTemperatureTolerance` | `1e-06` | Convergence threshold on `T` |
+
+`absoluteTemperatureTolerance` is an absolute change in degrees: once the
+temperature stops moving by more than this between outer iterations, the
+thermal loop is considered converged.
+
+All of the `linGeomTotalDispSolid` and base `solidModel` options apply as
+well; see that page for the full list. The entries most relevant to the
+thermal loop are:
+
+| Entry | Default | Relevance |
+| --- | --- | --- |
+| `nCorrectors` | `10000` | Maximum correctors, both loops |
+| `solutionTolerance` | `1e-06` | Primary convergence tolerance |
+| `alternativeTolerance` | `1e-07` | Secondary convergence tolerance |
+| `infoFrequency` | `100` | Frequency for solver progress output |
+
+The temperature loop always performs at least two iterations, and converges
+when the absolute change in `T` falls below
+`absoluteTemperatureTolerance`, or when the solver and relative residuals meet
+`solutionTolerance` or `alternativeTolerance`.
+
+### Required input files
+
+- `T` and `D` in the time directory;
+- `constant/solidProperties`;
+- `constant/thermalProperties`, providing the `thermal` sub-dictionary;
+- `constant/mechanicalProperties`;
+- `constant/g`.
+
+`T` is `MUST_READ`, so a case that omits it will fail at construction.
+
+Example `constant/thermalProperties`:
+
+```text
+thermal
+{
+    type            constant;
+    C               C [0 2 -2 -1 0 0 0] 434;
+    k               k [1 1 -3 -1 0 0 0] 250;
+}
+```
+
+### Recommended dictionary setup
+
+Minimal example for `constant/solidProperties`:
+
+```text
+solidModel        weakThermalLinearGeometry;
+
+weakThermalLinearGeometryCoeffs
+{
+    solutionAlgorithm            implicitSegregated;
+
+    nCorrectors                  10000;
+    solutionTolerance            1e-06;
+    alternativeTolerance         1e-07;
+    materialTolerance            1e-05;
+    absoluteTemperatureTolerance 1e-06;
+    infoFrequency                100;
+}
+```
+
+`fvSchemes` must provide `laplacian(k,T)` in addition to the entries
+`linGeomTotalDispSolid` needs, and `fvSolution` must provide solvers for `T`
+and `D`.
+
+### Boundary conditions
+
+Displacement boundaries use the standard solids4foam patch types. Temperature
+boundaries use the usual OpenFOAM scalar patch types, plus `thermalConvection`
+for a convective heat-transfer boundary.
+
+Unlike `thermalLinGeomSolid` and `thermalSolid`, this model does not implement
+the `setTemperatureAndHeatFlux()` interface, so it cannot be used as the solid
+side of a thermal fluid-solid interface.
+
+### Field glossary
+
+- `T`: temperature; written each output time.
+- `grad(T)`: temperature gradient, used to report the heat flux.
+- `heatFlux`: `-k*grad(T)`, constructed and written by `writeFields()`.
+- `rhoC`: product of density and specific heat capacity.
+- All the fields of `linGeomTotalDispSolid`: `D`, `DD`, `pointD`, `pointDD`,
+  `grad(D)`, `grad(DD)`, `U`, `sigma`.
+
+Each write also prints the maximum and minimum temperature and the maximum
+magnitude of the heat flux.
+
+---
+
+## Developer Notes
+
+### Class role
+
+`weakThermalLinGeomSolid` inherits from `linGeomTotalDispSolid` rather than
+from `solidModel` directly, and adds a `thermalModel` member. That inheritance
+is the whole design: the thermal part is a prefix to an otherwise unmodified
+mechanical solve.
+
+- `D` remains the primary solution variable;
+- `nonLinGeom()` returns `LINEAR_GEOMETRY`;
+- the heat equation is uncoupled from the stress state, so there is no
+  `sigma && grad(U)` term.
+
+### Construction
+
+The constructor calls the `linGeomTotalDispSolid` constructor, constructs the
+`thermalModel` from the mesh, builds `rhoC_` as
+`thermal.C()*mechanical().rho()` and `k_` from `thermal.k()`, reads `T`
+(`MUST_READ`), creates `grad(T)`, reads `absoluteTemperatureTolerance`, and
+forces creation of `T.oldTime()`.
+
+### `evolve()`
+
+1. Loop on the heat equation `rhoC*ddt(T) == laplacian(k, T)`: store `T`,
+   relax and solve, relax `T`, update `grad(T)`; repeat until the private
+   `converged()` overload is satisfied or `nCorrectors` is reached.
+2. Call `linGeomTotalDispSolid::evolve()` to solve the momentum equation.
+
+There is no outer loop around the two, which is the difference from
+`thermalLinGeomSolid`. `evolve()` always returns `true`.
+
+### `writeFields()`
+
+Reports the temperature range, constructs and writes the `heatFlux` field, and
+then calls `linGeomTotalDispSolid::writeFields()`.
+
+### Extension points
+
+- `evolve()` if the heat equation needs source terms or a different coupling;
+- the private `converged()` overload for a different thermal criterion.
+
+Because the class derives from `linGeomTotalDispSolid`, any change to that
+model's momentum solve is inherited here automatically.
+
+---
+
+## Tutorials
+
+No tutorial selects `weakThermalLinearGeometry` by default. It is offered as a
+commented alternative in the thermoelasticity cases, which are the natural
+places to try it:
+
+- `solids/thermoelasticity/hotCylinder`
+- `solids/thermoelasticity/hotSphere`
+- `solids/thermoelasticity/slabCooling`
+
+Those cases run `thermalLinearGeometry` as shipped; switching the `solidModel`
+entry to `weakThermalLinearGeometry` is a one-line change.

--- a/tutorials/fluidSolidInteraction/beamInCrossFlow/README.md
+++ b/tutorials/fluidSolidInteraction/beamInCrossFlow/README.md
@@ -154,7 +154,7 @@ selected with `./Allrun aitken`, and either option can be combined with
 
 For a higher-level overview of the available FSI coupling schemes and the main
 `fluidSolidInterface` options, see the
-[`fluidSolidInterfaces` README](../../../src/solids4FoamModels/fluidSolidInterfaces/README.md).
+[fluid-solid interfaces documentation](https://www.solids4foam.com/documentation/fluid-solid-interfaces/).
 
 For the current settings, a fair comparison over the strongly-coupled transient
 window up to `t = 1.0 s`, using the same time step, PETSc-based solid solve,

--- a/tutorials/solids/elastoplasticity/cooksMembrane/README.md
+++ b/tutorials/solids/elastoplasticity/cooksMembrane/README.md
@@ -35,7 +35,7 @@ Young's modulus $$E = 206.9$$ MPa, Poisson's ratio $$\nu=0.29$$, initial yield
 stress $$\sigma_Y = 0.45$$ MPa and the hardening parameters
 $$\sigma_{\infty} = 0.715$$ MPa, $$\delta = 16.93$$, $$H = 0.12924$$ MPa. The
 strain hardening function is the one presented in
-[[1]]((https://onlinelibrary.wiley.com/doi/10.1002/nme.1620330705)):
+[[1]](https://onlinelibrary.wiley.com/doi/10.1002/nme.1620330705):
 
 $$
 \sigma_y = \sigma_Y + (\sigma_{\infty} -

--- a/tutorials/solids/hyperelasticity/cantileverBeam/README.md
+++ b/tutorials/solids/hyperelasticity/cantileverBeam/README.md
@@ -1,5 +1,5 @@
 ---
-sort: xx
+sort: 6
 ---
 
 # Slender Cantilever in Bending: `cantileverBeam`

--- a/tutorials/solids/hyperelasticity/heartTissueBeam/README.md
+++ b/tutorials/solids/hyperelasticity/heartTissueBeam/README.md
@@ -1,5 +1,5 @@
 ---
-sort: xx
+sort: 7
 ---
 
 # Heart Tissue Beam: `heartTissueBeam`

--- a/tutorials/solids/hyperelasticity/ratCarotid/README.md
+++ b/tutorials/solids/hyperelasticity/ratCarotid/README.md
@@ -1,5 +1,5 @@
 ---
-sort: xx
+sort: 8
 ---
 
 # Inflation of a Rat Carotid Artery: `ratCarotid`

--- a/tutorials/solids/linearElasticity/rigidCylinderContactBrick/README.md
+++ b/tutorials/solids/linearElasticity/rigidCylinderContactBrick/README.md
@@ -1,5 +1,5 @@
 ---
-sort: xx
+sort: 15
 ---
 
 # Rigid cylinder contact with block: `rigidCylinderContactBrick`


### PR DESCRIPTION
Phase 1 of the [solids4foam.com](https://www.solids4foam.com) `/documentation/`
restructure. It is the upstream half.

> [!NOTE]
> **Merge this one first.** The companion site PR,
> solids4foam/solids4foam.github.io#82, is held as a draft until this merges,
> because its submodule pointer has to be moved onto the resulting commit on
> `development` before it can go in.

Several READMEs are committed here but reachable from no page on the website —
`stabilisationModels`, `linGeomTotalDispSolid`, `nonLinGeomUpdatedLagSolid`,
`nonLinGeomTotalLagTotalDispSolid`, `decomposeParMonolithic`, `CONTRIBUTING.md`
— roughly 1400 lines in all. The site's theme orders and titles pages from
`sort:` front matter, so publishing them is mostly a matter of adding it.

## Changes

- `sort:` front matter added or adjusted on the 13 READMEs the website
  consumes, placing each in its intended position in the sidebar.
- New `applications/README.md`, the index for the applications section.
- New `applications/solvers/solids4Foam/README.md`, holding the solver
  walkthrough that previously lived on the website's overview page.
- `src/solids4FoamModels/README.md` retitled as the "Under the hood" section
  index.
- Three broken links fixed. Each resolved in a Git checkout but not on the
  website, where these files are published:
  - `beamInCrossFlow/README.md` linked `../../../src/.../fluidSolidInterfaces/README.md`;
  - `scripts/README.md` had `[OpenFOAM.com](OpenFOAM.com)` four times;
  - `cooksMembrane/README.md` had a doubled parenthesis that left a URL in the
    link text.
- The `volStrainRate` table in `stabilisationModels/README.md` said "Four
  modes" while listing, and implementing, five.

## Linking convention

Adopted for any README intended for the website, and applied throughout:

> Links to **other pages** use absolute `https://www.solids4foam.com/documentation/…`
> URLs. Relative links are used only for images in the same directory, and for
> source files on GitHub.

A repo reader and a site reader then follow the same link, and the site tree
can be reshaped without breaking anything.

## Verification

- `markdownlint-cli2` over `applications/**`, `src/**`, `CONTRIBUTING.md` and
  `README.md`: no new errors (two pre-existing MD013 hits remain, both
  unwrappable — a code fence and a table row).
- Built the website against this branch with `jekyll build --safe`: 118 pages,
  zero broken internal links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
