### PR TITLE
Documentation: add READMEs for the material models

### DIFF
--- a/src/solids4FoamModels/materialModels/README.md
+++ b/src/solids4FoamModels/materialModels/README.md
@@ -1,0 +1,327 @@
+---
+sort: 3
+---
+
+# Material models
+
+A material model describes how a material responds, as opposed to a solid
+model, which describes how the governing equations are discretised and
+solved. solids4foam splits this into two independent models:
+
+- the **mechanical model** (`mechanicalModel`), which turns deformation into
+  stress and provides the density and the implicit stiffness used by the
+  momentum equation. It is read from `constant/mechanicalProperties` and every
+  solid model creates one.
+- the **thermal model** (`thermalModel`), which provides the specific heat
+  capacity and thermal conductivity used by the heat equation. It is read from
+  `constant/thermalProperties` and is only created by the solid models that
+  solve for temperature.
+
+The two are deliberately separate. A thermal analysis therefore needs both
+dictionaries: the density that multiplies the specific heat capacity is taken
+from the mechanical model, not the thermal one.
+
+---
+
+## User Guide
+
+### The `constant/mechanicalProperties` dictionary
+
+`mechanicalProperties` is read `MUST_READ`, so it must exist for every solid
+case. It has these top-level entries:
+
+| Entry | Required | Description |
+| --- | --- | --- |
+| `planeStress` | yes | `yes`/`no`; plane stress or plane strain/3-D |
+| `mechanical` | yes | List of named material sub-dictionaries |
+| `writeSubMeshes` | no | Default `no`; write the material sub-meshes |
+
+`planeStress` is read with `lookup()` and so has no default; omitting it is a
+fatal error even for a genuinely three-dimensional case, where `no` is the
+correct answer. It is read once by `mechanicalModel` and is then available to
+every law through the protected `planeStress()` accessor, which searches the
+current region first and then the `region0` or `solid` sub-registry — this is
+what makes it work in fluid-solid interaction cases where the solid is a named
+region.
+
+`writeSubMeshes` is only meaningful for multi-material cases; it is read with
+`lookupOrDefault<Switch>` and, when enabled, writes each material sub-mesh to
+disk so that the partitioning can be inspected.
+
+### Selecting a mechanical law
+
+The `mechanical` entry is a **list**, not a dictionary. Each element is a
+named sub-dictionary, and the `type` keyword inside it selects the mechanical
+law at runtime:
+
+```text
+planeStress     no;
+
+mechanical
+(
+    steel
+    {
+        type            linearElastic;
+        rho             rho [1 -3 0 0 0 0 0] 7854;
+        E               E [1 -1 -2 0 0 0 0] 200e9;
+        nu              nu [0 0 0 0 0 0 0] 0.3;
+    }
+);
+```
+
+For a single-material case the name (`steel` above) is arbitrary and is used
+only in solver output. It becomes significant as soon as there is more than
+one entry — see below.
+
+There are **two separate run-time selection tables**, and a law is registered
+in exactly one of them:
+
+- `linGeomMechLaw`, used when the solid model reports
+  `LINEAR_GEOMETRY`;
+- `nonLinGeomMechLaw`, used when the solid model reports
+  `TOTAL_LAGRANGIAN` or `UPDATED_LAGRANGIAN`.
+
+A law can therefore not be paired with an incompatible solid model. If a
+nonlinear-geometry law is requested from a linear-geometry solid model, the
+selector detects this and reports that the law "can only be used with a
+nonlinear geometry solid model" rather than simply saying the type is unknown.
+The two catalogues are documented at:
+
+- [Linear geometry mechanical laws](https://www.solids4foam.com/documentation/material-models/linear-geometry-laws.html)
+- [Nonlinear geometry mechanical laws](https://www.solids4foam.com/documentation/material-models/nonlinear-geometry-laws.html)
+
+### Entries common to every law
+
+Four entries are handled by the `mechanicalLaw` base class and so are
+available inside any law sub-dictionary, whichever `type` is selected:
+
+| Entry | Default | Description |
+| --- | --- | --- |
+| `type` | none | Required; the law's run-time type name |
+| `rho` | none | Density; required by laws using the base `rho()` |
+| `solvePressureEqn` | `no` | Solve a smoothing Laplacian for the pressure |
+| `pressureSmoothingScaleFactor` | `100` | Scales that smoothing |
+
+`rho` is read as a `dimensionedScalar` by `mechanicalLaw::rhoScalar()`. A law
+that overrides `rho()` need not provide it, but almost all do use the base
+implementation. Note that `rho()` uses `READ_IF_PRESENT`, so a `rho` field
+placed in the time directory will be read in preference to the uniform value.
+
+`solvePressureEqn` and `pressureSmoothingScaleFactor` are read with
+`lookupOrAddDefault`, which means the defaults are written back into the
+in-memory dictionary and appear in the `mechanicalProperties.withDefaultValues`
+file the solver writes at the end of a run. That file is a useful way to see
+exactly what was used.
+
+A fifth, optional entry is `regionName`. The base class needs to know which
+mesh region is the "base" solid region; it uses `regionName` if present, else
+`solid` if that region exists, else `region0`. Only unusual multi-region
+set-ups need to set it explicitly.
+
+### Multi-material cases
+
+Give the `mechanical` list more than one entry and solids4foam switches to its
+multi-material path:
+
+```text
+planeStress     yes;
+
+mechanical
+(
+    outer
+    {
+        type            linearElastic;
+        rho             rho [1 -3 0 0 0 0 0] 1000;
+        E               E [1 -1 -2 0 0 0 0] 200e+9;
+        nu              nu [0 0 0 0 0 0 0] 0.3;
+    }
+    inner
+    {
+        type            linearElastic;
+        rho             rho [1 -3 0 0 0 0 0] 1000;
+        E               E [1 -1 -2 0 0 0 0] 20e+9;
+        nu              nu [0 0 0 0 0 0 0] 0.35;
+    }
+);
+```
+
+The rules that follow from the implementation are:
+
+1. **The name of each entry must be the name of a `cellZone`.** The keyword of
+   each `mechanical` entry (`outer`, `inner` above) is taken verbatim as a
+   cellZone name. If no cellZone of that name exists, construction aborts with
+   "cellZone not found for material \<name\>".
+2. **Every cell must be in exactly one of those cellZones.** Before the
+   sub-meshes are built, `checkCellZones()` counts how many of the listed
+   zones each cell belongs to and aborts if any cell is in none of them
+   ("There are cells that are not in a material cellZone!") or in more than
+   one. Cells in other, unlisted cellZones are not exempt: the check is over
+   the whole mesh.
+3. **Each material gets its own sub-mesh.** `solidSubMeshes` builds one
+   `fvMeshSubset` per material from the corresponding cellZone, and the
+   mechanical law for that material is constructed **on the sub-mesh**, not on
+   the base mesh. Every field the law creates therefore lives on the sub-mesh,
+   and the results are mapped back to the base mesh by `mechanicalModel`.
+4. **Interfaces are internal faces, not patches.** A face shared by two
+   materials stays an internal face of the base mesh; in each sub-mesh it
+   appears on the auto-generated `oldInternalFaces` patch. There is no
+   coupling dictionary and no patch to set up.
+
+Cell zones are normally created after meshing with `setSet` followed by
+`setsToZones` (or with `topoSet`). The `layeredPipe` tutorial does exactly
+this, with a `batch.setSet` file that makes an `outer` and an `inner` cellSet
+and subtracts one from the other so the two do not overlap.
+
+```note
+Because the sub-mesh partition is by cellZone, a material region does not need
+to be contiguous, and the base mesh does not need to be conformal in any
+special way. It does, however, have to be a single mesh: separately meshed
+parts must be merged first, as in the `punch` tutorial.
+```
+
+### What happens at a bi-material interface
+
+Stress is discontinuous across an interface between dissimilar materials,
+which is exactly what a smooth cell-to-face interpolation gets wrong. Rather
+than interpolate the base displacement onto each sub-mesh naively,
+solids4foam computes an interface displacement that drives the two sides
+towards traction equilibrium.
+
+For each interface face, the stiffness-weighted update is
+
+```text
+Di = Di.prevIter
+   + wab*(tractionB - tractionA)
+   + wa*(Da - Da.prevIter) + wb*(Db - Db.prevIter)
+```
+
+where `A` and `B` are the two sides, `da` and `db` are the normal distances
+from the face to the two cell centres, `Ka` and `Kb` are the implicit
+stiffnesses there, and
+
+```text
+wab = da*db/(db*Ka + da*Kb)
+wa  = db*Ka/(db*Ka + da*Kb)
+wb  = 1 - wa
+```
+
+The consequences for the user are:
+
+- The correction is **iterative**: it uses the previous outer-iteration values,
+  so traction continuity is achieved at convergence, not in a single
+  iteration. Expect multi-material cases to need more outer correctors than
+  the equivalent single-material case, particularly when the stiffness ratio
+  is large.
+- It uses the implicit stiffness `impK`, so the stiffness contrast between
+  materials is what sets the weights. This is the mechanism that keeps the
+  solution oscillation-free across a large jump in Young's modulus.
+- For nonlinear-geometry laws the face normal is rotated with Nanson's
+  formula, using the relative deformation gradient for updated Lagrangian
+  solid models and the total one for total Lagrangian solid models.
+
+If no face is shared by two materials — for example, materials separated by an
+internal boundary — the correction is skipped entirely and each sub-mesh is
+filled by plain interpolation.
+
+### Multi-material limitations
+
+Some capabilities are single-material only, and fail with a clear
+`notImplemented` or fatal error rather than silently giving a wrong answer:
+
+| Capability | Status with more than one material |
+| --- | --- |
+| `correct(pointSymmTensorField&, ...)` | Not implemented |
+| Face-quadrature `correct(...)`/`grad(...)` | Not implemented |
+| `crackerFvMesh` | Fatal error at construction (foam-extend) |
+
+The vertex-centred solid models are not affected by the first two rows in the
+same way: they use `dualMechanicalModel`, which handles multiple materials by
+constructing every law on the whole dual mesh and masking each law by the
+cells belonging to its material.
+
+### Thermal properties
+
+Solid models that solve a temperature equation additionally read
+`constant/thermalProperties`, which selects a `thermalLaw` giving the specific
+heat capacity and thermal conductivity. See the thermal model page in this
+section.
+
+---
+
+## Developer Notes
+
+### Class layout
+
+`mechanicalModel` derives from both `IOdictionary` (it *is* the
+`mechanicalProperties` dictionary) and `PtrList<mechanicalLaw>` (it *is* the
+list of laws). The number of laws is what selects between the single- and
+multi-material code paths throughout the class; there is no separate flag.
+
+`solidSubMeshes` is created lazily, on the first call to `solSubMeshes()`, and
+deliberately aborts if constructed for a single material. Note the ordering
+trap handled in `clearOut()`: the laws must be cleared before the sub-meshes,
+because the laws hold `GeometricField`s registered on the sub-meshes.
+
+### Accumulation pattern
+
+`rho()`, `impK()`, `bulkModulus()` and `shearModulus()` all follow the same
+shape. With one law they forward straight to it; with several they build a
+`PtrList` of the per-sub-mesh fields and call
+`solidSubMeshes::mapSubMeshVolFields` to assemble the base-mesh field. The
+same pattern with `mapSubMeshSurfaceFields` is used for `sigma`, with one
+difference: the surface field is zeroed first, because interface faces receive
+a contribution from both materials, whereas volume fields store nothing on the
+interface.
+
+`impKf()` is not accumulated from per-law surface fields; it is a plain linear
+interpolation of the assembled `impK`, with the comment that this gives the
+best convergence in practice.
+
+### Gradients and vol-to-point interpolation
+
+In the multi-material path, `grad()` does not take the gradient of the base
+field. It interpolates the base `D` to each sub-mesh (applying the interface
+correction), takes the gradient on each sub-mesh, calls `correctBoundarySnGrad`
+to restore non-orthogonal correction on boundaries that the sub-setting turned
+into `calculated` patches, maps back, and finally re-applies
+`gaussGrad::correctBoundaryConditions`. The surface-field variant additionally
+overwrites the normal component with `n*fvc::snGrad(D)`, which the code notes
+is necessary for convergence in many cases.
+
+`interpolate()` follows the same shape using one
+`enhancedVolPointInterpolation` (`newLeastSquaresVolPointInterpolation` on
+foam-extend) per sub-mesh, then maps the point fields back.
+`correctSymmPlanes()` then zeroes the normal component of `pointD` on symmetry
+and empty patches by testing the average patch normal against the coordinate
+axes, and applies the solid model's 2-D corrector.
+
+### Adding a new mechanical law
+
+See the `mechanicalLaw` base-class page in this section for the interface a new
+law must implement and the concrete steps to register it. The base class lives
+at
+[`mechanicalLaw.H`](https://github.com/solids4foam/solids4foam/blob/development/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/mechanicalLaw/mechanicalLaw.H).
+
+### Dictionary write-back
+
+`writeDict()` is called from `solidModel::end()`. Because each law's
+dictionary is a copy rather than a reference into `mechanicalProperties`, the
+law dictionaries have to be reassembled into a `mechanical` entry before being
+written, which is why the function exists at all. The result is
+`constant/mechanicalProperties.withDefaultValues`, showing every entry
+including the ones filled in by `lookupOrAddDefault`.
+
+---
+
+## Tutorials
+
+Cases with more than one entry in the `mechanical` list:
+
+- `solids/multiMaterial/layeredPipe`: a bi-material thick-walled cylinder;
+  the reference case for the multi-material machinery, with cellZones built by
+  `setSet`/`setsToZones` and an analytical solution to compare against.
+- `solids/linearElasticity/punch`: two separately meshed parts merged into one
+  mesh, then split into the `punch_top` and `punch_bottom` cellZones.
+- `solids/thermoelasticity/hotCylinder/hotCylinderPredefinedTFieldMultipleMaterials`:
+  `steel` and `aluminium` materials, each a `thermoMechanicalLaw` wrapping a
+  `linearElastic` law.

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/README.md
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/README.md
@@ -1,0 +1,111 @@
+---
+sort: 2
+---
+
+# Linear geometry mechanical laws
+
+This section documents the mechanical laws that assume the linear geometry
+(small strain, small rotation) approximation.
+
+A mechanical law is the constitutive part of a solids4foam case: the solid
+model assembles and solves the momentum equation, and the mechanical law
+answers the single question _given the current displacement field, what is the
+stress?_ Linear geometry laws answer that question in terms of the small-strain
+tensor
+
+```text
+epsilon = symm(grad(D))
+```
+
+or, for an incremental solid model, in terms of the increment
+`symm(grad(DD))` accumulated onto the old-time strain. There is no distinction
+between the reference and deformed configurations, no deformation gradient
+`F`, and no distinction between Cauchy and Piola-Kirchhoff stress. Laws in this
+directory are registered under the `linGeomMechLaw` run-time selection table
+and are intended for use with the linear geometry solid models, for example
+`linearGeometryTotalDisplacement`, `unsLinearGeometry` and
+`poroLinearGeometry`.
+
+```note
+The nonlinear geometry counterparts live in `nonLinearGeometryLaws` and are
+registered under a separate `nonLinGeomMechLaw` table. A law from one table
+cannot be selected by a solid model that uses the other.
+```
+
+---
+
+## Catalogue
+
+For every law in this subsection the run-time selection name registered by
+`addToRunTimeSelectionTable` is identical to the C++ class name, so the class
+name is what you type in `constant/mechanicalProperties`.
+
+| Runtime type | Purpose |
+| --- | --- |
+| `linearElastic` | Isotropic Hooke's law |
+| `orthotropicLinearElastic` | Nine-parameter orthotropic Hooke's law |
+| `linearElasticMisesPlastic` | Hooke's law with J2 (von Mises) plasticity |
+| `linearElasticMohrCoulombPlastic` | Hooke's law with Mohr-Coulomb plasticity |
+| `poroMechanicalLaw` | Wrapper adding a pore-pressure term |
+| `thermoMechanicalLaw` | Wrapper adding a thermal expansion term |
+| `viscousHookeanElastic` | Generalised Maxwell (Prony series) viscoelasticity |
+| `anisotropicBiotElastic` | Orthotropic elasticity for soil skeletons |
+| `diffusionElastic` | Hooke's law scaled by a mesh motion diffusivity |
+| `linearElasticCt` | `E` from CT data; **not currently built** |
+| `linearElasticFromFile` | Hooke's law with `E` read as a field from disk |
+
+Three of these are _wrappers_ rather than stand-alone constitutive models:
+`poroMechanicalLaw` and `thermoMechanicalLaw` each own a nested, run-time
+selectable law and add a spherical stress contribution to whatever it returns.
+They can therefore be combined with most of the other entries in the table.
+
+`diffusionElastic` is not a physical material model; it exists so that a solid
+model can be used as a mesh motion solver.
+
+---
+
+## Selecting a law
+
+Mechanical laws are selected in `constant/mechanicalProperties`. The
+`mechanical` entry is a _list_ of sub-dictionaries, one per material, so
+multi-material cases are expressed by adding further entries:
+
+```text
+planeStress     no;
+
+mechanical
+(
+    steel
+    {
+        type            linearElastic;
+        rho             rho [1 -3 0 0 0 0 0] 7854;
+        E               E [1 -1 -2 0 0 0 0] 200e9;
+        nu              nu [0 0 0 0 0 0 0] 0.3;
+    }
+);
+```
+
+The name of each sub-dictionary (`steel` above) is arbitrary; for
+multi-material cases it must match the corresponding `cellZone`.
+
+### Entries every law understands
+
+These are read by the `mechanicalLaw` base class, so they are valid inside any
+of the sub-dictionaries above:
+
+| Entry | Default | Description |
+| --- | --- | --- |
+| `rho` | required | Density, `[1 -3 0 0 0 0 0]` |
+| `solvePressureEqn` | `no` | Solve a Laplacian for hydrostatic pressure |
+| `pressureSmoothingScaleFactor` | `100` | Scale factor for that equation |
+| `regionName` | auto | Object registry holding the solid mesh |
+
+`rho` is looked up on demand rather than at construction, so a missing `rho`
+is reported the first time the solid model asks for the density.
+`solvePressureEqn` is intended for nearly incompressible materials; not every
+law honours it, and the individual pages say which do.
+
+The top-level `planeStress` switch sits outside the `mechanical` list and is
+read by the base class through the `mechanicalProperties` dictionary itself.
+Several laws in this subsection abort if `planeStress` is `yes` — see the
+individual pages.

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/anisotropicBiotElastic/README.md
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/anisotropicBiotElastic/README.md
@@ -1,0 +1,236 @@
+---
+sort: 10
+---
+
+# anisotropicBiotElastic
+
+This law calculates small-strain orthotropic effective stress. Pore pressure
+can be included by nesting it inside `poroMechanicalLaw`. The runtime type is:
+
+```text
+anisotropicBiotElastic
+```
+
+---
+
+## User Guide
+
+### What it computes
+
+The cell-centred `correct` obtains the total strain from the displacement
+gradient:
+
+```text
+epsilon = symm(grad(D))                         // total formulation
+epsilon = epsilon.oldTime() + symm(grad(DD))   // incremental formulation
+```
+
+In the branch labelled as 2-D, the implemented stress relation is:
+
+```text
+sigma_xx = A11*epsilon_xx + A12*epsilon_yy
+sigma_yy = A21*epsilon_xx + A22*epsilon_yy
+sigma_xy = A44*epsilon_xy
+```
+
+The other stress components are not assigned in this branch. In the 3-D
+branch, the relation is:
+
+```text
+sigma_xx = A11*epsilon_xx + A12*epsilon_yy + A31*epsilon_zz
+sigma_yy = A12*epsilon_xx + A22*epsilon_yy + A23*epsilon_zz
+sigma_zz = A31*epsilon_xx + A23*epsilon_yy + A33*epsilon_zz
+sigma_xy = A44*epsilon_xy
+sigma_yz = A55*epsilon_yz
+sigma_xz = A66*epsilon_xz
+```
+
+The same relations are applied to the boundary values. The law implements
+only `correct(volSymmTensorField&)`. Its surface overload aborts with
+`notImplemented`. The inherited point overload also aborts. The inherited
+`CompactListList` overload is unavailable on foam-extend and aborts with
+`notImplemented` on the other forks.
+
+### Model options
+
+The elastic properties are read as plain scalars, so the dictionary does not
+attach dimension sets to them. Use one consistent pressure unit for all
+Young's and shear moduli.
+
+| Entry | Required | Description |
+| --- | --- | --- |
+| `Ex` | yes | Young's modulus in the x direction |
+| `Ey` | yes | Young's modulus in the y direction |
+| `Ez` | in the 3-D branch | Young's modulus in the z direction |
+| `nuxy` | yes | Poisson's ratio `nuxy` |
+| `nuyz` | in the 3-D branch | Poisson's ratio `nuyz` |
+| `nuzx` | in the 3-D branch | Poisson's ratio `nuzx` |
+| `Gxy` | yes | Shear modulus in the xy plane |
+| `Gyz` | in the 3-D branch | Shear modulus in the yz plane |
+| `Gzx` | in the 3-D branch | Shear modulus in the zx plane |
+| `rho` | for direct use | Density, `[1 -3 0 0 0 0 0]` |
+| `regionName` | no | Base mesh region; otherwise `solid` or `region0` |
+| `solvePressureEqn` | no | Accepted switch; default `no`, unused here |
+| `pressureSmoothingScaleFactor` | no | Default `100`, unused here |
+
+Which entries are required depends on a branch flag that is currently
+inverted, so read the following carefully before setting up a case.
+
+```warning
+The law selects its 2-D branch when `mesh.solutionD()[vector::Z] > 0`, which
+is true when z is a **solved** direction — that is, for a **3-D** mesh. The
+sense of the test is the opposite of the one intended, so today a 3-D case
+takes the 2-D branch and reads only `Ex`, `Ey`, `nuxy` and `Gxy`, silently
+ignoring `Ez`, `nuyz`, `nuzx`, `Gyz` and `Gzx` and leaving the out-of-plane
+stress components at zero. A genuinely 2-D case, with z empty, takes the 3-D
+branch and aborts with `keyword Ez is undefined` unless all nine constants are
+supplied. This is tracked as
+[issue #334](https://github.com/solids4foam/solids4foam/issues/334); supply all
+nine constants until it is fixed.
+```
+
+`rho` is read through the base-class density functions. When the law is nested
+inside `poroMechanicalLaw`, density belongs to the outer law, as in the setup
+below. The pressure-equation entries are stored by `mechanicalLaw`, but this
+law never calls `updateSigmaHyd()`, so they do not change its stress update.
+
+### Recommended dictionary setup
+
+The following seabed-soil values follow the available poroelastic tutorial:
+
+```text
+planeStress     no;
+
+mechanical
+(
+    seabedSoil
+    {
+        type            poroMechanicalLaw;
+        rho             rho [1 -3 0 0 0 0 0] 2650;
+        biotCoeff       biotCoeff [0 0 0 0 0 0 0] 1.0;
+
+        effectiveStressMechanicalLaw
+        {
+            type        anisotropicBiotElastic;
+            Ex          1.2e7;
+            Ey          1.2e7;
+            Ez          2e7;
+            nuxy        0.2;
+            nuyz        0.24;
+            nuzx        0.4;
+            Gxy         0.5e7;
+            Gyz         1.2e7;
+            Gzx         1.2e7;
+
+            // Optional for a non-standard base mesh name
+            // regionName solid;
+        }
+    }
+);
+```
+
+### Field glossary
+
+- `epsilon`: cell-centred total small-strain tensor. It is created with
+  `NO_READ` and `NO_WRITE` and accumulated from its old-time value for an
+  incremental solid model.
+- `grad(D)`, `grad(DD)`: displacement-gradient fields looked up for total and
+  incremental solid models respectively; the law does not own them.
+- `sigma`: caller-owned cell-centred stress updated by `correct`.
+- `impK`: temporary uniform pressure-dimensioned field returned to the solid
+  model.
+
+---
+
+## Developer Notes
+
+### Class role
+
+`anisotropicBiotElastic` derives directly from `mechanicalLaw`. It stores the
+branch flag `model2d_`, ten scalar stiffness coefficients and the
+cell-centred `epsilon_` field. It is registered in the `linGeomMechLaw`
+selection table under `anisotropicBiotElastic`.
+
+The source uses `#ifdef OPENFOAM_NOT_EXTEND` to select writable internal and
+boundary field accessors. The class itself has no `FOAMEXTEND`-only interface
+guards. Its source is listed in both `Make/files.openfoam` and
+`Make/files.foamextend`.
+
+### Construction
+
+The base constructor first reads `solvePressureEqn` with default `false` and
+`pressureSmoothingScaleFactor` with default `100.0`. It then reads
+`regionName`, or selects an existing `solid` or `region0` mesh. If none is
+available, it raises a fatal error asking for `regionName`.
+
+The derived constructor sets `model2d_` from whether the z solution direction
+is greater than zero, zeroes every stiffness coefficient and creates
+`epsilon_`. In the 2-D branch it raises a fatal error if x or y is an empty
+direction. It then reads `Ex`, `Ey`, `nuxy` and `Gxy`, and derives:
+
+```text
+nuyx = nuxy*Ey/Ex
+J    = 1/(1 - nuxy*nuyx)
+A11  = J*Ex
+A22  = J*Ey
+A12  = J*nuyx*Ex
+A21  = J*nuxy*Ey
+A44  = 2*Gxy
+```
+
+In the 3-D branch it reads all nine elastic entries and derives:
+
+```text
+nuyx = nuxy*Ey/Ex
+nuxz = nuzx*Ex/Ez
+nuzy = nuyz*Ez/Ey
+J = (1 - nuxy*nuyx - nuyz*nuzy - nuzx*nuxz
+     - 2*nuyx*nuzy*nuxz)/(Ex*Ey*Ez)
+A11 = (1 - nuyz*nuzy)/(J*Ey*Ez)
+A22 = (1 - nuxz*nuzx)/(J*Ex*Ez)
+A33 = (1 - nuyx*nuxy)/(J*Ey*Ex)
+A12 = (nuxy + nuzy*nuxz)/(J*Ex*Ez)
+A31 = (nuzx + nuyx*nuzy)/(J*Ey*Ez)
+A23 = (nuyz + nuyx*nuxz)/(J*Ex*Ey)
+A44 = 2*Gxy
+A55 = 2*Gyz
+A66 = 2*Gzx
+```
+
+The constructor prints the supplied properties and derived coefficients. It
+does not validate moduli, Poisson's ratios or the denominators, and emits no
+law-specific warnings.
+
+### Key methods
+
+- `impK()` returns a uniform field containing
+  `max(A11, max(A22, A33))`. In the 2-D branch `A33` remains zero. This is the
+  diffusivity of the solid model's implicit Laplacian term and affects the
+  outer-iteration convergence rate rather than the converged answer.
+- `correct(volSymmTensorField&)` updates `epsilon_` from `grad(D)` or
+  `grad(DD)`, then applies the component-wise constitutive relation to cell
+  and boundary values.
+- `correct(surfaceSymmTensorField&)` always aborts with `notImplemented`.
+- `materialTangent()` is not overridden. The inherited implementation aborts
+  with `notImplemented`, so this law does not supply a Newton material
+  tangent.
+
+### Extension points
+
+A related orthotropic law can copy this class, replace the property reads and
+stiffness derivation, and update the component equations in `correct`. It must
+be registered in the appropriate mechanical-law selection table and added to
+both build lists if all forks are supported. Implement the surface, point and
+quadrature overloads, and `materialTangent()`, when the target solid models
+require those interfaces.
+
+The source is at
+[anisotropicBiotElastic.C][source].
+
+[source]: https://github.com/solids4foam/solids4foam/blob/master/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/anisotropicBiotElastic/anisotropicBiotElastic.C
+
+---
+
+## Tutorials
+
+- `solids/poroelasticity/rodAndSeabed`

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/diffusionElastic/README.md
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/diffusionElastic/README.md
@@ -1,0 +1,195 @@
+---
+sort: 11
+---
+
+# diffusionElastic
+
+This law applies isotropic small-strain elasticity with shear and bulk
+stiffnesses scaled by a normalized mesh-motion diffusivity. The runtime type
+is:
+
+```text
+diffusionElastic
+```
+
+---
+
+## User Guide
+
+### What it computes
+
+The law obtains a raw face diffusivity from the selected `motionDiffusivity`,
+limits it relative to its face average, and normalizes it:
+
+```text
+dRaw_f = motionDiffusivity
+dAvg   = average(dRaw_f)
+d_f    = min(maxFactor*dAvg, max(minFactor*dAvg, dRaw_f))/dAvg
+d      = average(d_f)
+```
+
+The cell field `d` receives zero-gradient boundary conditions. The diffusivity
+fields are calculated during construction and are not refreshed by either
+`correct` overload.
+
+For non-incremental solid models, the strain is calculated from the total
+displacement gradient. For incremental solid models, the strain increment is
+added to the old-time strain:
+
+```text
+epsilon  = symm(grad(D))
+epsilon  = epsilon.oldTime() + symm(grad(DD))    // incremental
+
+epsilon_f = symm(grad(D)_f)
+epsilon_f = epsilon_f.oldTime() + symm(grad(DD)_f) // incremental
+```
+
+The cell-centred and face-centred stresses are then:
+
+```text
+sigma   = d*(2*mu*dev(epsilon) + kappa*tr(epsilon)*I)
+sigma_f = d_f*(2*mu*dev(epsilon_f) + kappa*tr(epsilon_f)*I)
+```
+
+The law implements `correct(volSymmTensorField&)` and
+`correct(surfaceSymmTensorField&)`. The point-tensor overload is inherited
+from `mechanicalLaw` and aborts with `notImplemented`. The
+`CompactListList` quadrature-point overload is also inherited and aborts with
+`notImplemented` on forks where that interface is compiled.
+
+### Model options
+
+| Entry | Required | Description |
+| --- | --- | --- |
+| `mu` | yes | Shear stiffness, `[1 -1 -2 0 0 0 0]` |
+| `kappa` | yes | Bulk stiffness, `[1 -1 -2 0 0 0 0]` |
+| `diffusivity` | yes | Mesh-motion diffusivity specification |
+| `writeStiffScaleFactor` | yes | Write `stiffnessScaleFactor` if `yes` |
+| `maxFactor` | no | Upper limiter relative to the average; default `100` |
+| `minFactor` | no | Lower limiter relative to the average; default `0.1` |
+| `rho` | yes | Density, `[1 -3 0 0 0 0 0]` |
+| `solvePressureEqn` | no | Base-class switch; default `no` |
+| `pressureSmoothingScaleFactor` | no | Base-class factor; default `100` |
+| `regionName` | no | Override the base mesh region name |
+
+`diffusivity` is passed directly to `motionDiffusivity::New`, so its syntax
+must match a mesh-motion diffusivity available in the selected OpenFOAM fork.
+Only the ordering of the limiter factors is checked: `maxFactor` less than
+`minFactor` is fatal.
+
+The base class reads `solvePressureEqn` and
+`pressureSmoothingScaleFactor`, but this law calculates the volumetric stress
+directly and never calls `updateSigmaHyd()`. Those entries therefore do not
+alter its constitutive response. If `regionName` is omitted, the base class
+selects `solid` and then `region0`, in that order.
+
+### Recommended dictionary setup
+
+The following values use aluminium-like stiffness and density for a mesh
+pseudo-material with an inverse-distance diffusivity based on `movingWall`:
+
+```text
+mechanical
+(
+    aluminiumMesh
+    {
+        type            diffusionElastic;
+        rho             rho [1 -3 0 0 0 0 0] 2700;
+        mu              mu [1 -1 -2 0 0 0 0] 26e9;
+        kappa           kappa [1 -1 -2 0 0 0 0] 69e9;
+        diffusivity     quadratic inverseDistance (movingWall);
+        writeStiffScaleFactor yes;
+
+        // Optional
+        // maxFactor    100;
+        // minFactor    0.1;
+        // regionName   region0;
+        // solvePressureEqn no;
+        // pressureSmoothingScaleFactor 100;
+    }
+);
+```
+
+### Field glossary
+
+- `distf`: normalized and limited face diffusivity, `d_f`.
+- `stiffnessScaleFactor`: cell-centred `d`, obtained by averaging `distf`;
+  written only when `writeStiffScaleFactor yes` is selected.
+- `epsilon`, `epsilonf`: small-strain tensors at cell centres and faces. Their
+  old-time values are stored during construction for incremental solid models.
+- `bulkModulus`: temporary cell field returned as `kappa*d`.
+- `shearModulus`: temporary cell field returned as `mu*d`.
+- `k`: temporary implicit-stiffness field returned by `impK()`.
+
+---
+
+## Developer Notes
+
+### Class role
+
+`diffusionElastic` derives directly from `mechanicalLaw`. It stores uniform
+`dimensionedScalar` values `mu_` and `kappa_`, scalar limiter values
+`maxFactor_` and `minFactor_`, an `autoPtr<motionDiffusivity>`, and the face
+and cell scale fields `df_` and `d_`.
+
+The class contains no fork-specific preprocessor guards. Its source appears in
+`Make/files.openfoam` but not in `Make/files.foamextend`, so it is built for
+the OpenFOAM.com and OpenFOAM.org path, but not for foam-extend.
+
+### Construction
+
+The base constructor first reads or inserts `solvePressureEqn` and
+`pressureSmoothingScaleFactor`, then resolves `regionName`. The derived
+constructor proceeds in this order:
+
+1. It reads `mu` and `kappa` as dimensioned scalars.
+2. It reads `maxFactor` and `minFactor`, using `100` and `0.1` by default.
+3. It constructs the selected motion diffusivity from `diffusivity`.
+4. It initializes `distf` from that model and initializes
+   `stiffnessScaleFactor` by face-to-cell averaging.
+5. It stores old-time values for `epsilon` and `epsilonf`.
+6. It aborts if `maxFactor` is less than `minFactor`.
+7. It corrects, limits, and normalizes the diffusivity fields.
+8. It reads `writeStiffScaleFactor` and enables automatic writing of the cell
+   scale field when requested.
+
+Missing required entries and an unknown motion-diffusivity type produce the
+corresponding OpenFOAM dictionary or selection errors. The base class emits a
+fatal error if it cannot find `solid` or `region0` and no `regionName` was
+given. The derived constructor emits no warnings.
+
+### Key methods
+
+- `updateD()`: calls the motion diffusivity's `correct()`, limits and
+  normalizes its face field, averages it to cells, and corrects the cell-field
+  boundary conditions. It is called by the constructor.
+- `impK()`: returns `d*((4/3)*mu + kappa)`. This is the diffusivity used by the
+  solid model's implicit Laplacian term and affects the outer-iteration
+  convergence rate rather than the converged answer.
+- `correct(volSymmTensorField&)`: updates the cell strain and applies the
+  diffusivity-scaled constitutive relation.
+- `correct(surfaceSymmTensorField&)`: updates the face strain and applies the
+  corresponding face-scaled relation.
+- `bulkModulus()` and `shearModulus()`: return `kappa*d` and `mu*d` cell
+  fields.
+- `materialTangent()`: is not overridden; the base implementation aborts with
+  `notImplemented`.
+
+### Extension points
+
+A related spatially scaled small-strain law can be made by copying this class,
+changing the two constitutive expressions, and retaining `updateD()` when the
+same mesh-motion diffusivity and limiter are appropriate. Implement the point
+and quadrature-point `correct` overloads, and `materialTangent()`, if the new
+law must support vertex-centred, higher-order, block-coupled, or PETSc SNES
+solid models. Add the source to each fork-specific build list that supports
+its dependencies.
+
+The source is at
+[diffusionElastic.C](https://github.com/solids4foam/solids4foam/blob/master/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/diffusionElastic/diffusionElastic.C).
+
+---
+
+## Tutorials
+
+No tutorial currently uses `diffusionElastic`.

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElastic/README.md
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElastic/README.md
@@ -1,0 +1,198 @@
+---
+sort: 3
+---
+
+# linearElastic
+
+This page documents the isotropic Hookean linear elastic mechanical law. The
+runtime type is:
+
+```text
+linearElastic
+```
+
+This is the default choice for small-strain elasticity and by far the most
+widely used law in the solids4foam tutorial suite. It is also the law most
+often nested inside the `poroMechanicalLaw` and `thermoMechanicalLaw`
+wrappers.
+
+---
+
+## User Guide
+
+### What it computes
+
+The cell-centred `correct` splits the stress into deviatoric and hydrostatic
+parts:
+
+```text
+sigmaHyd = K*tr(epsilon)
+sigma    = 2*mu*dev(epsilon) + sigmaHyd*I + sigma0
+```
+
+The hydrostatic part is passed through `updateSigmaHyd()`, so when
+`solvePressureEqn` is enabled it is obtained from a smoothed Laplacian
+equation instead of directly from `K*tr(epsilon)`. The face-centred and
+point-centred overloads instead use the plain form
+
+```text
+sigma = 2*mu*epsilon + lambda*tr(epsilon)*I + sigma0f
+```
+
+and both abort with `notImplemented` if `solvePressureEqn` is enabled. The
+point overload additionally aborts if `sigma0` is non-zero.
+
+### Model options
+
+Elastic constants are given as **either** `E` and `nu`, **or** `mu` and `K`.
+The `E`/`nu` pair is checked first; if neither pair is present the law aborts
+at construction.
+
+| Entry | Required | Description |
+| --- | --- | --- |
+| `E` | with `nu` | Young's modulus, `[1 -1 -2 0 0 0 0]` |
+| `nu` | with `E` | Poisson's ratio, dimensionless |
+| `mu` | with `K` | Shear modulus, `[1 -1 -2 0 0 0 0]` |
+| `K` | with `mu` | Bulk modulus, `[1 -1 -2 0 0 0 0]` |
+| `sigma0` | no | Uniform initial stress, symmetric tensor |
+| `rho` | yes | Density, `[1 -3 0 0 0 0 0]` |
+
+`sigma0` is optional. If it is absent but a non-uniform `sigma0` field already
+carries a non-zero value, that field is used instead and a message is printed.
+
+The remaining `mechanicalLaw` base-class entries — `solvePressureEqn`
+(default `no`), `pressureSmoothingScaleFactor` (default `100`) and
+`regionName` — apply here as described in the
+[subsection index](https://www.solids4foam.com/documentation/material-models/linear-geometry-laws.html).
+
+### Derived quantities and checks
+
+The constructor derives whichever pair was not supplied, and also the first
+Lame parameter:
+
+```text
+mu     = E/(2*(1 + nu))
+lambda = nu*E/((1 + nu)*(1 - 2*nu))        // plane strain / 3-D
+lambda = nu*E/((1 + nu)*(1 - nu))          // planeStress yes
+```
+
+Three checks are applied:
+
+- `nu` outside `[-1, 0.5]` is a fatal error;
+- `nu` above `0.49` with `solvePressureEqn no` produces a warning suggesting
+  the pressure equation be enabled;
+- `planeStress yes` combined with `solvePressureEqn yes` is a fatal error.
+
+When `nu` is exactly `0.5`, `K` and `lambda` are set to `GREAT` and `impK`
+falls back to `2*mu`; use a hybrid or pressure-solving solid model in that
+case.
+
+### Recommended dictionary setup
+
+```text
+planeStress     no;
+
+mechanical
+(
+    steel
+    {
+        type            linearElastic;
+        rho             rho [1 -3 0 0 0 0 0] 7854;
+        E               E [1 -1 -2 0 0 0 0] 200e9;
+        nu              nu [0 0 0 0 0 0 0] 0.3;
+
+        // Optional
+        // sigma0        sigma0 [1 -1 -2 0 0 0 0] (0 0 0 0 0 0);
+        // solvePressureEqn no;
+    }
+);
+```
+
+### Field glossary
+
+- `epsilon`, `epsilonf`: small-strain tensor at cell centres and faces; both
+  have their old-time values stored so that incremental solid models work.
+- `sigmaHyd`: hydrostatic stress, `tr(sigma)/3`, maintained by the base class.
+- `sigma0`, `sigma0f`: initial (residual) stress at cells and faces.
+- `impK`: implicit stiffness handed to the solid model's Laplacian term;
+  `2*mu + lambda`, or `2*mu` for `nu == 0.5`.
+
+---
+
+## Developer Notes
+
+### Class role
+
+`linearElastic` derives directly from `mechanicalLaw` and stores five
+`dimensionedScalar` members: `mu_`, `K_`, `E_`, `nu_` and `lambda_`. Because
+the properties are uniform scalars rather than fields, the law is cheap and is
+the natural base case against which other laws are compared.
+
+It implements an unusually complete set of interfaces, which is why it is the
+only law usable by every solid model in the toolbox:
+
+- `correct(volSymmTensorField&)` and the `epsilon`-taking overload;
+- `correct(surfaceSymmTensorField&)` and its `epsilon`-taking overload, used
+  by the `uns` (cell-centred, face-based) solid models;
+- `correct(pointSymmTensorField&, const pointTensorField&)`, used by the
+  vertex-centred solid models;
+- `correct(CompactListList<symmTensor>&, const CompactListList<tensor>&)`, the
+  face quadrature-point form used by the higher-order vertex-centred path.
+
+The quadrature-point overload is guarded by `#ifndef FOAMEXTEND` in both the
+header and the source, so it is compiled only for the OpenFOAM.com and
+OpenFOAM.org forks. Everything else is common to all three forks; the law is
+listed in both `Make/files.openfoam` and `Make/files.foamextend`.
+
+### Construction
+
+The constructor stores old-time `epsilon` and `epsilonf`, reads the elastic
+pair, derives the remaining constants, validates `nu`, and finally reads
+`sigma0`. Note that the error messages emitted for a missing elastic pair name
+`linearElasticMisesPlastic` rather than `linearElastic`, a copy-paste artefact
+that does not affect behaviour.
+
+### Key methods
+
+- `impK()`: the implicit stiffness, `2*mu + lambda` (or `2*mu` for
+  `nu == 0.5`). This is the diffusivity of the Laplacian term in the solid
+  model's momentum equation and controls the outer-iteration convergence rate
+  rather than the converged answer.
+- `materialTangent()`: returns the full 6x6 isotropic elasticity matrix, used
+  by the block-coupled and PETSc SNES solid models.
+- `bulkModulus()`, `shearModulus()`: uniform fields with zero-gradient
+  boundaries, provided so that wrapper laws such as `thermoMechanicalLaw` can
+  query them generically.
+- `mu()`, `K()`, `E()`, `nu()`, `lambda()`: direct scalar accessors, used by
+  the coupled solid models.
+
+### Extension points
+
+A new isotropic elastic law is most cheaply written by copying this class and
+replacing the two `correct` bodies. If the new law has spatially varying
+properties, the `dimensionedScalar` members must become `volScalarField`
+members, and the scalar accessors above have to be dropped or reimplemented —
+see `linearElasticFromFile` for that pattern.
+
+The source is at
+[linearElastic.C](https://github.com/solids4foam/solids4foam/blob/master/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElastic/linearElastic.C).
+
+---
+
+## Tutorials
+
+`linearElastic` is used by most of the `solids/linearElasticity` cases, for
+example:
+
+- `solids/linearElasticity/plateHole`
+- `solids/linearElasticity/cooksMembrane`
+- `solids/linearElasticity/pressurisedCylinder`
+- `solids/linearElasticity/contactPatchTest`
+- `solids/beamsPlatesShells/squarePlate`
+- `solids/multiMaterial/layeredPipe`
+- `solids/fracture/crackingPlateHole`
+- `fluidSolidInteraction/3dTube`
+- `fluidSolidInteraction/perpendicularFlap`
+
+It is also the law nested inside `thermoMechanicalLaw` in every
+`solids/thermoelasticity` and `thermoFluidSolidInteraction` tutorial.

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticCt/README.md
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticCt/README.md
@@ -1,0 +1,250 @@
+---
+sort: 12
+---
+
+# linearElasticCt
+
+This page documents the small-strain elastic law that assigns a cell-wise
+Young's modulus from CT image values. The runtime type is:
+
+```text
+linearElasticCt
+```
+
+```warning
+`linearElasticCt.C` is listed in neither `Make/files.openfoam` nor
+`Make/files.foamextend`, so it is **not compiled** into the standard
+`solids4FoamModels` library. Its run-time registration therefore never
+happens, and selecting `linearElasticCt` in `mechanicalProperties` fails with
+an unknown-type error. The source is present and this page describes it, but
+the law has to be added to a build list before it can be used. This is tracked
+as [issue #336](https://github.com/solids4foam/solids4foam/issues/336); note
+that [issue #335](https://github.com/solids4foam/solids4foam/issues/335)
+applies to this law too once it is built.
+```
+
+---
+
+## User Guide
+
+### What it computes
+
+The law converts each selected CT value, `Hu`, to a relative density and then
+to Young's modulus:
+
+```text
+relRho = 0.000769*Hu + 1.028                 for Hu > 816
+relRho = max(0.0019*Hu + 0.105, 0.2)        otherwise
+
+E = 0.09*relRho^7.4*1e9                     for relRho > 1.54
+E = (0.06 + 0.9*relRho^2)*1e9               otherwise
+```
+
+Cells whose selected slice, row or column is on an outer CT-array index are
+instead assigned `Hu = 0`, `relRho = 0` and `E = 0`. The lookup uses one CT
+sample without interpolation. The row and column indices are reversed after
+they are found.
+
+The elastic coefficients and stress are then evaluated as implemented:
+
+```text
+mu     = E/(1 + nu)
+lambda = E*nu/((1 + nu)*(1 - 2*nu))         // plane strain / 3-D
+lambda = E*nu/((1 + nu)*(1 - nu))           // planeStress yes
+
+epsilon = symm(grad(D))
+sigma   = 2*mu*epsilon + lambda*tr(grad(D))*I
+```
+
+The law implements `correct(volSymmTensorField&)` and
+`correct(surfaceSymmTensorField&)`. Both abort with a fatal error for an
+incremental solid solver. The inherited point-tensor overload aborts with
+`notImplemented`. On non-foam-extend forks, the inherited
+`CompactListList` quadrature-point overload also aborts with
+`notImplemented`.
+
+### Model options
+
+| Entry | Required | Description |
+| --- | --- | --- |
+| `rho` | yes | Density, `[1 -3 0 0 0 0 0]` |
+| `nu` | yes | Poisson's ratio, dimensionless |
+| `constantE` | no | Use a uniform `E`; default `false` |
+| `value` | if `constantE` | Uniform `E`, read as a scalar with pressure units |
+| `nSlices` | for CT | Number of CT slices |
+| `nRows` | for CT | Number of rows per slice |
+| `nColumns` | for CT | Number of columns per row |
+| `sliceSpacing` | for CT | Slice spacing in mesh coordinate units |
+| `rowSpacing` | for CT | Row spacing in mesh coordinate units |
+| `columnSpacing` | for CT | Column spacing in mesh coordinate units |
+| `sliceOffset` | for CT | Offset in the mesh z direction |
+| `rowOffset` | for CT | Offset in the mesh y direction |
+| `columnOffset` | for CT | Offset in the mesh x direction |
+| `ctImagesFilePath` | for CT | Parent path of the `ctImages` directory |
+| `useRotationMatrix` | no | Rotate lookup coordinates; default `false` |
+| `vectorBeforeRotation` | if rotating | First direction vector |
+| `vectorAfterRotation` | if rotating | Second direction vector |
+| `centreOfRotation` | if rotating | Rotation centre in mesh coordinates |
+| `smooth` | no | Its presence enables smoothing |
+| `weight` | if smoothing | Weight retained from the current cell |
+| `nSmoothIters` | if smoothing | Number of smoothing iterations |
+| `bound` | no | Its presence enables a lower bound on `E` |
+| `boundLowerValue` | if bounding | Lower `E`, `[1 -1 -2 0 0 0 0]` |
+| `solvePressureEqn` | no | Base switch; default `false` |
+| `pressureSmoothingScaleFactor` | no | Base scalar; default `100` |
+| `regionName` | no | Base solid-mesh region name |
+
+`value`, the spacings and the offsets are read as plain scalars, so the code
+does not check their dimensions. The spacings and offsets are compared
+directly with the mesh cell-centre coordinates. The image files must be named
+`ct_scan_0.txt` through `ct_scan_<nSlices - 1>.txt` under
+`<ctImagesFilePath>/ctImages`. Each file is read in row-major order with
+`nRows*nColumns` scalar values.
+
+The presence of `smooth` or `bound` activates that operation; the value of
+either entry is not read. Smoothing is in-place and uses inverse-distance
+weighted neighbouring-cell values. `weight` blends the current value with
+the neighbour average. Bounding is applied after smoothing.
+
+The base class reads `solvePressureEqn` and
+`pressureSmoothingScaleFactor`, but this law does not call
+`updateSigmaHyd()`, so they do not change its stress calculation.
+`regionName` selects the solid model queried to determine whether the solver
+is incremental. If omitted, the base class searches for `solid` and then
+`region0`.
+
+### Recommended dictionary setup
+
+This example describes a femur CT volume with mesh coordinates in metres:
+
+```text
+planeStress     no;
+
+mechanical
+(
+    femur
+    {
+        type            linearElasticCt;
+        rho             rho [1 -3 0 0 0 0 0] 1900;
+        nu              nu [0 0 0 0 0 0 0] 0.3;
+
+        constantE       no;
+        nSlices         240;
+        nRows           512;
+        nColumns        512;
+        sliceSpacing    0.001;
+        rowSpacing      0.0005;
+        columnSpacing   0.0005;
+        sliceOffset     0;
+        rowOffset       -0.128;
+        columnOffset    -0.128;
+        ctImagesFilePath constant;
+
+        // Optional coordinate transformation
+        // useRotationMatrix    yes;
+        // vectorBeforeRotation (0 0 1);
+        // vectorAfterRotation  (0 1 0);
+        // centreOfRotation     (0 0 0);
+
+        // Optional smoothing
+        // smooth          yes;
+        // weight          0.5;
+        // nSmoothIters    5;
+
+        // Optional lower bound
+        // bound           yes;
+        // boundLowerValue Emin [1 -1 -2 0 0 0 0] 1e6;
+    }
+);
+```
+
+For a uniform pressure-valued modulus instead of CT data, set `constantE yes`
+and supply a scalar `value`, for example `value 17e9;`. The CT size, spacing,
+offset and path entries are then not read.
+
+### Field glossary
+
+- `E`: cell-wise Young's modulus. It has zero-gradient boundaries and is
+  explicitly written during construction.
+- `mu`: cell-wise coefficient `E/(1 + nu)` with its face interpolation
+  maintained in `muf_`.
+- `lambda`: cell-wise first Lame coefficient with its face interpolation
+  maintained in `lambdaf_`.
+- `Hu`: temporary cell-wise selected CT value, created only while `E` is
+  assembled from CT data.
+- `relRho`: temporary cell-wise relative density derived from `Hu`, created
+  only while `E` is assembled from CT data.
+
+---
+
+## Developer Notes
+
+### Class role
+
+`linearElasticCt` derives directly from `mechanicalLaw` and is registered in
+the linear-geometry mechanical-law selection table. It stores `E_`, `mu_` and
+`lambda_` as cell fields, `muf_` and `lambdaf_` as face fields, and `nu_` as a
+`dimensionedScalar`. Coordinate transformation is controlled by
+`useRotationMatrix_`, `rotationMatrix_` and `centreOfRotation_`.
+
+The header and source use `OPENFOAM_NOT_EXTEND` guards to select field-access
+APIs for OpenFOAM.com and OpenFOAM.org versus foam-extend. The inherited
+quadrature-point interface is guarded by `#ifndef FOAMEXTEND`. The source is
+currently listed in neither `Make/files.openfoam` nor
+`Make/files.foamextend`, so the law is not compiled into the standard library
+for any fork.
+
+### Construction
+
+The base constructor first reads `solvePressureEqn` and
+`pressureSmoothingScaleFactor`, selects `regionName`, and aborts if no solid
+region can be found. The derived constructor then creates zero-valued `E`,
+reads `nu`, creates the cell and face elastic-coefficient fields, and reads
+`useRotationMatrix`.
+
+When rotation is enabled, both direction vectors are read, normalised and used
+to construct the rotation tensor that maps the post-rotation direction back
+to the pre-rotation direction. A zero-magnitude direction causes a fatal
+error. The centre of rotation is then read.
+
+`setYoungsModulusFromCt()` next either assigns the uniform `value`, or reads
+the CT geometry and files, maps cell centres to image indices, evaluates the
+density and modulus correlations, optionally smooths and bounds `E`, and
+writes `E`. Failure to open an image file prints `Cannot open <file>.` but
+does not abort. Finally, the constructor recalculates all cell and face
+coefficients and substitutes the plane-stress expression for `lambda` when
+requested. It does not validate the range of `nu`.
+
+### Key methods
+
+- `impK()`: returns the cell-wise implicit stiffness `2*mu + lambda`. This is
+  the diffusivity of the solid model's Laplacian term and affects the
+  outer-iteration convergence rate rather than the converged answer.
+- `correct(volSymmTensorField&)`: looks up `grad(D)` and evaluates the
+  cell-centred stress. It rejects incremental solvers.
+- `correct(surfaceSymmTensorField&)`: looks up `grad(D)f` and evaluates the
+  face-centred stress from the interpolated coefficients. It rejects
+  incremental solvers.
+- `materialTangent()`: is not overridden; the inherited implementation aborts
+  with `notImplemented`.
+- `setYoungsModulusFromCt()`: builds `E` from a uniform value or the CT lookup,
+  then performs the optional smoothing and lower-bound operations.
+
+### Extension points
+
+A related image-driven law can copy this class and replace the CT-to-density
+and density-to-property relations in `setYoungsModulusFromCt()`. A different
+image layout requires changing the file-reading and coordinate-index mapping.
+New interfaces should override the corresponding base `correct` overload or
+`materialTangent()` rather than inheriting its `notImplemented` behaviour.
+The new source must also be added to the appropriate fork build lists and its
+runtime registration must remain in the linear-geometry selection table.
+
+The source is at
+[linearElasticCt.C](https://github.com/solids4foam/solids4foam/blob/master/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticCt/linearElasticCt.C).
+
+---
+
+## Tutorials
+
+No tutorial currently uses `linearElasticCt`.

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticFromFile/README.md
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticFromFile/README.md
@@ -1,0 +1,182 @@
+---
+sort: 13
+---
+
+# linearElasticFromFile
+
+This page documents the small-strain Hookean law that reads a cell-wise
+Young's modulus field from disk. The runtime type is:
+
+```text
+linearElasticFromFile
+```
+
+```warning
+The shear term of this law appears to be twice the Hookean value. It sets
+`mu = E/(1 + nu)`, whereas the shear modulus is `E/(2*(1 + nu))`, and then
+forms the stress as `mu*twoSymm(grad(D))`, which is `2*mu*epsilon`. The
+resulting deviatoric stress is therefore `2*E/(1 + nu)*epsilon` rather than
+`E/(1 + nu)*epsilon`. For comparison, `linearElastic` sets
+`mu = E/(2*(1 + nu))` for the same stress expression. The volumetric term and
+the `planeStress` handling are correct. Treat results from this law with
+caution until this is resolved; `linearElasticCt` contains the same
+expression. This is tracked as
+[issue #335](https://github.com/solids4foam/solids4foam/issues/335).
+```
+
+---
+
+## User Guide
+
+### What it computes
+
+The law reads the `E` field and evaluates the elastic coefficients as
+implemented:
+
+```text
+mu     = E/(1 + nu)
+lambda = E*nu/((1 + nu)*(1 - 2*nu))        // plane strain / 3-D
+lambda = E*nu/((1 + nu)*(1 - nu))          // planeStress yes
+
+epsilon = symm(grad(D))
+sigma   = 2*mu*epsilon + lambda*tr(grad(D))*I
+```
+
+The face-centred calculation uses interpolated `mu` and `lambda` fields with
+`grad(D)f` in the same relation.
+
+The law implements `correct(volSymmTensorField&)` and
+`correct(surfaceSymmTensorField&)`. Both abort with a fatal error for an
+incremental solid solver. The inherited point-tensor overload aborts with
+`notImplemented`. On non-foam-extend forks, the inherited
+`CompactListList` quadrature-point overload also aborts with
+`notImplemented`.
+
+### Model options
+
+| Entry | Required | Description |
+| --- | --- | --- |
+| `nu` | yes | Poisson's ratio, dimensionless |
+| `rho` | yes | Density, `[1 -3 0 0 0 0 0]` |
+| `solvePressureEqn` | no | Base switch; default `false` |
+| `pressureSmoothingScaleFactor` | no | Base scalar; default `100` |
+| `regionName` | no | Base solid-mesh region name |
+
+Young's modulus is not a dictionary entry. A volume scalar field named `E`
+must exist in the current time directory when the law is constructed. It is
+read with `MUST_READ` and marked `AUTO_WRITE`. Its dimensions must be pressure
+dimensions, `[1 -1 -2 0 0 0 0]`, for the field operations to be dimensionally
+consistent.
+
+The base class reads `solvePressureEqn` and
+`pressureSmoothingScaleFactor`, but this law does not call
+`updateSigmaHyd()`, so they do not change its stress calculation.
+`regionName` selects the solid model queried to determine whether the solver
+is incremental. If omitted, the base class searches for `solid` and then
+`region0`.
+
+The top-level `planeStress` entry selects the alternative expression for
+`lambda`. The constructor does not validate the range of `nu`.
+
+### Recommended dictionary setup
+
+This example describes an aluminium component whose spatially varying
+Young's modulus is supplied in the `E` volume field:
+
+```text
+planeStress     no;
+
+mechanical
+(
+    gradedAluminium
+    {
+        type            linearElasticFromFile;
+        rho             rho [1 -3 0 0 0 0 0] 2700;
+        nu              nu [0 0 0 0 0 0 0] 0.33;
+
+        // Optional base-class entries
+        // solvePressureEqn             no;
+        // pressureSmoothingScaleFactor 100;
+        // regionName                   region0;
+    }
+);
+```
+
+Place the pressure-dimensioned `E` field in the initial time directory before
+starting the solver. Its internal and boundary values define the spatial
+distribution used by the law.
+
+### Field glossary
+
+- `E`: cell-wise Young's modulus, read from the current time directory and
+  marked for automatic writing.
+- `mu`: cell-wise coefficient `E/(1 + nu)`.
+- `lambda`: cell-wise first Lame coefficient, with the plane-stress form used
+  when requested.
+- `muf_`, `lambdaf_`: face interpolations of `mu` and `lambda`, calculated
+  during construction.
+- `grad(D)`, `grad(D)f`: solver-provided displacement-gradient fields looked
+  up by the cell-centred and face-centred stress corrections.
+- `impK`: temporary cell field containing `2*mu + lambda`.
+
+---
+
+## Developer Notes
+
+### Class role
+
+`linearElasticFromFile` derives directly from `mechanicalLaw` and is
+registered in the linear-geometry mechanical-law selection table. It stores
+`E_`, `mu_` and `lambda_` as cell fields, `muf_` and `lambdaf_` as face
+fields, and `nu_` as a `dimensionedScalar`.
+
+The header uses `#ifdef OPENFOAM_NOT_EXTEND` only to include the surface-field
+API for OpenFOAM.com and OpenFOAM.org. The inherited quadrature-point
+interface is guarded by `#ifndef FOAMEXTEND`. The source is listed in both
+`Make/files.openfoam` and `Make/files.foamextend`.
+
+### Construction
+
+The base constructor first reads `solvePressureEqn` and
+`pressureSmoothingScaleFactor`, selects `regionName`, and aborts if no solid
+region can be found. The derived constructor then reads `E` from the current
+time directory, reads `nu`, calculates `mu` and `lambda`, and interpolates the
+two coefficients to faces. If `planeStress` is enabled, it replaces `lambda`
+with the plane-stress expression and interpolates that field again.
+
+A missing or unreadable `E` field causes the mandatory field read to abort.
+Both `correct` methods emit `Not implemented for incremental solid solver` as
+a fatal error when the selected solid model is incremental. The constructor
+does not issue a warning or validate `nu`.
+
+### Key methods
+
+- `impK()`: returns the cell-wise implicit stiffness `2*mu + lambda`. This is
+  the diffusivity of the solid model's Laplacian term and affects the
+  outer-iteration convergence rate rather than the converged answer.
+- `correct(volSymmTensorField&)`: looks up `grad(D)` and evaluates the
+  cell-centred stress. It rejects incremental solvers.
+- `correct(surfaceSymmTensorField&)`: looks up `grad(D)f` and evaluates the
+  face-centred stress from the interpolated coefficients. It rejects
+  incremental solvers.
+- `materialTangent()`: is not overridden; the inherited implementation aborts
+  with `notImplemented`.
+
+### Extension points
+
+A related spatially varying elastic law can copy this class and replace the
+`E` field read or the coefficient relations. A law that must support
+incremental, point-centred or quadrature-point solid models must implement the
+corresponding `correct` overloads. Newton-based models also require a
+`materialTangent()` override. The new source must remain in the appropriate
+fork build lists and its runtime registration must use the intended geometry
+selection table.
+
+The source is at
+[linearElasticFromFile.C](https://github.com/solids4foam/solids4foam/blob/master/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticFromFile/linearElasticFromFile.C).
+
+---
+
+## Tutorials
+
+No tutorial currently uses `linearElasticFromFile`.

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticMisesPlastic/README.md
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticMisesPlastic/README.md
@@ -1,0 +1,232 @@
+---
+sort: 5
+---
+
+# linearElasticMisesPlastic
+
+This page documents the small-strain elasto-plastic mechanical law with
+Hookean elasticity and von Mises (J2) plasticity. The runtime type is:
+
+```text
+linearElasticMisesPlastic
+```
+
+The return-mapping algorithm is the radial return of Box 3.2 in Simo and
+Hughes, _Computational Inelasticity_ (1998). The implementation is described
+in P. Cardiff, Z. Tuković, P. De Jaeger, M. Clancy and A. Ivanković (2017), _A
+Lagrangian cell-centred finite volume method for metal forming simulation_,
+[10.1002/nme.5345](https://doi.org/10.1002/nme.5345).
+
+---
+
+## User Guide
+
+### What it computes
+
+For each cell and each boundary face the law performs an elastic trial
+followed by a radial return:
+
+```text
+sTrial   = 2*mu*(dev(epsilon) - dev(epsilonP.oldTime()))
+fTrial   = mag(sTrial) - sqrt(2/3)*sigmaY.oldTime()
+```
+
+If `fTrial` is below `SMALL` the step is elastic. Otherwise the return
+direction is `plasticN = sTrial/mag(sTrial)` and a plastic multiplier
+increment `DLambda` is computed. The deviatoric and hydrostatic parts are then
+recombined:
+
+```text
+DEpsilonP = DLambda*plasticN
+s         = sTrial - 2*mu*DEpsilonP
+sigmaHyd  = K*tr(epsilon)
+sigma     = sigmaHyd*I + s
+```
+
+`sigmaHyd` is routed through `updateSigmaHyd()`, so it comes from the smoothed
+pressure equation when `solvePressureEqn` is enabled.
+
+### Hardening input
+
+The post-yield behaviour is supplied as a table of equivalent plastic strain
+versus yield stress, read by an `interpolationTable`. The number of rows in
+that table decides the algorithm:
+
+| Rows | Behaviour | Solution method |
+| --- | --- | --- |
+| 1 | Perfect plasticity | Closed form |
+| 2 | Linear hardening | Closed form, modulus `Hp` |
+| 3 or more | Nonlinear hardening | Newton iteration per cell |
+
+With one or two rows, `DLambda = fTrial/(2*mu)`, divided by `1 + Hp/(3*mu)`
+when the linear plastic modulus `Hp` is non-zero. With three or more rows a
+local Newton loop solves the yield function to a relative tolerance of `1e-8`
+in at most 100 iterations, using a first-order finite difference derivative
+with a step of `1e-6`; a warning is printed if it fails to converge.
+
+### Model options
+
+| Entry | Required | Description |
+| --- | --- | --- |
+| `E` | with `nu` | Young's modulus, `[1 -1 -2 0 0 0 0]` |
+| `nu` | with `E` | Poisson's ratio, dimensionless |
+| `mu` | with `K` | Shear modulus, `[1 -1 -2 0 0 0 0]` |
+| `K` | with `mu` | Bulk modulus, `[1 -1 -2 0 0 0 0]` |
+| `rho` | yes | Density, `[1 -3 0 0 0 0 0]` |
+| `file` or `fileName` | yes | Hardening table file |
+| `outOfBounds` | yes | `interpolationTable` bounds handling |
+
+As for `linearElastic`, the elastic constants are given as either the `E`/`nu`
+pair or the `mu`/`K` pair, and a missing pair is a fatal error.
+
+The hardening table entries are those of the standard OpenFOAM
+`interpolationTable` constructed from a dictionary. Tutorials write the file
+key as `"file|fileName"` so that the same dictionary works across forks, and
+set `outOfBounds clamp`. The referenced file contains a list of
+`(plasticStrain yieldStress)` pairs.
+
+Two further entries are read outside the material sub-dictionary or in a way
+worth flagging:
+
+| Entry | Where | Description |
+| --- | --- | --- |
+| `maxDeltaErr` | `controlDict` | Target plastic-strain integration error |
+| `tangentEps` | material dict | Perturbation for the numerical tangent |
+
+`maxDeltaErr` defaults to `0.01` and is only consulted when the solid model
+requests adaptive time-stepping through `newDeltaT()`. `tangentEps` is read
+with `lookup()` — that is, it is required, with no default — but only inside
+`materialTangentField()`, so it is needed only by the block-coupled and PETSc
+SNES solid models.
+
+```warning
+The constructor also reads a `solvePressureEquation` switch (default `no`),
+but that member is never used anywhere else in the class. The switch that
+actually takes effect is the base-class `solvePressureEqn`. Do not rely on
+`solvePressureEquation`.
+```
+
+`planeStress yes` is a fatal error. The header suggests the workaround of
+solving in 3-D with a `symmetryPlane` back patch and a traction-free front
+patch.
+
+### Recommended dictionary setup
+
+```text
+planeStress     no;
+
+mechanical
+(
+    aluminium
+    {
+        type            linearElasticMisesPlastic;
+        rho             rho [1 -3 0 0 0 0 0] 2700;
+        E               E [1 -1 -2 0 0 0 0] 70e9;
+        nu              nu [0 0 0 0 0 0 0] 0.3;
+        "file|fileName" "$FOAM_CASE/constant/plasticStrainVsYieldStress";
+        outOfBounds     clamp;
+        solvePressureEqn no;
+    }
+);
+```
+
+with `constant/plasticStrainVsYieldStress` containing, for example:
+
+```text
+(
+    (0    250e6)
+    (0.1  300e6)
+    (0.5  400e6)
+)
+```
+
+### Field glossary
+
+Written to the time directory (`AUTO_WRITE`):
+
+- `sigmaY`, `sigmaYf`, `pSigmaY`: current yield stress at cells, faces and
+  points. All three are `READ_IF_PRESENT`, so a restart picks up the hardened
+  state.
+- `epsilonP`, `epsilonPf`, `pEpsilonP`: accumulated plastic strain tensor.
+- `epsilonPEq`, `epsilonPEqf`, `pEpsilonPEq`: accumulated equivalent plastic
+  strain.
+- `DEpsilonP`, `DEpsilonPf`: plastic strain increment for the current step.
+- `DEpsilonPEq`, `DEpsilonPEqf`: equivalent plastic strain increment.
+- `activeYield`: `1` in cells that yielded in the current step, `0` elsewhere.
+
+Internal only: `plasticN`, `plasticNf`, `pPlasticN` (return direction),
+`DLambda`, `DLambdaf`, `pDLambda` (plastic multiplier increment) and
+`DSigmaY`, `DSigmaYf`, `pDSigmaY` (yield-stress increment).
+
+`updateTotalFields()` prints the maximum `DEpsilonPEq`, the maximum
+`epsilonPEq` and the number of actively yielding cells at the end of each time
+step; those three lines are the quickest health check on a plastic run.
+
+---
+
+## Developer Notes
+
+### Class role
+
+`linearElasticMisesPlastic` derives from `mechanicalLaw` and maintains a
+complete triple of state fields — cell, face and point — for every plastic
+quantity. This is what allows it to serve the cell-centred, face-based (`uns`)
+and vertex-centred solid models from one class. It is compiled for all three
+forks, appearing in both `Make/files.openfoam` and `Make/files.foamextend`.
+
+Note that the class is registered with a debug level of `1`, unlike the other
+laws in this subsection which use `0`.
+
+### Construction
+
+The initialiser list builds the `interpolationTable` first, because the
+initial yield stress `stressPlasticStrainSeries_(0.0)` is needed as the
+uniform value of `sigmaY`, `sigmaYf` and `pSigmaY`. The body then forces
+old-time storage for every state field, reads the elastic pair, and classifies
+the hardening as perfect, linear or nonlinear, computing `Hp_` in the linear
+case.
+
+### Key methods
+
+- `updatePlasticity()`: the per-point kernel. It is called once per cell and
+  once per boundary face from `correct()`, and decides between the elastic
+  branch and the return mapping.
+- `newtonLoop()`: local Newton solve for `DLambda` in the nonlinear hardening
+  case, calling `yieldFunction()` twice per iteration.
+- `correct(volSymmTensorField&)`: the full cell-centred update, ending with
+  `updateSigmaHyd()`. The surface overload delegates to a shared
+  `epsilon`-taking implementation.
+- `residual()`: relative change in `DEpsilonP` (or `DEpsilonPf`, if a face
+  gradient field exists) between outer iterations. This feeds the solid
+  model's `materialTolerance` check.
+- `newDeltaT()`: estimates the plastic-strain time integration error from the
+  rotation of the return direction over the step, following Lee and Bathe
+  (1994), and scales `deltaT` so that the error matches `maxDeltaErr`. It warns
+  if the error exceeds 50 times the target.
+- `impK()`, `impKdiagTensor()`: scalar and diagonal-tensor implicit
+  stiffnesses.
+- `materialTangentField()`: builds a per-face 6x6 tangent by numerical
+  perturbation of `grad(D)f`, one symmetric-tensor component at a time. The
+  branch is preceded by a commented-out `numericalTangent` lookup; there is
+  currently no analytic alternative.
+
+### Extension points
+
+- Replacing the `interpolationTable` with a run-time selectable hardening law
+  would remove the row-count-based dispatch in the constructor.
+- The Newton loop constants (`LoopTol_`, `MaxNewtonIter_`, `finiteDiff_`) are
+  compile-time members rather than dictionary entries; exposing them would
+  help for materials with steep hardening curves.
+- Kinematic hardening would require a back-stress field alongside `sigmaY` and
+  a modified `sTrial`.
+
+The source is at
+[linearElasticMisesPlastic.C](https://github.com/solids4foam/solids4foam/blob/master/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticMisesPlastic/linearElasticMisesPlastic.C).
+
+---
+
+## Tutorials
+
+Cases that select `linearElasticMisesPlastic`:
+
+- `solids/elastoplasticity/perforatedPlate`

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticMohrCoulombPlastic/README.md
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticMohrCoulombPlastic/README.md
@@ -1,0 +1,207 @@
+---
+sort: 6
+---
+
+# linearElasticMohrCoulombPlastic
+
+This law combines incremental isotropic Hookean elasticity with a
+principal-stress Mohr-Coulomb return calculation. The runtime type is:
+
+```text
+linearElasticMohrCoulombPlastic
+```
+
+---
+
+## User Guide
+
+### What it computes
+
+The cell-centred and face-centred `correct` functions form a trial stress from
+the strain increment and the stress variation stored at the old time:
+
+```text
+DEpsilon   = epsilon - epsilon.oldTime()
+DSigmaTrial = 2*mu*DEpsilon + lambda*tr(DEpsilon)*I
+sigmaTrial  = deltaSigma.oldTime() + DSigmaTrial + sigma0
+
+mu     = E/(2*(1 + nu))
+lambda = nu*E/((1 + nu)*(1 - 2*nu))        // plane strain / 3-D
+lambda = nu*E/((1 + nu)*(1 - nu))          // planeStress yes
+```
+
+The code obtains the principal stresses, orders them as `sigma1 >= sigma2 >=
+sigma3`, and evaluates
+
+```text
+k = (1 + sin(frictionAngle))/(1 - sin(frictionAngle))
+m = (1 + sin(dilationAngle))/(1 - sin(dilationAngle))
+f = k*sigma1 - sigma3 - 2*cohesion*sqrt(k)
+```
+
+The angles are read in degrees and converted to radians in the sine
+expressions. If `f > SMALL`, `calculateStress()` applies a non-associated
+return in principal-stress space. It uses `k` for the yield surface and `m`
+for the plastic-potential direction, and selects a plane, an edge, or the apex
+according to its projection tests. The returned principal stresses are then
+transformed back to tensor form. Otherwise, the elastic trial stress is kept.
+
+The law implements `correct(volSymmTensorField&)` and
+`correct(surfaceSymmTensorField&)`. The inherited point-centred overload aborts
+with `notImplemented`. On OpenFOAM.com and OpenFOAM.org, the inherited
+`CompactListList` quadrature-point overload also aborts with `notImplemented`;
+that overload is not compiled for foam-extend.
+
+### Model options
+
+| Entry | Required | Description |
+| --- | --- | --- |
+| `E` | yes | Young's modulus, `[1 -1 -2 0 0 0 0]` |
+| `nu` | yes | Poisson's ratio, `[0 0 0 0 0 0 0]` |
+| `frictionAngle` | yes | Friction angle in degrees, dimensionless |
+| `cohesion` | yes | Cohesion, `[1 -1 -2 0 0 0 0]` |
+| `dilationAngle` | yes | Dilation angle in degrees, dimensionless |
+| `rho` | yes | Density, `[1 -3 0 0 0 0 0]` |
+| `solvePressureEqn` | no | Base switch; default `no` |
+| `pressureSmoothingScaleFactor` | no | Base scalar; default `100` |
+| `regionName` | no | Base mesh region name override |
+
+`planeStress` is read from the enclosing `mechanicalProperties` dictionary,
+not from the law dictionary. It changes the value of `lambda` as shown above.
+The constructor does not check the ranges of `nu`, `frictionAngle`, or
+`dilationAngle`.
+
+The base class reads `solvePressureEqn` and
+`pressureSmoothingScaleFactor`, but this law never calls
+`updateSigmaHyd()`. Consequently, those entries do not alter its stress
+calculation. `regionName` is used when the base class finds the solid model,
+and `rho` is read when the solid model requests the density.
+
+Initial stress is supplied through the `sigma0` field. It is not a dictionary
+entry read by this law.
+
+### Recommended dictionary setup
+
+```text
+planeStress     no;
+
+mechanical
+(
+    soil
+    {
+        type            linearElasticMohrCoulombPlastic;
+        rho             rho [1 -3 0 0 0 0 0] 2000;
+        E               E [1 -1 -2 0 0 0 0] 20e6;
+        nu              nu [0 0 0 0 0 0 0] 0.3;
+        frictionAngle   frictionAngle [0 0 0 0 0 0 0] 30;
+        cohesion        cohesion [1 -1 -2 0 0 0 0] 1e5;
+        dilationAngle   dilationAngle [0 0 0 0 0 0 0] 0;
+
+        // Optional for a non-standard solid region
+        // regionName   solid;
+    }
+);
+```
+
+### Field glossary
+
+- `epsilon_`, `epsilonf_`: cell- and face-centred small-strain fields; both
+  read if present and retain old-time values.
+- `deltaSigma_`, `deltaSigmaf`: stress variation from `sigma0` at cells and
+  faces. They are neither read nor written.
+- `DEpsilon`, `DEpsilonf`: cell and face strain increments. They are read if
+  present and not written.
+- `DEpsilonP`, `DEpsilonPf`: cell and face plastic-strain increments.
+  `DEpsilonP` is read if present and written; `DEpsilonPf` is neither read nor
+  written.
+- `epsilonP`: accumulated cell-centred plastic strain, written at output
+  times.
+- `epsilonPEq`: accumulated equivalent plastic strain, written at output
+  times.
+- `activeYield`: cell-centred yielding flag, read if present and written; `1`
+  denotes active yielding and `0` denotes an elastic state.
+- `sigma0`, `sigma0f`: initial stress at cells and its face interpolation,
+  maintained by the base class.
+
+---
+
+## Developer Notes
+
+### Class role
+
+`linearElasticMohrCoulombPlastic` derives directly from `mechanicalLaw` and is
+registered in the `linGeomMechLaw` runtime-selection table. It stores the
+elastic constants `E_`, `nu_`, `lambda_`, `mu_`, and `K_`; the three input
+plasticity properties; the derived return-mapping vectors and tensors; and the
+stress, strain-increment, plastic-strain, and yielding fields listed above.
+
+The law is listed in both `Make/files.openfoam` and `Make/files.foamextend`.
+The implementation uses `OPENFOAM_NOT_EXTEND` guards for mathematical
+constants and field access, and an `OPENFOAM_COM` guard for face addressing.
+The inherited quadrature-point interface is guarded by `#ifndef FOAMEXTEND`.
+
+### Construction
+
+The base constructor first reads `solvePressureEqn` and
+`pressureSmoothingScaleFactor`, then selects `regionName` explicitly or finds
+`solid` or `region0`. Failure to find a solid region causes a fatal error.
+
+The derived constructor then reads `E`, `nu`, `frictionAngle`, `cohesion`, and
+`dilationAngle`. It derives `lambda`, `mu`, `K`, `k`, `m`, the elastic
+principal-stress matrix and its inverse, the plane and edge directions, and
+the apex stress. It constructs all history and output fields, stores old-time
+values for `epsilon` and `epsilonf`, and creates `sigma0`.
+
+Missing required entries or entries with incompatible dimensions fail during
+dictionary lookup. A zero `sigma0` field produces a warning because the return
+calculation is stress-state dependent. During stress correction, the custom
+eigensolver can warn about a zero root, complex eigenvalues, or eigenvectors
+that it cannot determine; the latter two conditions replace the affected
+values with zero.
+
+### Key methods
+
+- `impK()`: returns the uniform field `2*mu + lambda`. This is the diffusivity
+  of the solid model's implicit Laplacian term and affects the outer-iteration
+  convergence rate rather than the converged answer.
+- `correct(volSymmTensorField&)`: updates cell strain, forms the incremental
+  trial stress, returns every cell and boundary value to the yield surface
+  when required, and stores `deltaSigma_` for the residual calculation.
+- `correct(surfaceSymmTensorField&)`: performs the same operation on faces and
+  transfers each internal-face yielding result to its owner and neighbour
+  cells.
+- `calculateStress()`: perturbs positive tensor components slightly, computes
+  principal values and directions, evaluates the yield function, and applies
+  the plane, edge, or apex return.
+- `calculateEigens()`: computes eigenvalues analytically and reconstructs the
+  associated eigenvectors from sub-determinants.
+- `residual()`: returns the global maximum relative change in cell or face
+  `deltaSigma`, choosing the face form when a face displacement-gradient field
+  exists.
+- `updateTotalFields()`: reconstructs the plastic-strain increment in yielding
+  cells, accumulates `epsilonP` and `epsilonPEq`, and reports their maxima and
+  the number of yielding cells.
+- `materialTangent()`: is not overridden. Calling the inherited implementation
+  aborts with `notImplemented`.
+
+### Extension points
+
+A related small-strain pressure-dependent plastic law can copy this class and
+replace the yield test and the plane, edge, and apex return data in
+`calculateStress()`. A new implementation must keep the cell and face paths
+consistent, update the plastic history in `updateTotalFields()`, and add a
+material tangent if it is to be used by Newton or block-coupled paths that
+request one.
+
+The source is at
+[linearElasticMohrCoulombPlastic.C](https://github.com/solids4foam/solids4foam/blob/master/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticMohrCoulombPlastic/linearElasticMohrCoulombPlastic.C).
+
+---
+
+## Tutorials
+
+- `solids/poroelasticity/stripFooting`
+- `solids/poroelasticity/suctionCaission`
+
+Both cases select this law inside the `effectiveStressMechanicalLaw`
+sub-dictionary of `poroMechanicalLaw`.

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/orthotropicLinearElastic/README.md
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/orthotropicLinearElastic/README.md
@@ -1,0 +1,196 @@
+---
+sort: 4
+---
+
+# orthotropicLinearElastic
+
+This page documents the orthotropic Hookean linear elastic mechanical law. The
+runtime type is:
+
+```text
+orthotropicLinearElastic
+```
+
+The law relates stress to strain through nine independent elastic constants:
+three Young's moduli, three shear moduli and three Poisson's ratios. The
+constants are given in a local material coordinate system, which under
+foam-extend can then be rotated into global Cartesian coordinates using
+per-cell material direction fields.
+
+The formulation follows P. Cardiff, A. Karač and A. Ivanković (2014), _A large
+strain finite volume method for orthotropic bodies with general material
+orientations_, Computer Methods in Applied Mechanics and Engineering, 268(1),
+318-335,
+[10.1016/j.cma.2013.09.008](https://doi.org/10.1016/j.cma.2013.09.008).
+
+---
+
+## User Guide
+
+### What it computes
+
+The law builds a fourth-order stiffness tensor `C` from the nine constants and
+evaluates
+
+```text
+sigma = C && epsilon
+```
+
+at cell centres and at faces. Only these two `correct` overloads are
+implemented, so the law works with the cell-centred and face-based solid
+models but not with the vertex-centred ones.
+
+### Model options
+
+All nine entries below are read with `lookup()` and are therefore
+**required**; the law aborts at construction if any is missing.
+
+| Entry | Dimensions | Description |
+| --- | --- | --- |
+| `E1` | `[1 -1 -2 0 0 0 0]` | Young's modulus, local 1 direction |
+| `E2` | `[1 -1 -2 0 0 0 0]` | Young's modulus, local 2 direction |
+| `E3` | `[1 -1 -2 0 0 0 0]` | Young's modulus, local 3 direction |
+| `nu12` | dimensionless | Poisson's ratio, 1-2 plane |
+| `nu23` | dimensionless | Poisson's ratio, 2-3 plane |
+| `nu31` | dimensionless | Poisson's ratio, 3-1 plane |
+| `G12` | `[1 -1 -2 0 0 0 0]` | Shear modulus, 1-2 plane |
+| `G23` | `[1 -1 -2 0 0 0 0]` | Shear modulus, 2-3 plane |
+| `G31` | `[1 -1 -2 0 0 0 0]` | Shear modulus, 3-1 plane |
+
+The reciprocal ratios are derived rather than read:
+
+```text
+nu21 = nu12*E2/E1
+nu32 = nu23*E3/E2
+nu13 = nu31*E1/E3
+```
+
+`rho` is also required, as for every mechanical law.
+
+### Material directions (foam-extend only)
+
+Under foam-extend, three optional vector entries set the local material axes:
+
+| Entry | Default | Description |
+| --- | --- | --- |
+| `materialDirectionX` | `(1 0 0)` | Local 1 axis |
+| `materialDirectionY` | `(0 1 0)` | Local 2 axis |
+| `materialDirectionZ` | `(0 0 1)` | Local 3 axis |
+
+Each is used as the uniform value of a corresponding `materialDirectionsX`,
+`materialDirectionsY` or `materialDirectionsZ` field, which is itself
+`READ_IF_PRESENT`. Supplying those fields in the time directory therefore
+gives a spatially varying material orientation, which is the point of the law.
+The vectors are normalised at construction and must be locally orthogonal and
+of non-zero length.
+
+```warning
+Under OpenFOAM.com and OpenFOAM.org these fields are constructed `NO_READ`
+with hard-coded global axes, and the rotation of `C` into global coordinates
+is skipped entirely. With those forks the law is restricted to materials whose
+principal axes coincide with the global x, y and z axes; the
+`materialDirection*` entries are ignored.
+```
+
+### Physical constraints
+
+The constructor rejects a configuration if any of the following holds:
+
+- `planeStress` is `yes` — the law is not implemented for plane stress;
+- any of `E1`, `E2`, `E3`, `G12`, `G23`, `G31` is negative;
+- `mag(nu_ij) >= sqrt(E_i/E_j)` for any of the three supplied ratios;
+- `1 - nu12*nu21 - nu23*nu32 - nu31*nu13 - 2*nu21*nu32*nu13 <= 0`, which is
+  the positive-definiteness condition on the compliance matrix.
+
+### Recommended dictionary setup
+
+```text
+planeStress     no;
+
+mechanical
+(
+    composite
+    {
+        type            orthotropicLinearElastic;
+        rho             rho [1 -3 0 0 0 0 0] 1600;
+
+        E1              E1 [1 -1 -2 0 0 0 0] 140e9;
+        E2              E2 [1 -1 -2 0 0 0 0] 10e9;
+        E3              E3 [1 -1 -2 0 0 0 0] 10e9;
+
+        nu12            nu12 [0 0 0 0 0 0 0] 0.3;
+        nu23            nu23 [0 0 0 0 0 0 0] 0.4;
+        nu31            nu31 [0 0 0 0 0 0 0] 0.021;
+
+        G12             G12 [1 -1 -2 0 0 0 0] 5e9;
+        G23             G23 [1 -1 -2 0 0 0 0] 3.6e9;
+        G31             G31 [1 -1 -2 0 0 0 0] 5e9;
+
+        // foam-extend only
+        // materialDirectionX (1 0 0);
+        // materialDirectionY (0 1 0);
+        // materialDirectionZ (0 0 1);
+    }
+);
+```
+
+### Field glossary
+
+- `epsilon`, `epsilonf`: small-strain tensor at cells and faces, with old-time
+  values stored.
+- `elasticC`, `elasticCf`: the stiffness tensor at cells and faces, built on
+  first use.
+- `materialDirectionsX/Y/Z`: unit vector fields defining the local axes
+  (foam-extend only).
+- `impK`: implicit stiffness, the mean of the three normal-direction diagonal
+  stiffnesses.
+
+---
+
+## Developer Notes
+
+### Class role
+
+`orthotropicLinearElastic` derives from `mechanicalLaw`. Its distinguishing
+feature is a fork-dependent storage type for the stiffness tensor:
+
+- under foam-extend, `volSymmTensor4thOrderField` / its surface counterpart,
+  which support `transform()` and the `&&` double-inner-product directly;
+- under OpenFOAM, a plain `volTensorField` is used to hold the same nine
+  components, with the packing documented in the header:
+  `XXXX, XXYY, XXZZ, YYYY, YYZZ, ZZZZ, XYXY, YZYZ, ZXZX` mapped onto the
+  tensor components `XX, XY, XZ, YX, YY, YZ, ZX, ZY, ZZ`. The double product
+  is then performed by the free function in `doubleDotProduct.H`.
+
+The law is listed in both `Make/files.openfoam` and `Make/files.foamextend`.
+
+### Construction
+
+Elastic constants are read directly in the initialiser list; the derived
+ratios, the direction fields and the physical checks follow. `elasticC` and
+`elasticCf` are _not_ built in the constructor: `makeElasticC()` and
+`makeElasticCf()` are called lazily on first access through `elasticC()` and
+`elasticCf()`, each guarded against double initialisation.
+
+### Key methods
+
+- `impK()`: returns `(C_XXXX + C_YYYY + C_ZZZZ)/3`. The code notes that a
+  `diagTensor` implicit stiffness would be more faithful, but that the
+  averaged scalar achieves comparable convergence.
+- `correct(volSymmTensorField&)`, `correct(surfaceSymmTensorField&)`: update
+  the strain then apply the double product.
+
+Both `makeElasticC()` and `makeElasticCf()` recompute the same `A11` through
+`A66` coefficients from scratch; the duplication is harmless because each runs
+at most once.
+
+### Extension points
+
+Adding the missing global rotation for the OpenFOAM forks is the obvious
+improvement: it requires a `transform()` equivalent for the nine-component
+tensor packing, after which the `#ifdef FOAMEXTEND` guards around the
+direction fields can be removed. Implementing `materialTangent()` would also
+let the law be used by the block-coupled and PETSc SNES solid models.
+
+The source is at
+[orthotropicLinearElastic.C](https://github.com/solids4foam/solids4foam/blob/master/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/orthotropicLinearElastic/orthotropicLinearElastic.C).

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/poroMechanicalLaw/README.md
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/poroMechanicalLaw/README.md
@@ -1,0 +1,189 @@
+---
+sort: 7
+---
+
+# poroMechanicalLaw
+
+This page documents the linear-geometry wrapper that obtains effective stress
+from another run-time selectable mechanical law and subtracts a scaled pore
+pressure. The runtime type is:
+
+```text
+poroMechanicalLaw
+```
+
+---
+
+## User Guide
+
+### What it computes
+
+The law asks the nested mechanical law to update the effective stress and then
+forms the total stress as
+
+```text
+sigma = sigmaEff - b*(p + p0)*I
+```
+
+where `b` is the Biot coefficient. For a face-centred stress field, the current
+pressure and initial pressure are interpolated to the faces:
+
+```text
+pf    = interpolate(p)
+p0f   = interpolate(p0)
+sigma = sigmaEfff - b*(pf + p0f)*I
+```
+
+On the first call, the effective-stress field is initialised by adding the pore
+term to the supplied total stress. Subsequent calls retain that field and pass
+it to the nested law.
+
+The law implements `correct(volSymmTensorField&)` and
+`correct(surfaceSymmTensorField&)`. The point-centred overload is inherited
+from `mechanicalLaw` and aborts with `notImplemented`. The
+`CompactListList` quadrature-point overload is also inherited and aborts with
+`notImplemented`; that overload is compiled only when `FOAMEXTEND` is not
+defined. The nested effective-stress law must itself implement whichever of the
+cell- or face-centred overloads the selected solid model calls.
+
+### Model options
+
+| Entry | Required | Description |
+| --- | --- | --- |
+| `effectiveStressMechanicalLaw` | yes | Nested mechanical-law dictionary |
+| `biotCoeff` | no | Biot coefficient, dimensionless; default `1.0` |
+| `pressureFieldName` | no | Pressure field name; default `p` |
+| `pressureFieldRegion` | no | Pressure field region; default `region0` |
+| `p0` | no | Uniform initial pore pressure; default `0`, `[1 -1 -2 0 0 0 0]` |
+| `rho` | yes | Density, `[1 -3 0 0 0 0 0]` |
+| `regionName` | no | Base solid-region name; otherwise detected |
+| `solvePressureEqn` | no | Base switch; default `no`, unused by this wrapper |
+| `pressureSmoothingScaleFactor` | no | Default `100`; unused by this wrapper |
+
+The nested dictionary must contain its own `type` and all entries required by
+that law. Density belongs to the outer dictionary because `rho()` reads it from
+the wrapper's dictionary.
+
+Pressure lookup first checks `pressureFieldRegion`. If that registry does not
+exist, the law falls back to the `solid` registry. It does not fall back when
+the selected registry exists but does not contain `pressureFieldName`.
+
+The outer `solvePressureEqn` and `pressureSmoothingScaleFactor` entries are read
+by the base constructor, but this wrapper never calls `updateSigmaHyd()`, so
+they do not alter its pore-pressure term. A nested law may read and use its own
+copies of those entries.
+
+### Recommended dictionary setup
+
+The following setup represents a saturated soil with an isotropic linear
+elastic effective-stress response:
+
+```text
+planeStress     no;
+
+mechanical
+(
+    saturatedSoil
+    {
+        type            poroMechanicalLaw;
+        rho             rho [1 -3 0 0 0 0 0] 2000;
+
+        effectiveStressMechanicalLaw
+        {
+            type        linearElastic;
+            E           E [1 -1 -2 0 0 0 0] 20e6;
+            nu          nu [0 0 0 0 0 0 0] 0.3;
+        }
+
+        // Optional
+        // biotCoeff          biotCoeff [0 0 0 0 0 0 0] 1.0;
+        // pressureFieldName  p;
+        // pressureFieldRegion region0;
+        // p0                 p0 [1 -1 -2 0 0 0 0] 0;
+    }
+);
+```
+
+### Field glossary
+
+- `sigmaEff`: cell-centred effective stress, created on the first cell-centred
+  update and written automatically.
+- `sigmaEfff`: face-centred effective stress, created on the first face-centred
+  update and written automatically.
+- `p`: externally maintained cell-centred pressure field; its actual name is
+  selected by `pressureFieldName`.
+- `p0`: uniform cell-centred initial pore pressure, held by the law and neither
+  read nor written as a field.
+- `p0f`: demand-created face interpolation of `p0`.
+- `biotCoeff`: temporary uniform cell field returned by `biotCoeff()` and not
+  written.
+
+---
+
+## Developer Notes
+
+### Class role
+
+`poroMechanicalLaw` derives directly from `mechanicalLaw` and is registered in
+the `linGeomMechLaw` selection table. It owns the nested law through an
+`autoPtr<mechanicalLaw>`, keeps demand-created cell and face effective-stress
+fields, and stores the Biot coefficient, pressure field name, pressure region,
+initial pressure field and a pointer to its face interpolation.
+
+The class contains no `FOAMEXTEND` preprocessor guards. Its source appears in
+both `Make/files.openfoam` and `Make/files.foamextend`. The inherited
+quadrature-point interface is absent from foam-extend because that interface is
+guarded by `#ifndef FOAMEXTEND` in `mechanicalLaw`.
+
+### Construction
+
+The `mechanicalLaw` constructor first reads `solvePressureEqn` and
+`pressureSmoothingScaleFactor`, then uses `regionName` or detects `solid` or
+`region0`. It emits a fatal error if no solid region can be found.
+
+The wrapper then requires the `effectiveStressMechanicalLaw` sub-dictionary,
+reads its `type`, and constructs that linear-geometry law. It next reads
+`biotCoeff`, `pressureFieldName`, `pressureFieldRegion` and `p0`, in that order,
+using the defaults listed above. A non-zero `p0` produces an informational
+message. The wrapper itself emits no construction warning. Missing required
+dictionary entries cause dictionary lookup errors, and the nested law can emit
+its own validation errors and warnings.
+
+At stress correction, lookup aborts if the pressure field cannot be found in
+the configured region or in `solid`. The demand-driven `p0f` constructor also
+contains a defensive fatal error if its pointer is already set.
+
+### Key methods
+
+- `impK()` delegates directly to the nested effective-stress law. It is the
+  diffusivity of the solid model's implicit Laplacian term and affects the
+  outer-iteration convergence rate rather than the converged answer.
+- `correct(volSymmTensorField&)` looks up `p`, creates `sigmaEff` if needed,
+  updates it with the nested law, and subtracts the cell-centred pore term.
+- `correct(surfaceSymmTensorField&)` interpolates `p`, creates `sigmaEfff` if
+  needed, updates it with the nested law, and subtracts the face-centred pore
+  term.
+- `biotCoeff()` returns a uniform cell-centred field containing `b`.
+- `materialTangent()` is not overridden or delegated. The inherited
+  implementation aborts with `notImplemented`.
+
+### Extension points
+
+A related linear-geometry wrapper can copy this class, replace the added stress
+contribution, and retain delegation of `impK()` and stress correction to a
+nested law. Any additional dictionary entries should be read in the constructor.
+Support for point or quadrature-point solid models requires explicit overloads
+that also delegate to compatible nested-law interfaces. The new class must be
+registered in the appropriate mechanical-law selection table and added to the
+OpenFOAM and foam-extend build lists where supported.
+
+The source is at
+[poroMechanicalLaw.C](https://github.com/solids4foam/solids4foam/blob/master/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/poroMechanicalLaw/poroMechanicalLaw.C).
+
+---
+
+## Tutorials
+
+- `solids/poroelasticity/stripFooting`
+- `solids/poroelasticity/suctionCaission`
+- `solids/poroelasticity/rodAndSeabed`

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/thermoMechanicalLaw/README.md
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/thermoMechanicalLaw/README.md
@@ -1,0 +1,199 @@
+---
+sort: 8
+---
+
+# thermoMechanicalLaw
+
+This law adds an isotropic thermal stress to the stress calculated by a nested
+linear-geometry mechanical law. The runtime type is:
+
+```text
+thermoMechanicalLaw
+```
+
+---
+
+## User Guide
+
+### What it computes
+
+The cell-centred stress is first calculated by the nested mechanical law and
+then corrected using its bulk modulus:
+
+```text
+sigma = sigmaMech - 3*K*alpha*(T - T0)*I
+```
+
+For the face-centred overload, the temperature and nested-law bulk modulus are
+interpolated from cells to faces:
+
+```text
+sigmaf = sigmaMech,f - 3*interpolate(K)*alpha*(interpolate(T) - T0)*I
+```
+
+The law implements `correct(volSymmTensorField&)` and
+`correct(surfaceSymmTensorField&)`. It does not implement the
+`pointSymmTensorField` overload, which aborts with `notImplemented`. On
+OpenFOAM.com and OpenFOAM.org, the `CompactListList` overload is present in the
+base-class interface but also aborts with `notImplemented`. That interface is
+excluded from foam-extend by `#ifndef FOAMEXTEND`.
+
+The nested law is selected from the linear-geometry runtime table. The
+decoupled thermal correction may not be appropriate when the nested law is a
+nonlinear function of volumetric stress, such as a plasticity law whose
+response depends on volumetric stress.
+
+### Model options
+
+| Entry | Required | Description |
+| --- | --- | --- |
+| `rho` | yes | Density, `[1 -3 0 0 0 0 0]` |
+| `alpha` | yes | Linear expansion coefficient, `[0 0 0 -1 0 0 0]` |
+| `T0` | yes | Stress-free reference temperature, `[0 0 0 1 0 0 0]` |
+| `mechanicalLaw` | yes | Nested linear-geometry law dictionary |
+| `TcaseDirectory` | no | Relative temperature-case path; default `.` |
+| `solvePressureEqn` | no | Outer base-class switch; default `no` |
+| `pressureSmoothingScaleFactor` | no | Outer smoothing scale; default `100` |
+| `regionName` | conditional | Base-mesh region name; detected if omitted |
+
+The `mechanicalLaw` sub-dictionary must contain its own `type` and all entries
+required by the selected law. The outer `solvePressureEqn` and
+`pressureSmoothingScaleFactor` entries are read by the base constructor, but
+this wrapper does not call `updateSigmaHyd()`, so they do not change its stress
+calculation. Put those entries inside `mechanicalLaw` when the nested law uses
+them.
+
+If `regionName` is absent, the base class selects a registered mesh named
+`solid`, then `region0`. Construction aborts if neither is available.
+
+The law first uses an in-memory `T` field when one is available. Otherwise it
+reads `T` from the current time of `TcaseDirectory`. A separate temperature
+case must use the same base mesh point coordinates and the same numbers of
+points, faces and cells as the mechanical case.
+
+### Recommended dictionary setup
+
+```text
+planeStress     no;
+
+mechanical
+(
+    steel
+    {
+        type            thermoMechanicalLaw;
+        rho             rho [1 -3 0 0 0 0 0] 7750;
+        alpha           alpha [0 0 0 -1 0 0 0] 9.7e-06;
+        T0              T0 [0 0 0 1 0 0 0] 300;
+
+        // Optional: read T from a separate case relative to this case
+        // TcaseDirectory  "steelTemperatureCase";
+
+        mechanicalLaw
+        {
+            type            linearElastic;
+            E               E [1 -1 -2 0 0 0 0] 190e9;
+            nu              nu [0 0 0 0 0 0 0] 0.305;
+
+            // Optional for the nested law
+            // solvePressureEqn no;
+        }
+    }
+);
+```
+
+### Field glossary
+
+- `T`: temperature used in the thermal correction. It is either looked up
+  from the mechanical mesh registry or read from disk. A disk-read field is
+  set to `AUTO_WRITE` so it is available for restart and inspection.
+- `Tf`: temporary face interpolation of `T` used by the surface correction.
+- `Kf`: temporary face interpolation of the nested law's bulk modulus.
+- The nested `mechanicalLaw` owns the strain, stress-history and other
+  constitutive fields needed to calculate `sigmaMech`.
+
+---
+
+## Developer Notes
+
+### Class role
+
+`thermoMechanicalLaw` derives directly from `mechanicalLaw` and owns an
+`autoPtr<mechanicalLaw>` for the nested law. It also stores the uniform
+`dimensionedScalar` values `alpha_` and `T0_`, a lazily allocated temperature
+field, a disk-read flag, the relative temperature-case path, lazily allocated
+`Time` and `fvMesh` objects, and the last checked time index.
+
+The class has no `#ifdef FOAMEXTEND` or `#ifndef FOAMEXTEND` block of its own.
+It uses `OPENFOAM_COM` and `OPENFOAM_NOT_EXTEND` guards for constructor and
+field-API differences. The inherited quadrature-point interface is guarded by
+`#ifndef FOAMEXTEND`. The law is listed in both `Make/files.openfoam` and
+`Make/files.foamextend`.
+
+### Construction
+
+The base constructor first reads `solvePressureEqn` and
+`pressureSmoothingScaleFactor`, inserting defaults of `false` and `100.0`, and
+then resolves `regionName`. The wrapper then:
+
+1. Requires the `mechanicalLaw` sub-dictionary and its `type` entry.
+2. Selects and constructs that law through `NewLinGeomMechLaw`.
+3. Reads `alpha` and `T0` as dimensioned scalars.
+4. Inserts `TcaseDirectory` with the default `.` when it is absent.
+5. Initialises the temperature, time and mesh pointers and the time index.
+
+Missing required entries cause dictionary lookup errors. An unknown nested
+type, or a type from the nonlinear-geometry selection table, causes a fatal
+selection error. The selected nested law can emit its own construction errors
+and warnings. The wrapper constructor performs no range checks on `alpha` or
+`T0` and emits no warning itself.
+
+Temperature-case objects are created only when disk access is needed. Reading
+aborts if the temperature mesh topology or point locations differ from the
+base mesh, or if no `T` field is available in memory or on disk. Disk lookup is
+attempted at most once per mechanical time step. Once a disk field has been
+read, its last value remains available when a later time has no new `T` file.
+
+### Key methods
+
+- `impK()` delegates to the nested law. It is the diffusivity used for the
+  solid model's implicit Laplacian term and affects outer-iteration convergence
+  rate rather than the converged answer.
+- `bulkModulus()` delegates to the nested law and supplies `K` for the thermal
+  stress correction.
+- `correct(volSymmTensorField&)` delegates the mechanical stress calculation,
+  obtains `T`, and subtracts the cell-centred thermal stress.
+- `correct(surfaceSymmTensorField&)` performs the same sequence with
+  interpolated temperature and bulk modulus.
+- `lookupTemperatureField()` prefers a solver-registered `T` until a
+  temperature has been read from disk; after that, it uses the disk-backed
+  field.
+- `readTField()` synchronises the temperature-case time, reads at most once per
+  time step, copies a single-material field directly, and maps a base-mesh
+  field onto the current material mesh for a multi-material case.
+- `materialTangent()` is not overridden. The base implementation aborts with
+  `notImplemented`, so `materialTangentField()` also cannot be used.
+
+### Extension points
+
+A related additive wrapper can copy this class, select its underlying law from
+the appropriate runtime table, and replace the correction terms in both
+implemented `correct()` overloads. It must continue to delegate `impK()` and
+any required modulus queries. Supporting vertex-centred or higher-order solid
+models additionally requires point and `CompactListList` overloads instead of
+the base-class `notImplemented` fallbacks. A new wrapper must also be added to
+the applicable build lists and runtime selection table.
+
+The source is at
+[thermoMechanicalLaw.C](https://github.com/solids4foam/solids4foam/blob/master/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/thermoMechanicalLaw/thermoMechanicalLaw.C).
+
+---
+
+## Tutorials
+
+- `solids/thermoelasticity/slabCooling`
+- `solids/thermoelasticity/hotCylinder/hotCylinder`
+- `solids/thermoelasticity/hotCylinder/hotCylinderPredefinedTFieldMultipleMaterials`
+- `solids/thermoelasticity/hotSphere`
+- `thermoFluidSolidInteraction/flowOverHeatedPlate`
+- `thermoFluidSolidInteraction/thermalCavity`
+- `thermoFluidSolidInteraction/hotTJunction`

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/viscousHookeanElastic/README.md
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/viscousHookeanElastic/README.md
@@ -1,0 +1,224 @@
+---
+sort: 9
+---
+
+# viscousHookeanElastic
+
+This page documents the small-strain generalised Maxwell law, with an elastic
+volumetric response and a relaxing deviatoric response. The runtime type is:
+
+```text
+viscousHookeanElastic
+```
+
+---
+
+## User Guide
+
+### What it computes
+
+The law places a relaxed spring in parallel with a list of Maxwell arms. It
+first forms the instantaneous modulus and relative moduli:
+
+```text
+E0        = EInfinity + sum(E[i])
+gammaInf  = EInfinity/E0
+gamma[i]  = E[i]/E0
+mu        = E0/(2*(1 + nu))
+
+lambdaInf = nu*EInfinity/((1 + nu)*(1 - 2*nu))  // plane strain / 3-D
+lambdaInf = nu*EInfinity/((1 + nu)*(1 - nu))    // planeStress yes
+k         = lambdaInf + (2/3)*gammaInf*mu
+```
+
+For a non-incremental solid model, the trial deviatoric stress and elastic
+volumetric stress are:
+
+```text
+e       = dev(symm(grad(D)))
+s       = 2*mu*e
+sigmaVol = k*tr(grad(D))*I
+```
+
+For an incremental solid model, the implemented update is:
+
+```text
+De       = dev(symm(grad(DD)))
+s        = s.oldTime() + 2*mu*De
+sigmaVol = tr(sigma.oldTime())*I + k*tr(grad(DD))*I
+```
+
+Each Maxwell-arm stress is then advanced using the midpoint exponential
+update. With `aT = 1` unless temperature shifting is enabled, the update and
+total stress are:
+
+```text
+aT = 10^(-C1*(T - Tref)/(C2 + (T - Tref)))
+
+h[i] = exp(-deltaT/(aT*tau[i]))*h[i].oldTime()
+       + exp(-deltaT/(2*aT*tau[i]))*(s - s.oldTime())
+
+sigma = sigmaVol + gammaInf*s + sum(gamma[i]*h[i])
+```
+
+Only the deviatoric response relaxes; `k` is constant. The law implements
+`correct(volSymmTensorField&)` and `correct(surfaceSymmTensorField&)`. The
+point-symmetric-tensor overload inherits `notImplemented`. On OpenFOAM.com and
+OpenFOAM.org, the `CompactListList` quadrature-point overload also inherits
+`notImplemented`; that overload is not compiled for foam-extend.
+
+### Model options
+
+| Entry | Required | Description |
+| --- | --- | --- |
+| `type` | yes | Runtime type; `viscousHookeanElastic` |
+| `rho` | yes | Density, `[1 -3 0 0 0 0 0]` |
+| `EInfinity` | yes | Relaxed modulus, `[1 -1 -2 0 0 0 0]` |
+| `E` | yes | Maxwell-arm modulus list, in pressure units |
+| `relaxationTimes` | yes | Maxwell-arm relaxation-time list |
+| `nu` | yes | Relaxed Poisson's ratio, dimensionless |
+| `WilliamsLandelFerry` | no | Enable WLF shifting; default `no` |
+| `WilliamsLandelFerryCoeffs` | with WLF | Dictionary containing WLF data |
+| `C1` | with WLF | Dimensionless first WLF coefficient |
+| `C2` | with WLF | Second WLF coefficient, `[0 0 0 1 0 0 0]` |
+| `Tref` | with WLF | Reference temperature, `[0 0 0 1 0 0 0]` |
+| `regionName` | no | Base mesh region selected by name |
+| `solvePressureEqn` | no | Base switch; default `no`, unused here |
+| `pressureSmoothingScaleFactor` | no | Default `100`; unused here |
+
+`E` and `relaxationTimes` are read as scalar lists and must have equal lengths.
+The code uses each relaxation time with `deltaTValue()`, so the values have the
+case time unit. Enabling `WilliamsLandelFerry` also requires a cell-centred `T`
+field for the cell correction and a face-centred `T` field for the face
+correction.
+
+The base class selects `solid` as `regionName` when that mesh exists, then
+`region0`; otherwise `regionName` must be supplied. Although the base class
+reads the two pressure-equation options, this law does not call
+`updateSigmaHyd()`, so neither option changes its stress update.
+
+### Recommended dictionary setup
+
+The following polymer values are used by the `viscoTube` tutorial:
+
+```text
+planeStress     no;
+
+mechanical
+(
+    polymer
+    {
+        type            viscousHookeanElastic;
+        rho             rho [1 -3 0 0 0 0 0] 7850;
+        EInfinity       EInfinity [1 -1 -2 0 0 0 0] 39.58e9;
+        nu              nu [0 0 0 0 0 0 0] 0.33;
+        E               (2.9318518519e9 5.8637037037e9
+                         6.5966666667e9 18.3240740741e9);
+        relaxationTimes (30 300 3000 12000);
+
+        // Optional temperature shift
+        // WilliamsLandelFerry yes;
+        // WilliamsLandelFerryCoeffs
+        // {
+        //     C1   C1 [0 0 0 0 0 0 0] 17.44;
+        //     C2   C2 [0 0 0 1 0 0 0] 51.6;
+        //     Tref Tref [0 0 0 1 0 0 0] 293.15;
+        // }
+    }
+);
+```
+
+### Field glossary
+
+- `s`, `sf`: instantaneous deviatoric trial stress at cell centres and faces.
+  Their old-time values are stored, but the fields are neither read nor
+  written.
+- `h0`, `h1`, and so on: cell-centred Maxwell-arm internal stresses. Each field
+  stores old-time and previous-iteration values and is neither read nor
+  written.
+- `hf0`, `hf1`, and so on: face-centred counterparts of the Maxwell-arm
+  stresses, with the same time and iteration storage.
+- `T`: temperature looked up when WLF shifting is enabled. Its location must
+  match the selected cell- or face-centred correction.
+- `K`: temporary cell field containing the constant relaxed bulk modulus `k`.
+- `impK`: temporary cell field containing the implicit stiffness used by the
+  solid model's Laplacian term.
+
+---
+
+## Developer Notes
+
+### Class role
+
+`viscousHookeanElastic` derives directly from `mechanicalLaw` and is registered
+in the `linGeomMechLaw` runtime-selection table. It stores `EInfinity`, the
+Maxwell moduli and relaxation times, their relative moduli, `nu`, `lambda`,
+`mu`, `k`, the cell and face internal-stress lists, the cell and face trial
+deviatoric stresses, and the WLF switch and coefficients.
+
+The class uses `#ifdef OPENFOAM_NOT_EXTEND` for OpenFOAM-specific field headers
+and for `primitiveField()` in its residual calculation; foam-extend uses
+`internalField()`. It appears in both `Make/files.openfoam` and
+`Make/files.foamextend`.
+
+### Construction
+
+The base constructor first reads `solvePressureEqn` and
+`pressureSmoothingScaleFactor`, adding their defaults to the stored dictionary,
+and selects the base region from `regionName`, `solid`, or `region0`. Failure to
+find a region is fatal. Density is read later by `rhoScalar()`, rather than by
+the constructor.
+
+The derived constructor then reads `EInfinity`, `E`, `relaxationTimes`, and
+`nu`. It reads `WilliamsLandelFerry` with a default of `false`; when enabled,
+it requires `C1`, `C2`, and `Tref` from `WilliamsLandelFerryCoeffs`. It checks
+that the two lists have equal lengths, calculates `E0` and the relative moduli,
+and rejects a relaxation time or Maxwell modulus below `SMALL` with a fatal
+error.
+
+It creates zero-valued `s`, `sf`, `h[i]`, and `hf[i]` fields and stores their
+old-time values. Finally, it calculates `mu`, rejects `nu` outside
+`[-1, 0.5]`, and calculates `lambda` and `k`. For `nu == 0.5`, it prints an
+incompressibility message and sets `lambda` and `k` to `GREAT`. Construction
+also prints the relative moduli and the state of WLF shifting. It emits no
+warnings.
+
+### Key methods
+
+- `impK()` forms a time-step-dependent algorithmic stiffness. Its scale factor
+  is `gammaInf + sum(gamma[i]*exp(-deltaT/(2*tau[i])))`; the returned field is
+  that factor times `2*mu`, plus `lambda` unless `nu == 0.5` or a cell field
+  named `p` exists. This diffusivity affects the outer-iteration convergence
+  rate rather than the converged answer. WLF shifting is not included in this
+  scale factor.
+- `correct(volSymmTensorField&)` and its face-field counterpart update the
+  trial stress, Maxwell-arm stresses, and total stress. They select `grad(D)`
+  or `grad(DD)` according to the solid model's incremental setting and apply
+  WLF shifting when enabled.
+- `residual()` returns the largest relative previous-iteration change over all
+  Maxwell-arm stresses. It uses face fields when the base mesh has an `Ff`
+  surface field and cell fields otherwise.
+- `bulkModulus()` delegates to `K()`, which returns a uniform field containing
+  `k`.
+- `materialTangent()` is not overridden. The base implementation aborts with
+  `notImplemented`, so solid models requiring a material tangent cannot use
+  this law.
+
+### Extension points
+
+A related linear viscoelastic law can copy this class and replace the
+Maxwell-arm update in both `correct` overloads. New internal variables need
+matching cell and face fields, old-time storage, previous-iteration storage if
+they contribute to `residual()`, and corresponding terms in `impK()`. A law
+needed by point- or quadrature-based solid models must also implement those
+`correct` overloads, and a law needed by Newton-based solid models must provide
+`materialTangent()`.
+
+The source is at
+[viscousHookeanElastic.C](https://github.com/solids4foam/solids4foam/blob/master/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/viscousHookeanElastic/viscousHookeanElastic.C).
+
+---
+
+## Tutorials
+
+- `solids/viscoelasticity/viscoTube`

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/mechanicalLaw/README.md
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/mechanicalLaw/README.md
@@ -1,0 +1,262 @@
+---
+sort: 1
+---
+
+# mechanicalLaw: the base class
+
+`mechanicalLaw` is the abstract base class for every constitutive law in
+solids4foam. A law's job is narrow: given the current deformation, return the
+stress, plus the handful of scalars the solid models need in order to build
+and solve the momentum equation. Everything else — reading
+`mechanicalProperties`, partitioning the mesh by material, mapping fields
+between sub-meshes — is done by `mechanicalModel` and is invisible to the law.
+
+Source:
+[`mechanicalLaw.H`](https://github.com/solids4foam/solids4foam/blob/development/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/mechanicalLaw/mechanicalLaw.H),
+[`mechanicalLaw.C`](https://github.com/solids4foam/solids4foam/blob/development/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/mechanicalLaw/mechanicalLaw.C)
+and
+[`newMechanicalLaw.C`](https://github.com/solids4foam/solids4foam/blob/development/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/mechanicalLaw/newMechanicalLaw.C).
+
+---
+
+## User Guide
+
+This is a developer-facing page. As a user you never select `mechanicalLaw`
+itself; you select one of its derived types with the `type` keyword inside a
+`mechanical` sub-dictionary. The only part of this class you interact with
+directly is the small set of entries it reads for every law:
+
+| Entry | Default | Description |
+| --- | --- | --- |
+| `rho` | none | Density, as a `dimensionedScalar` |
+| `solvePressureEqn` | `no` | Smooth the hydrostatic stress with a Laplacian |
+| `pressureSmoothingScaleFactor` | `100` | Scale factor for that smoothing |
+| `regionName` | see below | Name of the base solid mesh region |
+
+`rho` is read only when the law uses the base-class `rho()`/`rhoScalar()`,
+which nearly all do. `solvePressureEqn` and `pressureSmoothingScaleFactor` are
+read with `lookupOrAddDefault`, so their values are echoed into
+`constant/mechanicalProperties.withDefaultValues`. `regionName` defaults to
+`solid` if a `solid` region exists, otherwise `region0`; set it only in
+unusual multi-region set-ups, such as a law attached to a mesh-motion mesh.
+
+Enabling `solvePressureEqn` solves an additional Laplacian equation for the
+hydrostatic stress. It can quell checkerboarding in the hydrostatic stress at
+the cost of an extra linear solve per outer iteration; it is off by default.
+
+---
+
+## Developer Notes
+
+### The interface a law must implement
+
+Only two functions are pure virtual:
+
+| Function | Contract |
+| --- | --- |
+| `correct(volSymmTensorField& sigma)` | Set `sigma` from the deformation |
+| `impK()` | Return the implicit stiffness field |
+
+Everything else has a default implementation, which is either a sensible
+fallback or a `notImplemented` that fires only if a solid model actually
+requests it.
+
+**`correct(volSymmTensorField& sigma)`** is the constitutive update. It must
+overwrite `sigma` on the mesh the law was constructed on — which, in a
+multi-material case, is the material's sub-mesh, not the base mesh. Whether
+`sigma` is the Cauchy stress or a work-conjugate measure is fixed by the solid
+model the law is registered for: linear-geometry and total-Lagrangian laws in
+solids4foam return the Cauchy stress, and it is the law's responsibility to
+perform any push-forward internally. `correct()` is called every outer
+iteration, so it must be idempotent in the sense that calling it twice with
+the same deformation gives the same answer; any path-dependent state (plastic
+strain, viscous internal variables) must be advanced in `updateTotalFields()`,
+not here.
+
+**`impK()`** returns the diffusivity used for the implicit Laplacian term in
+the segregated momentum equation. It is not a physical property: it is a
+numerical stiffness that only has to make the outer iterations converge, since
+the discretisation is written as an implicit Laplacian plus an explicit
+deferred correction that cancels it at convergence. In practice laws return
+something of the order of `2*mu + lambda`, and it is legitimate to return a
+larger value to damp the iterations at the cost of slower convergence. Two
+things do depend on `impK()` beyond convergence rate, so it cannot be
+arbitrary:
+
+- the traction boundary conditions use it to convert a traction into a
+  surface-normal gradient;
+- the bi-material interface correction in `solidSubMeshes` uses the base-mesh
+  `impK` field to weight the two sides of an interface, so a badly scaled
+  `impK` degrades the interface treatment in multi-material cases.
+
+`impKf()` is the surface-field equivalent. The base class implements it as
+`fvc::interpolate(impK())`; override it only if the law can produce a genuinely
+better face value.
+
+**`rho()`** returns a `volScalarField` built from `rhoScalar()`, which reads
+the `rho` entry. The field is created with `READ_IF_PRESENT`, so a `rho` field
+in the time directory takes precedence over the dictionary value, and with
+`zeroGradient` boundaries which are corrected before the field is returned.
+Override `rho()` for a genuinely non-uniform density, or `rhoScalar()` alone
+if the law computes a uniform density from other entries.
+
+**`bulkModulus()`** and **`shearModulus()`** default to `notImplemented`. They
+are not needed by every solid model, but the ones that do call them will
+abort if the law has not overridden them, so implement them for any new law
+intended for general use. `bulkModulus()` is what the compressibility-related
+machinery uses; a nearly incompressible law must return the correct value here
+or the mixed pressure-displacement solid models cannot be used with it.
+
+### Optional interface
+
+| Function | Default | Purpose |
+| --- | --- | --- |
+| `correct(surfaceSymmTensorField&)` | `notImplemented` | The `uns` models |
+| `correct(pointSymmTensorField&, ...)` | `notImplemented` | Vertex-centred |
+| `correct(CompactListList<...>)` | `notImplemented` | Face quadrature |
+| `materialTangent()` | `notImplemented` | Newton-Raphson (PETSc SNES) |
+| `materialTangentField(...)` | uniform | Per-face material tangent |
+| `residual()` | `0` | Material convergence measure |
+| `newDeltaT()` | `endTime` | Law-requested time-step limit |
+| `updateTotalFields()` | no-op | End-of-time-step state update |
+| `setRestart()` | no-op | Adjust field write options on restart |
+
+A few notes on these. The surface-field `correct()` must be implemented for a
+law to work with the `uns` family of solid models, and the point-field variant
+for the vertex-centred ones; the face-quadrature variant is not available on
+foam-extend at all. `materialTangentField()` defaults to filling
+`mesh().nFaces()` entries with the single value from `materialTangent()`, so
+overriding just `materialTangent()` is enough for a homogeneous law.
+`residual()` returning a non-zero value makes the solid model keep iterating
+until the material has converged as well as the momentum equation — this is
+what plasticity laws use — and `mechanicalModel::residual()` takes the maximum
+over all laws. `newDeltaT()` is likewise reduced to the minimum over all laws.
+
+### Total- versus updated-Lagrangian variants
+
+A law is registered in exactly one of the two run-time selection tables:
+`linGeomMechLaw` or `nonLinGeomMechLaw`. Both tables have the same constructor
+signature, and the `nonLinearGeometry::nonLinearType` enumerator passed to it
+is what tells a nonlinear law which formulation it is being used in. It is
+available to the law through the protected `nonLinGeom()` accessor and takes
+one of `LINEAR_GEOMETRY`, `TOTAL_LAGRANGIAN` or `UPDATED_LAGRANGIAN`.
+
+The base class provides both deformation gradients so that a single law class
+can serve both formulations:
+
+- `F()` and `Ff()`: the total deformation gradient, relative to the initial
+  configuration;
+- `relF()` and `relFf()`: the relative deformation gradient, relative to the
+  configuration at the end of the previous time step.
+
+The `updateF(...)` family of protected functions is the intended entry point.
+It updates the appropriate gradient for the current formulation from the
+registered `grad(D)`/`grad(DD)` fields, and it also implements the
+*enforce-linear* escape hatch: if the solid model has tripped its
+`enforceLinear` switch — typically because the outer iterations are diverging
+— `updateF` overwrites `sigma` with the linear elastic response built from the
+linearised `mu` and `K` passed in, and returns `true`. A law should check that
+return value and skip its own constitutive update:
+
+```text
+if (updateF(sigma, mu_, K_))
+{
+    return;
+}
+```
+
+This is why laws must call `mu(...)` and `K(...)` to register their linearised
+moduli even when the constitutive model itself has no such constants: those
+fields are the fallback.
+
+Whether the law is used incrementally is a separate question from the
+formulation, and is answered by the protected `incremental()` accessor, which
+asks the solid model whether it solves for `DD` rather than `D`. The base
+class uses this to decide which gradient field to look up, so a law that goes
+through `updateF()` does not need to care.
+
+### Other base-class services
+
+`mechanicalLaw` also manages a number of demand-driven fields so that derived
+laws do not each reimplement them: `mu`/`muf` and `K`/`Kf` (linearised shear
+and bulk moduli), `epsilon`/`epsilonf` (small strain, via `updateEpsilon()`),
+`sigma0`/`sigma0f` (initial or residual stress), and
+`sigmaHyd`/`gradSigmaHyd` with the `updateSigmaHyd(...)` overloads that
+implement the optional pressure smoothing equation. The accessors are
+protected and each field is only allocated when first used.
+
+`planeStress()` returns the `planeStress` switch from `mechanicalProperties`,
+searching the law's own region first and then the `region0` or `solid`
+sub-registry, so it works both for standalone solid cases and for the solid
+region of a fluid-solid interaction case.
+
+### Adding a new mechanical law
+
+1. **Create the directory and class.** Place it under
+   `src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/`,
+   in `linearGeometryLaws/` or `nonLinearGeometryLaws/` according to which
+   selection table it belongs to. Copying `linearElastic` or
+   `neoHookeanElastic` is the fastest start.
+
+2. **Derive from `mechanicalLaw`** and declare the run-time type name in the
+   header:
+
+   ```text
+   TypeName("myElasticLaw");
+   ```
+
+   The string is what users write as `type` in `mechanicalProperties`; it does
+   not have to match the class name, though by convention it does. The one
+   deliberate exception in the toolbox is the thermal law `constantThermal`,
+   whose type name is `constant`.
+
+3. **Provide the standard constructor**, taking
+   `(const word& name, const fvMesh& mesh, const dictionary& dict,
+   const nonLinearGeometry::nonLinearType& nonLinGeom)`, and forward all four
+   arguments to the base class. Read the law's own entries from `dict` in the
+   initialiser list, using `lookup` for required entries and
+   `lookupOrDefault`/`lookupOrAddDefault` for optional ones. Disallow copy
+   construction and assignment, as the base class does.
+
+4. **Implement `correct(volSymmTensorField&)` and `impK()`**, and override
+   `bulkModulus()` and `shearModulus()` unless the law is only ever going to
+   be used with solid models that do not need them.
+
+5. **Register the law** in the `.C` file:
+
+   ```text
+   #include "addToRunTimeSelectionTable.H"
+
+   namespace Foam
+   {
+       defineTypeNameAndDebug(myElasticLaw, 0);
+       addToRunTimeSelectionTable
+       (
+           mechanicalLaw, myElasticLaw, linGeomMechLaw
+       );
+   }
+   ```
+
+   Use `nonLinGeomMechLaw` instead for a finite-strain law. Registering in the
+   wrong table is the common mistake; the selector's error message will then
+   tell users the law "can only be used with a linear geometry solid model".
+
+6. **Add the source to the build.** There is a single `Make/files` per build
+   flavour in `src/solids4FoamModels/Make/`: add one line to **both**
+   `files.openfoam` and `files.foamextend`, next to the sibling laws, e.g.
+
+   ```text
+   $(linGeomLaws)/myElasticLaw/myElasticLaw.C
+   ```
+
+   Header files are not listed. If the law cannot compile on foam-extend,
+   omit it from `files.foamextend` rather than guarding the whole file.
+
+7. **Rebuild** with `./Allwmake` in the repository root. Because the laws are
+   pulled in by the run-time selection table rather than by any explicit
+   reference, a law that is missing from `Make/files` will compile in a unity
+   build but never appear in the table — the symptom is "Unknown mechanicalLaw
+   type" listing every law except yours.
+
+8. **Add a tutorial and a `README.md`** in the law's directory, following the
+   pattern of the existing law pages.

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/GentElastic/README.md
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/GentElastic/README.md
@@ -1,0 +1,183 @@
+---
+sort: 21
+---
+
+# GentElastic
+
+This page documents the Gent-Flory elastic law for microgel behaviour. The
+runtime type is:
+
+```text
+GentElastic
+```
+
+---
+
+## User Guide
+
+### What it computes
+
+The law updates the deformation gradient and evaluates the following stress at
+cell centres or faces:
+
+```text
+J     = det(F)
+B     = symm(F & F.T())
+C     = symm(F.T() & F)
+omega = Vs/Na
+Nv    = N/omega
+
+sigma = kb*temperature*(Nv/J)
+      * ((ilim/(ilim - tr(B) + 3))*C - I)
+```
+
+Here `Na` is fixed at `6.022141e23` and dimensionless, while `kb` is fixed at
+`1.38064852e-23` with dimensions `[1 2 -2 -1 0 0 0]`. The nonlinear stress
+does not use `E`, `nu`, `mu` or `K`; those quantities are used by `updateF()`
+when the solid model enforces a linear response and by `impK()`.
+
+The `volSymmTensorField` and `surfaceSymmTensorField` `correct()` overloads are
+implemented. The inherited `pointSymmTensorField` overload aborts with
+`notImplemented`. On OpenFOAM.com and OpenFOAM.org, the inherited
+`CompactListList` overload also exists and aborts with `notImplemented`; that
+interface is excluded from foam-extend by `#ifndef FOAMEXTEND`.
+
+### Model options
+
+| Entry | Required | Description |
+| --- | --- | --- |
+| `E` | yes | Young's modulus, `[1 -1 -2 0 0 0 0]` |
+| `nu` | yes | Poisson's ratio, dimensionless |
+| `temperature` | yes | Temperature, `[0 0 0 1 0 0 0]` |
+| `ilim` | yes | Limiting invariant parameter, dimensionless |
+| `Vs` | yes | Volume divided by `Na` to form `omega`, `[0 3 0 0 0 0 0]` |
+| `N` | yes | Crosslink parameter divided by `omega`, dimensionless |
+| `rho` | yes | Density, `[1 -3 0 0 0 0 0]` |
+| `solvePressureEqn` | no | Base switch; default `no` |
+| `pressureSmoothingScaleFactor` | no | Base scale factor; default `100` |
+| `regionName` | no | Base mesh region; otherwise detected automatically |
+
+The top-level `planeStress` switch is also required. It changes the `K` used
+for linear enforcement and `impK()`, but it does not change the nonlinear
+stress expression. Although the base constructor reads `solvePressureEqn` and
+`pressureSmoothingScaleFactor`, this law never calls `updateSigmaHyd()`, so
+neither option changes its computed stress.
+
+No range or positivity checks are applied to the material entries. In
+particular, the denominator `ilim - tr(B) + 3` is not guarded against zero.
+
+### Recommended dictionary setup
+
+Illustrative setup for a water-swollen microgel:
+
+```text
+planeStress     no;
+
+mechanical
+(
+    waterSwollenMicrogel
+    {
+        type            GentElastic;
+        rho             rho [1 -3 0 0 0 0 0] 1000;
+        E               E [1 -1 -2 0 0 0 0] 3e4;
+        nu              nu [0 0 0 0 0 0 0] 0.49;
+        temperature     temperature [0 0 0 1 0 0 0] 298;
+        ilim            ilim [0 0 0 0 0 0 0] 100;
+        Vs              Vs [0 3 0 0 0 0 0] 1.8e-5;
+        N               N [0 0 0 0 0 0 0] 1e-4;
+
+        // Optional base-class entries
+        // regionName                    region0;
+        // solvePressureEqn              no;
+        // pressureSmoothingScaleFactor  100;
+    }
+);
+```
+
+### Field glossary
+
+- `F_`, `Ff_`: total deformation gradients at cell centres and faces. They
+  are read if present and written for restart.
+- `relF_`, `relFf_`: relative deformation gradients maintained by `updateF()`.
+- `mu_<material>`, `K_<material>`: cell fields populated from the uniform
+  derived moduli when the volume correction is used.
+- `muf_<material>`, `Kf_<material>`: corresponding face fields populated by
+  the surface correction.
+- `impK`: implicit stiffness field returned to the solid model, with value
+  `(4/3)*mu + K` unless an `impK` field is read from the current time.
+- `sigma`: stress field supplied by the solid model and overwritten by
+  `correct()`.
+
+---
+
+## Developer Notes
+
+### Class role
+
+`GentElastic` derives directly from `mechanicalLaw` and is registered in the
+`nonLinGeomMechLaw` runtime selection table. It stores ten constant
+`dimensionedScalar` members: `E_`, `nu_`, `mu_`, `temperature_`, `ilim_`,
+`K_`, `Na_`, `kb_`, `omega_` and `N_`.
+
+The class itself has no fork guards. The inherited quadrature-point interface
+is guarded by `#ifndef FOAMEXTEND`. `GentElastic.C` appears in both
+`Make/files.openfoam` and `Make/files.foamextend`.
+
+### Construction
+
+The base constructor first reads or inserts `solvePressureEqn` and
+`pressureSmoothingScaleFactor`, then reads `regionName` or detects `solid` or
+`region0`. Failure to find a base mesh region is fatal.
+
+The derived constructor then performs these operations in order:
+
+1. Reads `E` and `nu`, and derives `mu = E/(2*(1 + nu))`.
+2. Reads `temperature` and `ilim`.
+3. Reads the top-level `planeStress` switch and derives `K`:
+
+   ```text
+   K = nu*E/((1 + nu)*(1 - nu))     + (2/3)*mu  // plane stress
+   K = nu*E/((1 + nu)*(1 - 2*nu))   + (2/3)*mu  // otherwise
+   ```
+
+4. Sets the fixed values of `Na` and `kb`.
+5. Reads `Vs` and calculates `omega = Vs/Na`.
+6. Reads `N` and replaces it internally by `N/omega`.
+
+Missing or dimensionally inconsistent required entries cause dictionary or
+dimension errors. The constructor contains no explicit material validation
+and emits no law-specific fatal error or warning. If `solvePressureEqn` is
+enabled, the base constructor only prints an informational message.
+
+### Key methods
+
+- `impK()` returns a cell field equal to `(4/3)*mu + K`. It is the
+  diffusivity of the solid model's implicit Laplacian term and affects the
+  outer-iteration convergence rate rather than the converged answer.
+- Both implemented `correct()` methods call `updateF(sigma, mu, K)` first. If
+  it returns `true`, the linearised stress supplied by `updateF()` is kept.
+  Otherwise they evaluate the Gent-Flory expression above using `F` or `Ff`.
+  `updateF()` aborts for non-incremental updated-Lagrangian use or an unknown
+  nonlinear-geometry type, and warns when linearity is enforced for stability.
+- `materialTangent()` is not overridden. The inherited implementation aborts
+  with `notImplemented`, so solid models that request a material tangent
+  cannot use this law.
+- `setRestart()` sets both `F` and `Ff` to `AUTO_WRITE`, constructing either
+  field if it has not already been used.
+
+### Extension points
+
+A related law can copy this class, replace both `correct()` expressions, and
+update the `dimensionedScalar` inputs and `impK()` linearisation. It must use a
+new `TypeName`, register in the `nonLinGeomMechLaw` table, and be added to both
+build lists when it supports all forks. Implement the point, quadrature-point
+and material-tangent interfaces if the target solid models require them.
+
+The source is at
+[GentElastic.C](https://github.com/solids4foam/solids4foam/blob/master/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/GentElastic/GentElastic.C).
+
+---
+
+## Tutorials
+
+No tutorial currently selects the `GentElastic` runtime type.

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/GuccioneElastic/README.md
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/GuccioneElastic/README.md
@@ -1,0 +1,299 @@
+---
+sort: 23
+---
+
+# GuccioneElastic
+
+This page documents the Guccione transversely isotropic exponential
+hyperelastic law, intended for passive myocardium. The runtime type is:
+
+```text
+GuccioneElastic
+```
+
+The law is anisotropic about a local fibre direction `f0`, which is either a
+single uniform vector read from `mechanicalProperties` or a full
+`volVectorField` read from a time directory. The implementation follows the
+formulation used in E. Garcia-Blanco, R. Ortigosa, A. J. Gil, C. H. Lee and
+J. Bonet, _A new computational framework for electro-activation in cardiac
+mechanics_, Computer Methods in Applied Mechanics and Engineering, 348 (2019)
+796-845. The underlying constitutive model is due to J. M. Guccione,
+A. D. McCulloch and L. K. Waldman (1991).
+
+---
+
+## User Guide
+
+### Constitutive relation
+
+The strain energy density is exponential in a quadratic form `Q` of the
+Green-Lagrange strain `E`:
+
+```text
+W = 0.5*k*(exp(Q) - 1)
+
+S = dW/dE = 0.5*k*exp(Q)*dQ/dE
+```
+
+where `S` is the deviatoric part of the 2nd Piola-Kirchhoff stress and `k` has
+units of pressure. Two equivalent expressions for `Q` are implemented, selected
+by `calculateStressInLocalCoordinateSystem`.
+
+With `calculateStressInLocalCoordinateSystem no` (the default), `Q` is written
+in terms of invariants of `E` and the structural tensor `f0*f0`:
+
+```text
+I1 = tr(E)
+I2 = 0.5*(sqr(tr(E)) - tr(E & E))
+I4 = E && (f0*f0)
+I5 = (E & E) && (f0*f0)
+
+Q  = ct*sqr(I1) - 2*ct*I2
+   + (cf - 2*cfs + ct)*sqr(I4)
+   + 2*(cfs - ct)*I5
+```
+
+With `calculateStressInLocalCoordinateSystem yes`, `E` is first rotated into
+the orthonormal fibre frame `(f0, s0, n0)` to give `EStar`, and `Q` takes the
+classical component form:
+
+```text
+Q = cf*sqr(E11)
+  + ct*(sqr(E22) + sqr(E33) + 2*sqr(E23))
+  + cfs*(2*sqr(E12) + 2*sqr(E13))
+```
+
+The Cauchy stress is then assembled differently in the two solver modes. In
+the standard (displacement-only) mode a penalty bulk term enforces near
+incompressibility:
+
+```text
+sigma = dev(symm(F & S & F.T))/J + sigmaHyd*I
+
+sigmaHyd = 0.5*bulkModulus*(sqr(J) - 1)/J
+```
+
+In pressure-displacement mode the hydrostatic part comes from the solved
+pressure field `p` instead:
+
+```text
+sigma = dev(symm(F & S & F.T)) - p*I
+```
+
+### Fibre, sheet and sheet-normal directions
+
+Only `f0` is user input. The constructor normalises it, then constructs the
+sheet direction `s0` by removing the `f0` component from the global `x`
+direction (falling back to `y` where that degenerates), normalises it, and sets
+`n0 = f0 ^ s0`. The rotation tensor `R` has `f0`, `s0` and `n0` as its columns
+and is used for the local-coordinate-system branch. Because `s0` and `n0` are
+generated automatically rather than supplied, the transverse response is
+isotropic in the plane normal to `f0` unless `ct` and `cfs` are chosen to
+differ.
+
+### Model options
+
+Required entries in the material sub-dictionary:
+
+| Entry | Type | Description |
+| --- | --- | --- |
+| `k` | `dimensionedScalar` | Exponential stress scale, `[1 -1 -2 0 0 0 0]` |
+| `cf` | `scalar` | Fibre-direction stiffness coefficient |
+| `ct` | `scalar` | Transverse stiffness coefficient |
+| `cfs` | `scalar` | Fibre-transverse shear coefficient |
+| `rho` | `dimensionedScalar` | Density, read by the base `mechanicalLaw` |
+
+`bulkModulus` is also read with `lookup()` and is therefore required, unless
+`pressureDisplacement` is `yes`, in which case it is silently set to `GREAT`
+and never read.
+
+Optional entries:
+
+| Entry | Default | Description |
+| --- | --- | --- |
+| `pressureDisplacement` | `false` | Pressure-displacement formulation |
+| `uniformFibreField` | `false` | Read `f0` as a single vector |
+| `f0` | none | Fibre vector; required if `uniformFibreField` |
+| `calculateStressInLocalCoordinateSystem` | `false` | Use `EStar` form of `Q` |
+| `impKcoeff` | `1.0` | Scales `impK`, pressure-displacement only |
+| `writeS0N0R` | `false` | Write `s0`, `n0` and `R` at construction |
+
+`tangentEps` is read with `lookup()` inside `materialTangentField()`. It is
+only needed by solid models that request a material tangent, but it is a hard
+requirement for those.
+
+When `uniformFibreField` is `false`, a `volVectorField` named `f0` must exist
+in the start time directory or in `0`; the code tries the current time
+directory first and falls back to `0`, and aborts if neither has it.
+
+### Compatibility
+
+`correct(volSymmTensorField&)` is implemented for both modes, so the law works
+with the cell-centred nonlinear-geometry solid models, both total and updated
+Lagrangian (`updateF()` handles both).
+
+`correct(surfaceSymmTensorField&)` is implemented **only** when
+`pressureDisplacement` is enabled; otherwise it hits `notImplemented`. The
+face-based path is what `coupledPressureDisplacementSolid` uses, and that model
+also supplies the `p` and `pf` fields that the pressure-displacement branch
+looks up from the registry. Selecting `pressureDisplacement yes` with a solid
+model that does not create `p` will fail at the first `correct()` call.
+
+### Recommended dictionary setup
+
+Standard penalty-bulk-modulus form, for example with
+`nonLinearGeometryTotalLagrangianTotalDisplacement`:
+
+```text
+mechanical
+(
+    myocardium
+    {
+        type            GuccioneElastic;
+        rho             rho [1 -3 0 0 0 0 0] 1000;
+
+        k               k [1 -1 -2 0 0 0 0] 2000;
+        cf              8;
+        ct              2;
+        cfs             4;
+
+        // Penalty bulk modulus; aim for ~100 x the shear modulus
+        bulkModulus     bulkModulus [1 -1 -2 0 0 0 0] 1e6;
+
+        uniformFibreField yes;
+        f0              (0 0 1);
+
+        calculateStressInLocalCoordinateSystem no;
+    }
+);
+```
+
+Pressure-displacement form, for `coupledPressureDisplacementSolid`:
+
+```text
+mechanical
+(
+    myocardium
+    {
+        type            GuccioneElastic;
+        rho             rho [1 -3 0 0 0 0 0] 1000;
+        nu              nu [0 0 0 0 0 0 0] 0.5;
+
+        pressureDisplacement yes;
+        impKcoeff       2;
+
+        k               k [1 -1 -2 0 0 0 0] 2000;
+        cf              8;
+        ct              2;
+        cfs             4;
+
+        calculateStressInLocalCoordinateSystem true;
+    }
+);
+```
+
+Note that `nu` is not read by this law; it appears in the tutorials because
+other parts of the case setup expect it.
+
+### Field glossary
+
+- `f0`: reference fibre direction, unit length after construction.
+- `s0`, `n0`: generated sheet and sheet-normal directions; written only if
+  `writeS0N0R` is enabled.
+- `R`, `Rf`: rotation from the local fibre frame to global Cartesian axes.
+- `f0f0`, `f0f0f`: structural tensor `sqr(f0)` at cells and faces.
+- `S2PK`, `S2PKf`: the deviatoric 2nd Piola-Kirchhoff stress `S`.
+- `muEff`: effective shear modulus used for `impK` in pressure-displacement
+  mode; recomputed at the end of every time step.
+- `expQf`: face field holding `exp(Q)`, under-relaxed between outer iterations
+  in the pressure-displacement face path.
+
+---
+
+## Developer Notes
+
+### Class role
+
+`GuccioneElastic` derives from `mechanicalLaw`. It carries two parallel sets of
+fields, cell-centred and face-centred, so the same law can serve both the
+standard cell-centred solid models and `coupledPressureDisplacementSolid`.
+
+### Construction
+
+The constructor:
+
+1. Reads `bulkModulus` via the file-local helper `readBulkModulus()`, which
+   short-circuits to `GREAT` when `pressureDisplacement` is set.
+2. Reads `k`, `cf`, `ct`, `cfs` and forms the linearised shear modulus
+   `mu = 0.5*k*(cf + cfs + ct)/3`.
+3. Builds `f0` and `f0f` through `makeF0()`/`makeF0f()`, either from a uniform
+   vector or from a field on disk.
+4. Stores old-time copies of `F` and `Ff`.
+5. Normalises `f0`, constructs `s0` and `n0`, and assembles `R` and `Rf`.
+6. If `pressureDisplacement`, calls `calcInitialShearModulus()` and
+   `calcEffectiveShearModulus()`.
+
+### `correct()` walkthrough
+
+`correct(volSymmTensorField&)` first calls `updateF()`. If that returns `true`
+the solver has enforced linearised elasticity for stability and the function
+returns immediately. Otherwise:
+
+- `C = symm(F.T() & F)` and `E = 0.5*(C - I)`;
+- `Q` and `dQ/dE` are formed by one of the two branches above;
+- `S_ = dQdE*0.5*k*exp(Q)` (rotated back to global axes in the local branch);
+- the deviatoric Cauchy stress is `dev(symm(F & S & F.T))/J`;
+- `updateSigmaHyd()` supplies the hydrostatic term, with implicit stiffness
+  `(4/3)*mu + bulkModulus`.
+
+In the pressure-displacement branch the `/J` division is omitted and the
+hydrostatic term is `-p*I`, taken from the registry field `p`.
+
+`correct(surfaceSymmTensorField&)` mirrors this for faces, but only in
+pressure-displacement mode. It additionally stores and under-relaxes `expQf_`
+between outer iterations, which damps the strong exponential nonlinearity.
+
+### Implicit stiffness `impK()`
+
+```text
+pressureDisplacement:  impK = impKcoeff*muEff
+otherwise:             impK = (4/3)*mu + bulkModulus
+```
+
+`muEff` is not a material constant. `calcEffectiveShearModulus()` perturbs the
+displacement gradient by `0.001` in each of the three shear planes of the
+principal stress frame, evaluates the deviatoric Cauchy stress through
+`calcDevCauchy()`, and takes the largest resulting secant shear stiffness. It
+does this for both the old-time and current deformation gradients and keeps the
+maximum. `updateTotalFields()` refreshes it once per time step, so `impK`
+stiffens automatically as the exponential response steepens.
+
+`calcInitialShearModulus()` runs the same perturbation procedure once at
+construction to replace the analytic small-strain `mu`.
+
+### Material tangent
+
+`materialTangentField()` builds a `mat66` per face by finite-differencing the
+face stress with respect to each component of `grad(D)f`, using the step size
+`tangentEps`. It calls the private `calculateStress()` helper, which is
+currently `notImplemented`, so the tangent path is not usable as it stands.
+
+### Extension points
+
+- Supply `s0` explicitly rather than generating it, if genuine orthotropy
+  (`cf`, `ct`, `cfs` all distinct with a meaningful sheet plane) is wanted.
+- Implement `calculateStress(surfaceSymmTensorField&, const surfaceTensorField&)`
+  to enable the material tangent and the non-pressure-displacement face path.
+- Replace the penalty `bulkModulus` with a different volumetric energy in the
+  `updateSigmaHyd()` call.
+
+---
+
+## Tutorials
+
+Cases that select `GuccioneElastic`:
+
+- `solids/hyperelasticity/heartTissueBeam` (pressure-displacement)
+- `solids/hyperelasticity/idealisedVentricle/caseOptions/pressureDisplacement`
+- `solids/hyperelasticity/idealisedVentricle/caseOptions/petsc`, where it is
+  the passive law nested inside `electroMechanicalLaw`

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/HolzapfelGasserOgdenElastic/README.md
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/HolzapfelGasserOgdenElastic/README.md
@@ -1,0 +1,226 @@
+---
+sort: 24
+---
+
+# HolzapfelGasserOgdenElastic
+
+This page documents the Holzapfel-Gasser-Ogden (HGO) anisotropic hyperelastic
+law for fibre-reinforced soft tissue, in particular arterial wall. The runtime
+type is:
+
+```text
+HolzapfelGasserOgdenElastic
+```
+
+The law is **incompressible only**: the bulk modulus is always set to `GREAT`
+and the hydrostatic stress is taken from a solved pressure field. It is
+therefore intended for `coupledPressureDisplacementSolid`.
+
+The constitutive model is due to G. A. Holzapfel, T. C. Gasser and
+R. W. Ogden, _A new constitutive framework for arterial wall mechanics and a
+comparative study of material models_, Journal of Elasticity, 61 (2000) 1-48.
+
+---
+
+## User Guide
+
+### Constitutive relation
+
+The response is an isotropic neo-Hookean ground matrix plus two exponential
+fibre families, symmetric about the circumferential direction. With
+incompressibility (`J = 1`) enforced through the pressure field:
+
+```text
+b     = symm(F & F.T)
+s     = mu*(b - I)
+
+N4    =  cos(fibreAngle)*Ec + sin(fibreAngle)*Ea
+N6    = -cos(fibreAngle)*Ec + sin(fibreAngle)*Ea
+n4    = F & N4
+n6    = F & N6
+
+I4    = C && symm(N4*N4)
+I6    = C && symm(N6*N6)
+
+sigma = -p*I + s
+      + 2*k1*(I4 - 1)*exp(k2*sqr(I4 - 1))*symm(n4*n4)
+      + 2*k1*(I6 - 1)*exp(k2*sqr(I6 - 1))*symm(n6*n6)
+```
+
+This corresponds to the strain energy
+
+```text
+Psi = 0.5*mu*(I1 - 3)
+    + (k1/(2*k2))*sum_i (exp(k2*sqr(I_i - 1)) - 1)
+```
+
+with `i` running over the two fibre families.
+
+```warning
+The fibre terms are active in compression as well as tension. The standard HGO
+model switches them off when `I4 < 1`; this implementation does not, so the
+fibres carry compressive load.
+```
+
+### Local material directions
+
+The fibre directions are built from a local cylindrical triad that must already
+exist as fields:
+
+- `Ec`, `Ea`, `Er` as `volVectorField`s (circumferential, axial, radial);
+- `Ecf`, `Eaf`, `Erf` as `surfaceVectorField`s.
+
+All six are read `MUST_READ`, so the case must provide them before the solver
+starts. In the `ratCarotid` tutorial they are produced by a case-local utility,
+`calcLocCoordinates`, which the `Allrun` script compiles and runs first. Note
+that `Er` is multiplied by zero when forming the fibre vectors, so only `Ec` and
+`Ea` affect the result.
+
+### Model options
+
+Required entries:
+
+| Entry | Type | Description |
+| --- | --- | --- |
+| `rho` | `dimensionedScalar` | Density, `[1 -3 0 0 0 0 0]` |
+| `fibreAngle` | `dimensionedScalar` | Fibre angle in **degrees** from `Ec` |
+| `k1` | `dimensionedScalar` | Fibre stress scale, `[1 -1 -2 0 0 0 0]` |
+| `k2` | `dimensionedScalar` | Dimensionless fibre exponent |
+
+The shear modulus is given either as `E` together with `nu`, or as `mu` alone;
+supplying both forms, or neither, is a fatal error. When `E` and `nu` are used,
+`mu = E/(2*(1 + nu))` and `nu` must be `0.5` — anything smaller aborts with
+"This is incompressible solid model (nu=0.5)".
+
+Optional entries:
+
+| Entry | Default | Description |
+| --- | --- | --- |
+| `impKcoeff` | `1.0` | Scales the implicit stiffness `impK` |
+
+`fibreAngle` is converted from degrees to radians in the constructor, so give
+it in degrees.
+
+### Compatibility
+
+Both `correct(volSymmTensorField&)` and `correct(surfaceSymmTensorField&)` are
+implemented, and both look up a pressure field — `p` at cells and `pf` at
+faces. Only `coupledPressureDisplacementSolid` provides these, so that is
+effectively the only compatible solid model. Total and updated Lagrangian
+kinematics are both handled, because the deformation gradient is updated
+through the base-class `updateF()`.
+
+The law is registered for both OpenFOAM and foam-extend builds. The
+`ratCarotid` tutorial is foam-extend-only for reasons unrelated to the law
+itself.
+
+### Recommended dictionary setup
+
+```text
+mechanical
+(
+    arteryWall
+    {
+        type            HolzapfelGasserOgdenElastic;
+        rho             rho [1 -3 0 0 0 0 0] 1200;
+
+        E               E [1 -1 -2 0 0 0 0] 132.69e3;
+        nu              nu [0 0 0 0 0 0 0] 0.5;
+        // or, equivalently:
+        // mu           mu [1 -1 -2 0 0 0 0] 44.23e3;
+
+        impKcoeff       1;
+
+        // Fibre angle measured from the circumferential direction
+        fibreAngle      fibreAngle [0 0 0 0 0 0 0] 39.76;
+        k1              k1 [1 -1 -2 0 0 0 0] 0.206e3;
+        k2              k2 [0 0 0 0 0 0 0] 1.465;
+    }
+);
+```
+
+`constant/solidProperties` must select `coupledPressureDisplacementSolid`, and
+the start time directory must contain `Ec`, `Ea`, `Er`, `Ecf`, `Eaf` and `Erf`.
+
+### Field glossary
+
+- `Ec`, `Ea`, `Er`: local circumferential, axial and radial unit vectors at
+  cell centres; `Ecf`, `Eaf`, `Erf` are the face equivalents. All are written
+  with `AUTO_WRITE`.
+- `muEff`: effective shear modulus used by `impK`, updated once per time step.
+- `p`, `pf`: pressure at cells and faces, owned by the solid model.
+
+---
+
+## Developer Notes
+
+### Class role
+
+`HolzapfelGasserOgdenElastic` derives from `mechanicalLaw`. Unlike most laws it
+overrides `rho()`, returning the locally read `rho_` as a uniform field with
+`calculated` patch types.
+
+### Construction
+
+The constructor reads `rho`, `fibreAngle`, `k1`, `k2` and the six direction
+fields, then resolves `mu_` from either `E`/`nu` or `mu` and pins `K_` to
+`GREAT`. It converts `fibreAngle_` to radians, and finally calls
+`calcInitialShearModulus()` followed by `calcEffectiveShearModulus()` to
+populate `muEff_`.
+
+### `correct()` walkthrough
+
+`correct(volSymmTensorField&)` shadows the member `K_` with a **local**
+zero-valued `dimensionedScalar` of the same name before calling `updateF()`:
+
+```text
+dimensionedScalar K_("K", mu_.dimensions(), 0);
+if (updateF(sigma, mu_, K_)) { return; }
+```
+
+That local `K_` is what the enforced-linear fallback inside `updateF()` uses,
+so if the solver ever enforces linearised elasticity the fallback behaves as a
+zero-bulk-modulus material. The same shadowing appears in
+`correct(surfaceSymmTensorField&)`.
+
+After `updateF()`, the isotropic part is `mu*(b - I)` with `b = symm(F & F.T)`,
+the pressure term is subtracted, and the two fibre contributions are added. The
+Jacobian is never computed: the code assumes `J == 1`.
+
+The face variant delegates to the private `correctF()`, which is the same
+algebra written for `surface*` field types using `Ecf`, `Eaf` and `Erf`.
+
+### Implicit stiffness `impK()`
+
+```text
+impK = impKcoeff*muEff
+```
+
+`muEff` is a field, not a constant. `calcEffectiveShearModulus()` perturbs the
+displacement gradient by `0.001` in each of the three shear planes of the
+principal deviatoric stress frame, recomputes the deviatoric Cauchy stress via
+`calcDevCauchy()`, and stores the largest secant shear stiffness per cell. It
+evaluates both the old-time and current deformation gradient and keeps the
+maximum of the two. `updateTotalFields()` calls it at the end of each time step,
+so `impK` tracks the stiffening fibre response.
+
+`calcInitialShearModulus()` performs the same three shear perturbations once at
+construction, starting from `F = I` and using the direction vectors of cell 0
+only, and sets `mu_` to the largest result. This overwrites the value derived
+from `E` and `nu`.
+
+### Extension points
+
+- Add the `I4 < 1` / `I6 < 1` switch to disable fibres in compression.
+- Introduce the Gasser dispersion parameter `kappa`, which the full HGO model
+  uses to blend `I1` and `I4`; this implementation has no dispersion.
+- Generalise the two fibre families to an arbitrary list, or read fibre
+  directions directly rather than deriving them from `Ec` and `Ea`.
+
+---
+
+## Tutorials
+
+Cases that select `HolzapfelGasserOgdenElastic`:
+
+- `solids/hyperelasticity/ratCarotid`

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/MooneyRivlinElastic/README.md
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/MooneyRivlinElastic/README.md
@@ -1,0 +1,208 @@
+---
+sort: 18
+---
+
+# MooneyRivlinElastic
+
+This page documents the three-parameter Mooney-Rivlin hyperelastic law. The
+runtime type is:
+
+```text
+MooneyRivlinElastic
+```
+
+The model extends the neo-Hookean form with a dependence on the second
+invariant, which lets it reproduce rubber behaviour over a wider range of
+deformation modes. It supports heterogeneous material coefficients and an
+initial stress field.
+
+References:
+
+- M. Mooney (1940), _A theory of large elastic deformation_, Journal of
+  Applied Physics 11, 582-592,
+  [10.1063/1.1712836](https://doi.org/10.1063/1.1712836).
+- R. S. Rivlin and D. W. Saunders (1951), _Large elastic deformations of
+  isotropic materials VII. Experiments on the deformation of rubber_,
+  Philosophical Transactions of the Royal Society of London A 243, 251-288,
+  [10.1098/rsta.1951.0004](https://doi.org/10.1098/rsta.1951.0004).
+
+---
+
+## User Guide
+
+### Strain energy function
+
+The isochoric part uses the three-term Rivlin-Saunders form:
+
+```text
+Psi_iso = c10*(I1Bar - 3) + c01*(I2Bar - 3)
+        + c11*(I1Bar - 3)*(I2Bar - 3)
+```
+
+where the isochoric left Cauchy-Green tensor and its invariants are
+
+```text
+bBar  = J^(-2/3)*(F & F.T()),   J = det(F)
+I1Bar = tr(bBar)
+I2Bar = 0.5*(I1Bar^2 - tr(bBar & bBar))
+```
+
+The volumetric part is the same as in `neoHookeanElastic`,
+`U(J) = 0.5*K*(0.5*(J^2 - 1) - ln(J))`. The Cauchy stress evaluated by the
+code is
+
+```text
+J*sigma = 0.5*K*(J^2 - 1)*I
+        + dev( 2*(c10 + c11*(I2Bar - 3))*bBar
+             - 2*(c01 + c11*(I1Bar - 3))*inv(bBar) )
+        + F & sigma0 & F.T()
+```
+
+Setting `c11` to zero recovers the classical two-parameter Mooney-Rivlin
+model, and additionally setting `c01` to zero recovers a neo-Hookean model
+with `mu = 2*c10`.
+
+The law is registered in the nonlinear-geometry table, so it works with both
+total-Lagrangian and updated-Lagrangian solid models. It is not available to
+linear-geometry solid models.
+
+### Model options
+
+| Entry | Requirement | Description |
+| --- | --- | --- |
+| `c10` | required | First coefficient, `[1 -1 -2 0 0 0 0]` |
+| `c01` | required | Second coefficient, `[1 -1 -2 0 0 0 0]` |
+| `c11` | required | Coupled coefficient, `[1 -1 -2 0 0 0 0]` |
+| `rho` | required | Density, `[1 -3 0 0 0 0 0]` |
+
+All three coefficients are read with `lookup()`, so all three must be present;
+give `c11 c11 [1 -1 -2 0 0 0 0] 0;` if the coupled term is not wanted.
+
+The bulk modulus is set by **either** `K` **or** `nu`; if neither is present
+the constructor aborts. If both are present, `K` wins.
+
+| Entry | Requirement | Description |
+| --- | --- | --- |
+| `K` | one of two | Bulk modulus, `[1 -1 -2 0 0 0 0]` |
+| `nu` | one of two | Poisson's ratio, used if `K` is absent |
+
+When `nu` is supplied, `K` is derived from the linearised Young's modulus,
+`E = 6*(c10 + c01)` and `K = E/(3*(1 - 2*nu))`. The linearised shear modulus
+is always `mu = 2*(c10 + c01)`.
+
+Optional base-class entries:
+
+| Entry | Default | Description |
+| --- | --- | --- |
+| `solvePressureEqn` | `false` | Smooth `sigmaHyd` with a Laplacian |
+| `pressureSmoothingScaleFactor` | `100` | Scale factor for that smoothing |
+| `regionName` | auto | Base mesh region name |
+
+### Heterogeneous coefficients and pre-stress
+
+`c10`, `c01` and `c11` are stored as `volScalarField`s created with
+`READ_IF_PRESENT` and `AUTO_WRITE`. Placing `c10`, `c01` or `c11` fields in
+the start-time directory therefore overrides the uniform dictionary value with
+a spatially varying one, and the fields are written at every output time.
+
+The base-class `sigma0` initial-stress field is pushed forward with `F` and
+added to the Cauchy stress. Note that the uniform values in the dictionary
+are still required even when field files are supplied.
+
+### Recommended dictionary setup
+
+Minimal example for `constant/mechanicalProperties`:
+
+```text
+planeStress     no;
+
+mechanical
+(
+    rubber
+    {
+        type            MooneyRivlinElastic;
+        rho             rho [1 -3 0 0 0 0 0] 1000;
+
+        K               K [1 -1 -2 0 0 0 0] 1.410e+09;
+        c10             c10 [1 -1 -2 0 0 0 0] 0.293e+06;
+        c01             c01 [1 -1 -2 0 0 0 0] 0.177e+06;
+        c11             c11 [1 -1 -2 0 0 0 0] 0;
+
+        solvePressureEqn             yes;
+        pressureSmoothingScaleFactor 100;
+    }
+);
+```
+
+### Field glossary
+
+- `c10`, `c01`, `c11`: material coefficient fields, written at output times.
+- `F`, `Ff`: total deformation gradient at cell centres and faces.
+- `sigma0`: initial stress field, pushed forward and added to `sigma`.
+- `sigmaHyd`: hydrostatic Cauchy stress, `-p`.
+- `sigma`: Cauchy stress tensor returned to the solid model.
+- `impK`: implicit stiffness used as the Laplacian diffusivity.
+
+---
+
+## Developer Notes
+
+### Class role
+
+`MooneyRivlinElastic` inherits from `mechanicalLaw` and is added to the
+`nonLinGeomMechLaw` runtime selection table. Unlike `neoHookeanElastic`, it
+uses the base class's field-valued `mu()`, `K()`, `muf()` and `Kf()`
+accessors, which is what allows spatially varying coefficients.
+
+### Construction
+
+The three coefficient fields are constructed with `READ_IF_PRESENT` from the
+dictionary values. The body then sets `mu()` from `2*(c10 + c01)`, resolves
+`K()` from `K` or `nu`, prints the coefficient ranges, and finally
+interpolates `mu()` and `K()` onto faces with `muf()` and `Kf()`.
+
+Note that the class does not define a destructor and does not call
+`F().storeOldTime()`; the base class handles old-time creation lazily when
+required.
+
+### `correct()` walkthrough
+
+`correct(volSymmTensorField&)`:
+
+1. calls `updateF(sigma, mu(), K())` and returns early if the solid model has
+   enforced linearity for stability;
+2. forms `J`, `bBar` and `bBar & bBar`, then `I1Bar` and `I2Bar`;
+3. builds the deviatoric stress from the two coefficient groups;
+4. calls `updateSigmaHyd(0.5*K()*(J^2 - 1), (4/3)*mu() + K())`;
+5. assembles
+   `sigma = (1/J)*(dev(s) + sigmaHyd*I + symm(F & sigma0 & F.T()))`.
+
+The surface overload mirrors this using `Ff()`, `c10f_`, `c01f_`, `c11f_` and
+`Kf()`. It deliberately bypasses `updateSigmaHyd()` and computes
+`0.5*Kf()*(J^2 - 1)` locally, so the pressure smoothing enabled by
+`solvePressureEqn` applies to the cell-centred stress only.
+
+### Implicit stiffness
+
+`impK()` returns `(4/3)*mu() + K()`, evaluated from the linearised moduli. It
+is a genuine field, so the segregated diffusivity follows any spatial
+variation in the coefficients. It does not stiffen as the material stiffens
+under large strain, so heavily deformed cases may need more outer correctors.
+
+### Extension points
+
+- Additional Rivlin terms only require extending the deviatoric-stress
+  expression in both `correct()` overloads and updating the linearised `mu`.
+- The face coefficients `c10f_`, `c01f_` and `c11f_` are interpolated once at
+  construction; a law with evolving coefficients would need to refresh them.
+
+---
+
+## Tutorials
+
+Cases that select `MooneyRivlinElastic`:
+
+- `solids/hyperelasticity/cylinderCrush`
+- `solids/hyperelasticity/cylindricalPressureVessel`
+- `solids/hyperelasticity/cylindricalPressureVessel/caseOptions/displacement`
+- `solids/hyperelasticity/longWall`

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/OgdenElastic/README.md
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/OgdenElastic/README.md
@@ -1,0 +1,184 @@
+---
+sort: 20
+---
+
+# OgdenElastic
+
+This page documents the three-term Ogden hyperelastic mechanical law. The
+runtime type is:
+
+```text
+OgdenElastic
+```
+
+---
+
+## User Guide
+
+### What it computes
+
+The cell-centred `correct` forms the right Cauchy-Green tensor and its
+principal stretches. With `c_i` denoting an eigenvalue of `C`, the implemented
+relation is:
+
+```text
+C        = F^T F
+J        = det(F)
+lambda_i = max(sqrt(c_i), VSMALL)
+p_i      = mu1*lambda_i^alpha1
+         + mu2*lambda_i^alpha2
+         + mu3*lambda_i^alpha3
+s        = rotation of diag(p_1, p_2, p_3) to the spatial basis
+sigmaHyd = (K/2)*(J^2 - 1)
+sigma    = (1/J)*[dev(s - (mu1 + mu2 + mu3)*I)
+           + sigmaHyd*I + symm(F sigma0 F^T)]
+```
+
+The subtraction of `(mu1 + mu2 + mu3)*I` occurs inside `dev`, so it does not
+alter the deviatoric result. `updateSigmaHyd()` either assigns the expression
+above directly or obtains a smoothed field by solving the pressure equation.
+If the solid model enforces material linearity, `updateF()` returns a Hookean
+stress based on `mu1 + mu2 + mu3` and `K` before the Ogden calculation.
+
+The law implements `correct(volSymmTensorField&)`. Its
+`correct(surfaceSymmTensorField&)` overload aborts with `notImplemented`. The
+inherited point-tensor overload also aborts. On OpenFOAM.com and OpenFOAM.org,
+the inherited `CompactListList` quadrature-point overload is present and
+aborts; that interface is not compiled on foam-extend.
+
+### Model options
+
+| Entry | Required | Description |
+| --- | --- | --- |
+| `mu1` | yes | First modulus parameter, `[1 -1 -2 0 0 0 0]` |
+| `mu2` | yes | Second modulus parameter, `[1 -1 -2 0 0 0 0]` |
+| `mu3` | yes | Third modulus parameter, `[1 -1 -2 0 0 0 0]` |
+| `alpha1` | yes | First exponent, `[0 0 0 0 0 0 0]` |
+| `alpha2` | yes | Second exponent, `[0 0 0 0 0 0 0]` |
+| `alpha3` | yes | Third exponent, `[0 0 0 0 0 0 0]` |
+| `K` | yes | Bulk modulus, `[1 -1 -2 0 0 0 0]` |
+| `rho` | yes | Density, `[1 -3 0 0 0 0 0]` |
+| `solvePressureEqn` | no | Solve for pressure; default `no` |
+| `pressureSmoothingScaleFactor` | no | Pressure scale; default `100` |
+| `regionName` | no | Base mesh region; otherwise detected |
+
+All seven law-specific entries are read as `dimensionedScalar` values. The
+constructor does not apply explicit range or sign checks. `rho` is read lazily
+by the base-class density accessor. The remaining base-class entries are
+described on the
+[mechanical-law page](https://www.solids4foam.com/documentation/material-models/mechanical-law.html).
+
+Initial stress is not a dictionary entry for this law. The base class instead
+reads a `sigma0` volume field if it is present and otherwise creates a zero
+field.
+
+### Recommended dictionary setup
+
+The following rubber parameters are used by the commented Ogden alternative
+in the `cylinderCrush` tutorial:
+
+```text
+mechanical
+(
+    rubber
+    {
+        type            OgdenElastic;
+        rho             rho [1 -3 0 0 0 0 0] 1000;
+        K               K [1 -1 -2 0 0 0 0] 1.410e9;
+        mu1             mu1 [1 -1 -2 0 0 0 0] 0.746e6;
+        mu2             mu2 [1 -1 -2 0 0 0 0] -0.306e6;
+        mu3             mu3 [1 -1 -2 0 0 0 0] 6.609e-5;
+        alpha1          alpha1 [0 0 0 0 0 0 0] 1.748;
+        alpha2          alpha2 [0 0 0 0 0 0 0] -1.656;
+        alpha3          alpha3 [0 0 0 0 0 0 0] 7.671;
+
+        // Optional
+        // solvePressureEqn             no;
+        // pressureSmoothingScaleFactor 100;
+        // regionName                   region0;
+    }
+);
+```
+
+### Field glossary
+
+- `mu_<name>`, `K_<name>`: uniform cell fields set to `mu1 + mu2 + mu3` and
+  `K` for use by the base class.
+- `muf_<name>`, `Kf_<name>`: corresponding interpolated face fields.
+- `F_`, `relF_`: total and relative deformation gradients maintained by
+  `updateF()`; `F_` is written for incremental total-Lagrangian restarts.
+- `sigmaHyd`, `grad(sigmaHyd)`: hydrostatic stress quantity and its gradient,
+  created when the stress is first corrected.
+- `sigma0`: initial stress field, read if present and otherwise initialised to
+  zero. It is pushed forward as `symm(F sigma0 F^T)/J`.
+- `impK`: implicit stiffness field returned as `(4/3)*mu + K`.
+- `eigenVal(C)`, `eigenVec(C)`, `s`: non-writing temporary fields created
+  during each cell-centred stress correction.
+
+---
+
+## Developer Notes
+
+### Class role
+
+`OgdenElastic` derives directly from `mechanicalLaw` and is registered in the
+`nonLinGeomMechLaw` runtime selection table. It stores seven uniform
+`dimensionedScalar` members: `mu1_`, `mu2_`, `mu3_`, `alpha1_`, `alpha2_`,
+`alpha3_` and `K_`.
+
+The `#ifdef FOAMEXTEND` branches in `correct()` select the appropriate mutable
+internal- and boundary-field APIs. The quadrature-point base interface is
+guarded by `#ifndef FOAMEXTEND`. The law is listed in both `Make/files.openfoam`
+and `Make/files.foamextend`.
+
+### Construction
+
+The base constructor first adds `solvePressureEqn` with default `false` and
+`pressureSmoothingScaleFactor` with default `100.0` when they are absent. It
+then uses `regionName`, or detects `solid` and then `region0`. Failure to find a
+base mesh region produces a fatal error.
+
+The derived constructor reads `mu1`, `mu2`, `mu3`, `alpha1`, `alpha2`,
+`alpha3` and `K`, in that order, and prints their values. A missing or malformed
+required entry produces the dictionary reader's fatal error; the class has no
+additional parameter validation. It sets the inherited cell shear modulus to
+`mu1 + mu2 + mu3`, sets the cell bulk modulus to `K`, and interpolates both to
+the faces. Construction itself emits no law-specific warnings.
+
+When `sigma0` is later created on a distinct single-material mesh, the base
+class warns that mapping from the base mesh may be incorrect. `updateF()` also
+aborts for a non-incremental updated-Lagrangian solid and warns once per time
+step when material linearity is enforced.
+
+### Key methods
+
+- `impK()`: returns `(4/3)*(mu1 + mu2 + mu3) + K`. This is the diffusivity of
+  the solid model's implicit Laplacian term and affects outer-iteration
+  convergence rate rather than the converged answer.
+- `correct(volSymmTensorField&)`: updates `F`, computes the eigenpairs of
+  `F^T F`, builds and rotates the three principal stress values, updates the
+  hydrostatic quantity, and adds the pushed-forward initial stress.
+- `correct(surfaceSymmTensorField&)`: aborts with `notImplemented`.
+- `materialTangent()`: is not overridden. The inherited implementation aborts
+  with `notImplemented`, so this law does not provide a 6x6 Newton tangent.
+
+### Extension points
+
+A related principal-stretch law can copy this class, retain registration in
+the nonlinear-geometry selection table, and replace the principal-stress and
+hydrostatic expressions in the cell-centred `correct()`. Implement the face,
+point or quadrature-point `correct()` overloads for solid models that use those
+interfaces, and override `materialTangent()` for Newton methods that request a
+consistent tangent. Add the new source file to each supported fork's build
+list.
+
+The source is at
+[OgdenElastic.C](https://github.com/solids4foam/solids4foam/blob/master/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/OgdenElastic/OgdenElastic.C).
+
+---
+
+## Tutorials
+
+- `solids/hyperelasticity/cylinderCrush` contains an equivalent Ogden setup,
+  but it is commented out; the active configuration uses
+  `MooneyRivlinElastic`.

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/README.md
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/README.md
@@ -1,0 +1,146 @@
+---
+sort: 14
+---
+
+# Nonlinear geometry mechanical laws
+
+This section documents the mechanical laws that make no small-strain or
+small-rotation assumption.
+
+A mechanical law is the constitutive part of a solids4foam case: the solid
+model assembles and solves the momentum equation, and the mechanical law
+answers the single question _given the current displacement field, what is the
+stress?_ Nonlinear geometry laws answer that question in terms of the
+deformation gradient
+
+```text
+F = I + grad(D)^T
+J = det(F)
+```
+
+and quantities derived from it, such as the left Cauchy-Green tensor
+`B = F & F.T()`, the Green strain `G = 0.5*(F.T() & F - I)`, and the isochoric
+split `isoB = J^(-2/3)*B`. Because the reference and deformed configurations
+are distinct, these laws must also be explicit about which stress measure they
+return — the Cauchy stress `sigma` for updated-Lagrangian laws, the second
+Piola-Kirchhoff stress `S` for total-Lagrangian ones.
+
+Laws in this directory are registered under the `nonLinGeomMechLaw` run-time
+selection table and are intended for the nonlinear geometry solid models, for
+example `nonLinearGeometryUpdatedLagrangian`,
+`nonLinearGeometryTotalLagrangianTotalDisplacement` and
+`unsNonLinearGeometryTotalLagrangian`.
+
+```note
+The linear geometry counterparts live in `linearGeometryLaws` and are
+registered under a separate `linGeomMechLaw` table. A law from one table
+cannot be selected by a solid model that uses the other.
+```
+
+---
+
+## Catalogue
+
+For every law in this subsection the run-time selection name registered by
+`addToRunTimeSelectionTable` is identical to the C++ class name, so the class
+name is what you type in `constant/mechanicalProperties`.
+
+| Runtime type | Purpose |
+| --- | --- |
+| `StVenantKirchhoffElastic` | Hookean law in Green strain and 2nd PK stress |
+| `StVenantKirchhoffOrthotropicElastic` | Nine-parameter orthotropic St Venant |
+| `neoHookeanElastic` | Compressible neo-Hookean, Simo and Hughes Eqn 9.2.6 |
+| `MooneyRivlinElastic` | Three-parameter Mooney-Rivlin |
+| `YeohElastic` | Three-parameter Yeoh |
+| `OgdenElastic` | Third-order Ogden, in principal stretches |
+| `GentElastic` | Gent-Flory law for the swelling behaviour of microgels |
+| `isotropicFungElastic` | Two-parameter exponential Fung-like model |
+| `GuccioneElastic` | Exponential Guccione law for myocardium |
+| `HolzapfelGasserOgdenElastic` | Two-fibre-family anisotropic HGO law |
+| `neoHookeanElasticMisesPlastic` | Neo-Hookean with J2 plasticity |
+| `viscoNeoHookeanElastic` | Neo-Hookean generalised Maxwell viscoelasticity |
+| `electroMechanicalLaw` | Wrapper adding an active electro-mechanical stress |
+| `diffusionHyperElastic` | Neo-Hookean scaled by a mesh motion diffusivity |
+
+`neoHookeanElastic`, `MooneyRivlinElastic`, `YeohElastic`, `OgdenElastic`,
+`GentElastic` and `isotropicFungElastic` are isotropic and purely elastic, and
+differ only in their strain energy function; `StVenantKirchhoffElastic` is the
+degenerate case that keeps a linear stress-strain relation while accounting for
+finite rotation. The remaining anisotropic laws each need directional data in
+addition to their material constants: `StVenantKirchhoffOrthotropicElastic`
+takes a local coordinate system, while `GuccioneElastic` and
+`HolzapfelGasserOgdenElastic` take a fibre direction field. The latter two were
+added for cardiovascular modelling.
+
+`neoHookeanElasticMisesPlastic` and `viscoNeoHookeanElastic` are the two
+inelastic laws in this subsection: they carry internal state between time
+steps, so they require the solid model to be run with a sensible time step
+rather than as a steady-state solve.
+
+`electroMechanicalLaw` is a _wrapper_. It owns a nested, run-time selectable
+passive hyperelastic law and adds an active stress contribution to whatever
+that law returns, so it can be combined with most of the other entries.
+
+`diffusionHyperElastic` is not a physical material model; like
+`diffusionElastic` in the linear geometry subsection, it exists so that a solid
+model can be used as a mesh motion solver.
+
+```warning
+`HolzapfelGasserOgdenElastic` is written for the mixed pressure-displacement
+formulation and is intended for `coupledPressureDisplacementSolid`. It is not
+a drop-in replacement for the other laws here.
+```
+
+---
+
+## Selecting a law
+
+Mechanical laws are selected in `constant/mechanicalProperties`. The
+`mechanical` entry is a _list_ of sub-dictionaries, one per material, so
+multi-material cases are expressed by adding further entries:
+
+```text
+planeStress     no;
+
+mechanical
+(
+    rubber
+    {
+        type            neoHookeanElastic;
+        rho             rho [1 -3 0 0 0 0 0] 1100;
+        E               E [1 -1 -2 0 0 0 0] 6e6;
+        nu              nu [0 0 0 0 0 0 0] 0.45;
+    }
+);
+```
+
+The name of each sub-dictionary (`rubber` above) is arbitrary; for
+multi-material cases it must match the corresponding `cellZone`.
+
+Most of these laws accept their stiffness as either the `E`/`nu` pair or the
+`mu`/`K` pair, in the same way as `linearElastic`, and then add their own
+law-specific constants. The individual pages give the exact entries.
+
+### Entries every law understands
+
+These are read by the `mechanicalLaw` base class, so they are valid inside any
+of the sub-dictionaries above:
+
+| Entry | Default | Description |
+| --- | --- | --- |
+| `rho` | required | Density, `[1 -3 0 0 0 0 0]` |
+| `solvePressureEqn` | `no` | Solve a Laplacian for hydrostatic pressure |
+| `pressureSmoothingScaleFactor` | `100` | Scale factor for that equation |
+| `regionName` | auto | Object registry holding the solid mesh |
+
+`rho` is looked up on demand rather than at construction, so a missing `rho`
+is reported the first time the solid model asks for the density.
+
+The top-level `planeStress` switch sits outside the `mechanical` list and is
+read by the base class through the `mechanicalProperties` dictionary itself.
+Several laws here consult it when converting `E` and `nu` into the constants
+they actually use: with `planeStress yes` the second Lame parameter becomes
+`nu*E/((1 + nu)*(1 - nu))` rather than `nu*E/((1 + nu)*(1 - 2*nu))`. It changes
+only that conversion — it does not impose a plane stress constraint on the
+solution — so a genuine plane stress analysis still has to be set up as a
+one-cell-thick three-dimensional model with a traction-free front and back.

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/StVenantKirchhoffElastic/README.md
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/StVenantKirchhoffElastic/README.md
@@ -1,0 +1,176 @@
+---
+sort: 15
+---
+
+# StVenantKirchhoffElastic
+
+This page documents the St. Venant-Kirchhoff hyperelastic law. The runtime
+type is:
+
+```text
+StVenantKirchhoffElastic
+```
+
+The St. Venant-Kirchhoff model is the simplest finite-strain extension of
+Hooke's law: the second Piola-Kirchhoff stress is a linear function of the
+Green-Lagrange strain. It captures large rotations exactly but is only valid
+for small to moderate strains, since the model softens unphysically under
+large compression.
+
+---
+
+## User Guide
+
+### Strain energy function
+
+```text
+Psi = mu*(E && E) + 0.5*lambda*(tr(E))^2
+
+E = 0.5*(C - I),   C = F.T() & F
+```
+
+Differentiating gives the second Piola-Kirchhoff stress that the code
+evaluates,
+
+```text
+S = 2*mu*E + lambda*tr(E)*I
+```
+
+which is then pushed forward to the Cauchy stress,
+
+```text
+sigma = (1/J)*F & S & F.T(),   J = det(F)
+```
+
+The law is registered in the nonlinear-geometry table, so it works with both
+total-Lagrangian and updated-Lagrangian solid models. It is not available to
+linear-geometry solid models; use `linearElastic` there instead.
+
+```warning
+Because `Psi` is quadratic in the Green strain, the model does not penalise
+`J` approaching zero. Do not use it for problems with large volumetric
+compression; prefer `neoHookeanElastic` or another of the rubber-like laws.
+```
+
+### Model options
+
+Elastic constants must be given as **either** `E` and `nu` **or** `mu` and
+`K`. Mixing the two pairs is a fatal error.
+
+| Entry | Requirement | Description |
+| --- | --- | --- |
+| `E` | with `nu` | Young's modulus, `[1 -1 -2 0 0 0 0]` |
+| `nu` | with `E` | Poisson's ratio, dimensionless |
+| `mu` | with `K` | Shear modulus, `[1 -1 -2 0 0 0 0]` |
+| `K` | with `mu` | Bulk modulus, `[1 -1 -2 0 0 0 0]` |
+| `rho` | required | Density, `[1 -3 0 0 0 0 0]` |
+
+The first Lame parameter is derived internally:
+
+```text
+lambda = nu*E/((1 + nu)*(1 - 2*nu))          plane strain / 3-D
+lambda = nu*E/((1 + nu)*(1 - nu))            plane stress
+```
+
+The plane-stress form is used when the top-level `planeStress` entry of
+`constant/mechanicalProperties` is `yes`. The bulk modulus is then recomputed
+as `K = lambda + (2/3)*mu`, so a user-supplied `K` is overwritten under plane
+stress.
+
+The base class also accepts the optional entries `solvePressureEqn` (default
+`false`), `pressureSmoothingScaleFactor` (default `100`) and `regionName`, but
+this law never calls `updateSigmaHyd()`, so the pressure smoothing has no
+effect here.
+
+### Recommended dictionary setup
+
+Minimal example for `constant/mechanicalProperties`:
+
+```text
+planeStress     no;
+
+mechanical
+(
+    steel
+    {
+        type            StVenantKirchhoffElastic;
+        rho             rho [1 -3 0 0 0 0 0] 7800;
+        E               E [1 -1 -2 0 0 0 0] 200e+09;
+        nu              nu [0 0 0 0 0 0 0] 0.3;
+    }
+);
+```
+
+### Field glossary
+
+- `F`, `Ff`: total deformation gradient at cell centres and faces.
+- `relF`, `relFf`: relative deformation gradient, used in the updated
+  Lagrangian formulation.
+- `sigma`: Cauchy stress tensor returned to the solid model.
+- `impK`: implicit stiffness used as the Laplacian diffusivity.
+
+---
+
+## Developer Notes
+
+### Class role
+
+`StVenantKirchhoffElastic` inherits from `mechanicalLaw` and is added to the
+`nonLinGeomMechLaw` runtime selection table. It holds `lambda_`, `mu_` and
+`K_` as uniform `dimensionedScalar` values, so a single material entry is
+homogeneous.
+
+### Construction
+
+The constructor resolves `E` and `nu` from whichever pair the user supplied,
+sets `lambda_` from the plane-stress or plane-strain relation, recomputes
+`K_ = lambda_ + (2/3)*mu_`, and finally calls `F().storeOldTime()` and
+`Ff().storeOldTime()` so that the old-time deformation gradients exist from
+the first time step.
+
+### `correct()` walkthrough
+
+Both the volume-field and the surface-field overloads follow the same five
+steps:
+
+1. call `updateF(sigma, mu_, K_)`; a `true` return means the solid model
+   requested enforced linearity for stability, the base class has already
+   written a Hooke's law stress, and the function returns;
+2. materialise `FT` into its own field before contracting;
+3. form `C = symm(FT & F)` and the Green strain `E = 0.5*(C - I)`;
+4. evaluate `S = 2*mu*E + lambda*tr(E)*I`;
+5. push forward with `sigma = (1/J)*transform(F, S)`.
+
+```warning
+This file carries the canonical `NOTE [IMPORTANT]` comment that other laws
+refer to: never write `F.T() & F` as a single field expression. The lazy
+`tmp<>` pathway can drop shear-squared contributions when the transpose is not
+materialised, which was observed with g++ 11.x. Always build `FT` first.
+```
+
+### Implicit stiffness
+
+`impK()` returns `2*mu + lambda`, the standard segregated-solver diffusivity
+for an isotropic elastic material. It is a uniform field, so the same value is
+used everywhere within the material.
+
+### Extension points
+
+- The constitutive relation is duplicated between the two `correct()`
+  overloads; any change must be applied to both.
+- `setRestart()` sets `AUTO_WRITE` on `F` and `Ff` so a restart reproduces the
+  same deformation state.
+
+---
+
+## Tutorials
+
+Cases that select `StVenantKirchhoffElastic`:
+
+- `solids/hyperelasticity/rigidRotation/rotatingBlock`
+- `solids/hyperelasticity/rigidRotation/rotatingCylinder`
+- `solids/hyperelasticity/rigidRotation/rotatingSphere`
+- `fluidSolidInteraction/cavityFlexibleBottom`
+
+The `fluidSolidInteraction/3dTube` and `fluidSolidInteraction-preCICE/3dTube`
+cases ship the law as a commented alternative to `linearElastic`.

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/StVenantKirchhoffOrthotropicElastic/README.md
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/StVenantKirchhoffOrthotropicElastic/README.md
@@ -1,0 +1,215 @@
+---
+sort: 16
+---
+
+# StVenantKirchhoffOrthotropicElastic
+
+This page documents the orthotropic St. Venant-Kirchhoff hyperelastic law. The
+runtime type is:
+
+```text
+StVenantKirchhoffOrthotropicElastic
+```
+
+The law is the orthotropic generalisation of
+`StVenantKirchhoffElastic`: the second Piola-Kirchhoff stress is a linear
+function of the Green-Lagrange strain through a fourth-order orthotropic
+stiffness tensor, expressed in a user-defined material coordinate system.
+
+```warning
+The entire implementation file is wrapped in `#ifdef FOAMEXTEND`. Although the
+source is listed in both `Make/files.openfoam` and `Make/files.foamextend`, it
+compiles to an empty translation unit on OpenFOAM.com and OpenFOAM.org
+builds, so the law is **only selectable in foam-extend**.
+```
+
+---
+
+## User Guide
+
+### Constitutive relation
+
+```text
+S = C : E,   E = 0.5*(F.T() & F - I),   sigma = (1/J)*F & S & F.T()
+```
+
+`C` is the orthotropic stiffness in the material frame, built from nine
+independent constants. With
+
+```text
+Jc = (1 - nu12*nu21 - nu23*nu32 - nu31*nu13 - 2*nu21*nu32*nu13)/(E1*E2*E3)
+```
+
+the normal-stress block is
+
+```text
+C11 = (1 - nu23*nu32)/(Jc*E2*E3)
+C22 = (1 - nu13*nu31)/(Jc*E1*E3)
+C33 = (1 - nu21*nu12)/(Jc*E2*E1)
+C12 = (nu12 + nu32*nu13)/(Jc*E1*E3)
+C31 = (nu31 + nu21*nu32)/(Jc*E2*E3)
+C23 = (nu23 + nu21*nu13)/(Jc*E1*E2)
+```
+
+and the shear block is `C44 = 2*G12`, `C55 = 2*G23`, `C66 = 2*G31`. The
+reciprocal Poisson's ratios are derived from the symmetry conditions
+`nu21 = nu12*E2/E1`, `nu32 = nu23*E3/E2` and `nu13 = nu31*E1/E3`; do not
+specify them.
+
+`C` is assembled in the local material frame and then rotated into the global
+frame with the `materialDirections` tensor field.
+
+Registered in the nonlinear-geometry table, the law works with both
+total-Lagrangian and updated-Lagrangian solid models. Plane stress is
+explicitly rejected at construction.
+
+### Model options
+
+All nine elastic constants are required and are read with `lookup()`:
+
+| Entry | Dimensions | Description |
+| --- | --- | --- |
+| `E1`, `E2`, `E3` | `[1 -1 -2 0 0 0 0]` | Young's moduli, material axes |
+| `nu12`, `nu23`, `nu31` | `[0 0 0 0 0 0 0]` | Independent Poisson's ratios |
+| `G12`, `G23`, `G31` | `[1 -1 -2 0 0 0 0]` | Shear moduli |
+| `rho` | `[1 -3 0 0 0 0 0]` | Density |
+
+Two optional entries set the material axes:
+
+| Entry | Default | Description |
+| --- | --- | --- |
+| `materialDirection1` | `(1 0 0)` | First material axis |
+| `materialDirection2` | `(0 1 0)` | Second material axis |
+
+Both are read with `lookupOrAddDefault`, so a missing entry is written back
+into the dictionary.
+
+```warning
+There is no working third material axis. The constructor reads
+`materialDirection2` a second time, with a default of `(0 0 1)`, in the slot
+where `materialDirection3` is intended. The third row of the rotation tensor
+therefore always ends up equal to the second, which makes the tensor singular
+and the resulting global stiffness wrong. A `materialDirection3` entry in the
+dictionary is silently ignored. Until this is fixed in the source, supply the
+orientation through a `materialDirections` field instead.
+```
+
+The two entries only build the uniform default of the `materialDirections`
+tensor field, whose rows are the three material axes. A spatially varying, and
+correct, orientation can be supplied by placing a `materialDirections`
+`volTensorField` in the time directory; it is read `READ_IF_PRESENT` and takes
+precedence over the uniform default. The rows are normalised after reading,
+and zero-length rows are a fatal error.
+
+### Physical-admissibility checks
+
+The constructor aborts if:
+
+- any of `E1`, `E2`, `E3`, `G12`, `G23`, `G31` is negative;
+- `mag(nu_ij)` is not less than `sqrt(E_i/E_j)` for the three supplied ratios;
+- the determinant term
+  `1 - nu12*nu21 - nu23*nu32 - nu31*nu13 - 2*nu21*nu32*nu13` is not positive;
+- `planeStress` is `yes`.
+
+### Recommended dictionary setup
+
+Minimal example for `constant/mechanicalProperties`:
+
+```text
+planeStress     no;
+
+mechanical
+(
+    composite
+    {
+        type            StVenantKirchhoffOrthotropicElastic;
+        rho             rho [1 -3 0 0 0 0 0] 1600;
+
+        E1              E1 [1 -1 -2 0 0 0 0] 130e+09;
+        E2              E2 [1 -1 -2 0 0 0 0] 10e+09;
+        E3              E3 [1 -1 -2 0 0 0 0] 10e+09;
+
+        nu12            nu12 [0 0 0 0 0 0 0] 0.3;
+        nu23            nu23 [0 0 0 0 0 0 0] 0.4;
+        nu31            nu31 [0 0 0 0 0 0 0] 0.023;
+
+        G12             G12 [1 -1 -2 0 0 0 0] 5e+09;
+        G23             G23 [1 -1 -2 0 0 0 0] 3.6e+09;
+        G31             G31 [1 -1 -2 0 0 0 0] 5e+09;
+
+        materialDirection1 (1 0 0);
+        materialDirection2 (0 1 0);
+    }
+);
+```
+
+### Field glossary
+
+- `materialDirections`: tensor field whose rows are the normalised material
+  axes; read from the time directory if present.
+- `elasticC`, `elasticCf`: fourth-order stiffness in the global frame, at cell
+  centres and faces; demand-driven and not written.
+- `F`, `Ff`: total deformation gradient.
+- `sigma`: Cauchy stress tensor returned to the solid model.
+- `impK`: implicit stiffness used as the Laplacian diffusivity.
+
+---
+
+## Developer Notes
+
+### Class role
+
+`StVenantKirchhoffOrthotropicElastic` inherits from `mechanicalLaw` and is
+added to the `nonLinGeomMechLaw` runtime selection table. It relies on the
+`symmTensor4thOrder` type and its `transform` overloads, which exist only in
+foam-extend; this is the reason for the `FOAMEXTEND` guard.
+
+### Construction
+
+The nine constants and the three reciprocal ratios are set in the initialiser
+list, together with the `materialDirections` field. The body then runs the
+admissibility checks, normalises the direction vectors, and initialises the
+scalar `mu_` and `K_` used by the base class:
+
+```text
+mu = (G12 + G23 + G31)/3
+K  = Ebar*mu/(3*(3*mu - Ebar)),   Ebar = (E1 + E2 + E3)/3
+```
+
+These two scalars are only passed to `updateF()`, where they define the
+isotropic Hooke's law fallback used when the solid model enforces linearity.
+
+### Demand-driven stiffness
+
+`elasticC()` and `elasticCf()` build their fields on first access through
+`makeElasticC()` and `makeElasticCf()`, which duplicate the same nine
+coefficient expressions. The cell-centred tensor is rotated by `matDir_` and
+the face tensor by `fvc::interpolate(matDir_)`. Both pointers are released in
+the destructor via `deleteDemandDrivenData`.
+
+### `correct()` walkthrough
+
+Both overloads:
+
+1. call `updateF(sigma, mu_, K_)` and return early if enforced linearity is
+   active;
+2. materialise `FT` before contracting, as required by the note in
+   `StVenantKirchhoffElastic.C`;
+3. form `C = symm(FT & F)` and the Green strain `E = 0.5*(C - I)`;
+4. evaluate `S = elasticC() && E`;
+5. push forward with `sigma = (1/J)*transform(F, S)`.
+
+### Implicit stiffness
+
+`impK()` returns the average of the three normal diagonal components of
+`elasticC`, `(C_XXXX + C_YYYY + C_ZZZZ)/3`. A `diagTensor` diffusivity would
+be more faithful, but the source comment notes that the scalar average gives
+similar convergence in practice.
+
+### Extension points
+
+- The coefficient assembly is duplicated between `makeElasticC()` and
+  `makeElasticCf()`; factor it out before changing the stiffness definition.
+- Fixing the third material direction requires changing the second
+  `materialDirection2` lookup in the `matDir_` initialiser to
+  `materialDirection3`.

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/YeohElastic/README.md
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/YeohElastic/README.md
@@ -1,0 +1,201 @@
+---
+sort: 19
+---
+
+# YeohElastic
+
+This page documents the compressible three-parameter Yeoh hyperelastic law.
+The runtime type is:
+
+```text
+YeohElastic
+```
+
+---
+
+## User Guide
+
+### What it computes
+
+The law uses the following isochoric strain-energy function:
+
+```text
+Psi_iso = c1*(isoI1 - 3) + c2*(isoI1 - 3)^2 + c3*(isoI1 - 3)^3
+```
+
+The implemented cell-centred stress update is:
+
+```text
+J       = det(F)
+isoB    = J^(-2/3)*symm(F & F.T)
+isoI1   = tr(isoB)
+q       = c1 + 2*c2*(isoI1 - 3) + 3*c3*(isoI1 - 3)^2
+sigmaHydExplicit = 0.5*K*(J^2 - 1)
+J*sigma = 2*q*dev(isoB) + sigmaHyd*I + symm(F & sigma0 & F.T)
+```
+
+For the cell-centred overload, `sigmaHyd` is passed through
+`updateSigmaHyd()`. It equals `sigmaHydExplicit` unless `solvePressureEqn` is
+enabled, in which case the base class obtains it from a smoothed Laplacian
+equation. The face-centred overload uses `Ff`, interpolated material fields and
+the explicit hydrostatic term directly.
+
+The law implements `correct(volSymmTensorField&)` and
+`correct(surfaceSymmTensorField&)`. The inherited point-centred overload aborts
+with `notImplemented`. On OpenFOAM.com and OpenFOAM.org, the inherited
+`CompactListList` quadrature-point overload also aborts with `notImplemented`;
+that overload is excluded from foam-extend by `#ifndef FOAMEXTEND` in the base
+class.
+
+### Model options
+
+The three Yeoh coefficients are required. The bulk response is specified by
+either `K` or `nu`; when both are present, `K` takes precedence.
+
+| Entry | Required | Description |
+| --- | --- | --- |
+| `c1` | yes | First Yeoh coefficient, `[1 -1 -2 0 0 0 0]` |
+| `c2` | yes | Second Yeoh coefficient, `[1 -1 -2 0 0 0 0]` |
+| `c3` | yes | Third Yeoh coefficient, `[1 -1 -2 0 0 0 0]` |
+| `K` | `K` or `nu` | Bulk modulus, `[1 -1 -2 0 0 0 0]` |
+| `nu` | `K` or `nu` | Poisson's ratio, `[0 0 0 0 0 0 0]` |
+| `rho` | yes | Density, `[1 -3 0 0 0 0 0]` |
+| `solvePressureEqn` | no | Solve hydrostatic stress; default `false` |
+| `pressureSmoothingScaleFactor` | no | Smoothing scale; default `100.0` |
+| `regionName` | no | Base mesh region name; detected when absent |
+
+Each coefficient dictionary value supplies the uniform fallback for a volume
+field of the same name. A `c1`, `c2` or `c3` field in the current time
+directory is read instead when present, and all three fields are written
+automatically.
+
+The constructor sets the linearised shear modulus to `mu = 2*c1`. When `nu`
+is used, it forms `E = 6*c1` and computes:
+
+```text
+K = E/(3*(1 - 2*nu)) = 2*c1/(1 - 2*nu)
+```
+
+The constructor does not validate the signs or ranges of `c1`, `c2`, `c3`,
+`K` or `nu`. The inherited `regionName` selection first uses an explicit
+entry, then looks for `solid`, and finally `region0`; construction aborts if
+none exists.
+
+### Recommended dictionary setup
+
+The following example represents a generic nearly incompressible silicone
+rubber:
+
+```text
+mechanical
+(
+    siliconeRubber
+    {
+        type            YeohElastic;
+        rho             rho [1 -3 0 0 0 0 0] 1100;
+        c1              c1 [1 -1 -2 0 0 0 0] 100e3;
+        c2              c2 [1 -1 -2 0 0 0 0] 10e3;
+        c3              c3 [1 -1 -2 0 0 0 0] 1e3;
+        nu              nu [0 0 0 0 0 0 0] 0.49;
+
+        // Alternative to nu
+        // K             K [1 -1 -2 0 0 0 0] 10e6;
+
+        // Optional
+        // solvePressureEqn false;
+        // pressureSmoothingScaleFactor 100.0;
+        // regionName    region0;
+    }
+);
+```
+
+### Field glossary
+
+- `c1`, `c2`, `c3`: cell-centred coefficient fields, read if present and
+  written automatically.
+- `c1f`, `c2f`, `c3f`: face interpolations of the coefficient fields, formed
+  during construction.
+- `mu`, `muf`: linearised cell and face shear-modulus fields; `mu = 2*c1`.
+- `K`, `Kf`: cell and face bulk-modulus fields; `Kf` is interpolated from `K`.
+- `F`, `Ff`: total deformation gradients at cell centres and faces, created by
+  the base class and written for restart.
+- `relF`, `relFf`: relative deformation gradients maintained by the base
+  class.
+- `sigmaHyd`: cell-centred hydrostatic stress, written automatically.
+- `sigma0`: initial stress read from its field file when present; the law
+  pushes it forward as `symm(F & sigma0 & F.T)/J`.
+- `impK`: implicit stiffness field, read if present and not written.
+
+---
+
+## Developer Notes
+
+### Class role
+
+`YeohElastic` derives directly from `mechanicalLaw` and is registered in the
+`nonLinGeomMechLaw` runtime-selection table. It stores `c1_`, `c2_` and `c3_`
+as `volScalarField`s, together with the face fields `c1f_`, `c2f_` and `c3f_`.
+
+The class has no fork-specific preprocessor guards. Its source appears in both
+`Make/files.openfoam` and `Make/files.foamextend`. The inherited
+quadrature-point interface is guarded by `#ifndef FOAMEXTEND` in
+`mechanicalLaw`.
+
+### Construction
+
+The base constructor first reads or inserts `solvePressureEqn` and
+`pressureSmoothingScaleFactor`, then selects the base mesh region. The derived
+constructor proceeds in this order:
+
+1. It constructs `c1_`, `c2_` and `c3_` from field files when present, using
+   the required dictionary values as fallbacks, then interpolates their face
+   fields.
+2. It sets the base-class linearised shear modulus to `2*c1_`.
+3. It reads `K` when present. Otherwise it reads `nu`, forms `E = 6*c1_`, and
+   sets `K = E/(3*(1 - 2*nu))`.
+4. It prints the maxima of the three coefficients, `mu` and `K`.
+5. It interpolates `mu` and `K` to their face fields.
+
+If neither `K` nor `nu` is present, construction terminates with a fatal error
+stating that one must be specified. The base constructor terminates with a
+fatal error if it cannot identify the solid region. There are no law-specific
+parameter-range checks or warnings. When `sigma0` is first created, the base
+class warns if a single material uses a material mesh different from the base
+mesh because the field may not be correct.
+
+### Key methods
+
+- `impK()`: returns `(4/3)*mu + K`. This is the diffusivity of the solid
+  model's implicit Laplacian term and affects outer-iteration convergence rate
+  rather than the converged answer.
+- `correct(volSymmTensorField&)`: updates `F`, calculates the isochoric tensor
+  and Yeoh response, passes the volumetric stress to `updateSigmaHyd()`, pushes
+  forward `sigma0`, and assigns the Cauchy stress.
+- `correct(surfaceSymmTensorField&)`: performs the corresponding calculation
+  on faces, but uses the explicit hydrostatic term instead of
+  `updateSigmaHyd()`.
+- `materialTangent()`: is not overridden. The inherited implementation aborts
+  with `notImplemented`, so this law does not provide a 6x6 Newton tangent.
+
+Both `correct()` implementations first call the base-class `updateF()`. That
+method can return early after applying linear elasticity when the solid model
+enforces linearity. It also rejects a non-incremental updated-Lagrangian call
+with a fatal error.
+
+### Extension points
+
+A related invariant-based law can copy this class, replace the coefficient
+`q` and stress expressions in both `correct()` overloads, and add any required
+cell properties and face interpolations. It should retain registration in the
+`nonLinGeomMechLaw` table and entries in both build lists. Implement the point,
+quadrature-point and material-tangent interfaces if the target solid models
+require them.
+
+The source is at
+[YeohElastic.C](https://github.com/solids4foam/solids4foam/blob/master/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/YeohElastic/YeohElastic.C).
+
+---
+
+## Tutorials
+
+No tutorial currently uses `YeohElastic`.

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/diffusionHyperElastic/README.md
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/diffusionHyperElastic/README.md
@@ -1,0 +1,196 @@
+---
+sort: 28
+---
+
+# diffusionHyperElastic
+
+This law applies a compressible neo-Hookean relation with shear and bulk
+stiffnesses scaled by a normalized mesh-motion diffusivity. The runtime type
+is:
+
+```text
+diffusionHyperElastic
+```
+
+---
+
+## User Guide
+
+### What it computes
+
+The law obtains a raw face diffusivity from the selected `motionDiffusivity`,
+limits it relative to its face average, and normalizes it:
+
+```text
+dRaw_f = motionDiffusivity
+dAvg   = average(dRaw_f)
+d_f    = min(maxFactor*dAvg, max(minFactor*dAvg, dRaw_f))/dAvg
+d      = average(d_f)
+```
+
+The cell field `d` receives zero-gradient boundary conditions. The diffusivity
+fields are calculated during construction and are not refreshed by
+`correct()`, `impK()`, `bulkModulus()`, or `shearModulus()`.
+
+For deformation gradient `F`, Jacobian `J`, and the volume-preserving left
+Cauchy-Green tensor `bBar`, the cell-centred Cauchy stress is:
+
+```text
+J     = det(F)
+bBar  = J^(-2/3)*symm(F & F.T())
+s     = mu*dev(bBar)
+sigma = d*(s + 0.5*K*(J^2 - 1)*I)/J
+```
+
+The base class updates `F` for incremental or non-incremental total
+Lagrangian models and incremental updated Lagrangian models. A
+non-incremental updated Lagrangian model produces a fatal error. If the solid
+model's `enforceLinear` switch is active, the base class returns a linear
+elastic stress before the expression above is evaluated.
+
+The law implements `correct(volSymmTensorField&)`. Its explicitly declared
+`correct(surfaceSymmTensorField&)` aborts with `NotImplemented`. The inherited
+point-tensor and `CompactListList` quadrature-point overloads also abort with
+`notImplemented` on forks where those interfaces are compiled.
+
+### Model options
+
+| Entry | Required | Description |
+| --- | --- | --- |
+| `mu` | yes | Shear stiffness, `[1 -1 -2 0 0 0 0]` |
+| `K` | yes | Bulk stiffness, `[1 -1 -2 0 0 0 0]` |
+| `diffusivity` | yes | Mesh-motion diffusivity specification |
+| `writeStiffScaleFactor` | yes | Write `stiffnessScaleFactor` if `yes` |
+| `maxFactor` | no | Upper limiter relative to the average; default `100` |
+| `minFactor` | no | Lower limiter relative to the average; default `0.1` |
+| `rho` | yes | Density, `[1 -3 0 0 0 0 0]` |
+| `solvePressureEqn` | no | Base-class switch; default `no` |
+| `pressureSmoothingScaleFactor` | no | Base-class factor; default `100` |
+| `regionName` | no | Override the base mesh region name |
+
+`diffusivity` is passed directly to `motionDiffusivity::New`, so its syntax
+must match a mesh-motion diffusivity available in the selected OpenFOAM fork.
+Only the ordering of the limiter factors is checked: `maxFactor` less than
+`minFactor` is fatal.
+
+The base class reads `solvePressureEqn` and
+`pressureSmoothingScaleFactor`, but this law calculates the volumetric stress
+directly and never calls `updateSigmaHyd()`. Those entries therefore do not
+alter its constitutive response. If `regionName` is omitted, the base class
+selects `solid` and then `region0`, in that order.
+
+### Recommended dictionary setup
+
+The following values describe a silicone-like mesh pseudo-material with an
+inverse-distance diffusivity based on `movingWall`:
+
+```text
+mechanical
+(
+    siliconeMesh
+    {
+        type            diffusionHyperElastic;
+        rho             rho [1 -3 0 0 0 0 0] 1100;
+        mu              mu [1 -1 -2 0 0 0 0] 0.6e6;
+        K               K [1 -1 -2 0 0 0 0] 60e6;
+        diffusivity     quadratic inverseDistance (movingWall);
+        writeStiffScaleFactor yes;
+
+        // Optional
+        // maxFactor    100;
+        // minFactor    0.1;
+        // regionName   region0;
+        // solvePressureEqn no;
+        // pressureSmoothingScaleFactor 100;
+    }
+);
+```
+
+### Field glossary
+
+- `distf`: normalized and limited face diffusivity, `d_f`.
+- `stiffnessScaleFactor`: cell-centred `d`, obtained by averaging `distf`;
+  written only when `writeStiffScaleFactor yes` is selected.
+- `F_`: total deformation gradient. Its old-time value is stored during
+  construction, and the field is written for incremental restarts.
+- `relF_`: relative deformation gradient maintained by the base class.
+- `mu_<name>`, `K_<name>`: cell fields populated from `mu` and `K` when
+  `updateF()` is first called.
+- `bulkModulus`: temporary cell field returned as `K*d`.
+- `shearModulus`: temporary cell field returned as `mu*d`.
+- `k`: temporary implicit-stiffness field returned by `impK()`.
+
+---
+
+## Developer Notes
+
+### Class role
+
+`diffusionHyperElastic` derives directly from `mechanicalLaw`. It stores
+uniform `dimensionedScalar` values `mu_` and `K_`, scalar limiter values
+`maxFactor_` and `minFactor_`, an `autoPtr<motionDiffusivity>`, and the face
+and cell scale fields `df_` and `d_`.
+
+The complete implementation is guarded by `#ifdef OPENFOAM_NOT_EXTEND`. Its
+source appears in `Make/files.openfoam` but not in `Make/files.foamextend`, so
+the law is built for the OpenFOAM.com and OpenFOAM.org path, but not for
+foam-extend.
+
+### Construction
+
+The base constructor first reads or inserts `solvePressureEqn` and
+`pressureSmoothingScaleFactor`, then resolves `regionName`. The derived
+constructor proceeds in this order:
+
+1. It reads `mu` and `K` as dimensioned scalars.
+2. It reads `maxFactor` and `minFactor`, using `100` and `0.1` by default.
+3. It constructs the selected motion diffusivity from `diffusivity`.
+4. It initializes `distf` from that model and initializes
+   `stiffnessScaleFactor` by face-to-cell averaging.
+5. It creates `F_` and stores its old-time value.
+6. It aborts if `maxFactor` is less than `minFactor`.
+7. It corrects, limits, and normalizes the diffusivity fields.
+8. It reads `writeStiffScaleFactor` and enables automatic writing of the cell
+   scale field when requested.
+
+Missing required entries and an unknown motion-diffusivity type produce the
+corresponding OpenFOAM dictionary or selection errors. The base class emits a
+fatal error if it cannot find `solid` or `region0` and no `regionName` was
+given. During stress correction, it emits a fatal error for non-incremental
+updated Lagrangian kinematics. It warns once per time step when
+`enforceLinear` is active.
+
+### Key methods
+
+- `updateD()`: calls the motion diffusivity's `correct()`, limits and
+  normalizes its face field, averages it to cells, and corrects the cell-field
+  boundary conditions. It is called by the constructor.
+- `impK()`: returns `d*((4/3)*mu + K)`. This is the diffusivity used by the
+  solid model's implicit Laplacian term and affects the outer-iteration
+  convergence rate rather than the converged answer.
+- `correct(volSymmTensorField&)`: asks the base class to update `F`, then
+  applies the diffusivity-scaled neo-Hookean relation unless linearity was
+  enforced.
+- `correct(surfaceSymmTensorField&)`: aborts with `NotImplemented`.
+- `bulkModulus()` and `shearModulus()`: return `K*d` and `mu*d` cell fields.
+- `materialTangent()`: is not overridden; the base implementation aborts with
+  `notImplemented`.
+
+### Extension points
+
+A related diffusivity-scaled finite-strain law can be made by copying this
+class, changing the cell-centred constitutive expression, and retaining
+`updateD()` when the same mesh-motion diffusivity and limiter are appropriate.
+Implement the face, point, and quadrature-point `correct` overloads, and
+`materialTangent()`, if the new law must support face-based, vertex-centred,
+higher-order, block-coupled, or PETSc SNES solid models. Add the source to each
+fork-specific build list that supports its dependencies.
+
+The source is at
+[diffusionHyperElastic.C](https://github.com/solids4foam/solids4foam/blob/master/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/diffusionHyperElastic/diffusionHyperElastic.C).
+
+---
+
+## Tutorials
+
+No tutorial currently uses `diffusionHyperElastic`.

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/electroMechanicalLaw/README.md
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/electroMechanicalLaw/README.md
@@ -1,0 +1,208 @@
+---
+sort: 27
+---
+
+# electroMechanicalLaw
+
+This law adds fibre-directed active stress to the stress calculated by a
+run-time selectable passive nonlinear mechanical law. The runtime type is:
+
+```text
+electroMechanicalLaw
+```
+
+---
+
+## User Guide
+
+### What it computes
+
+The cell-centred overload first asks the passive law to calculate the Cauchy
+stress, then adds an active contribution:
+
+```text
+A0           = f0 (x) f0
+J            = det(F)
+sigma        = sigma_passive + symm(F & (Ta_current*A0) & F^T)/J
+```
+
+When a cell-centred `Ta` field exists in the mesh object registry at the first
+call to `correct`, `Ta_current` is that field. Otherwise the dictionary value
+is ramped according to:
+
+```text
+Ta_current = (t/rampTime)*activeTension    for t < rampTime
+Ta_current = activeTension                 otherwise
+```
+
+The field-based choice is made once and retained. For the face-centred
+overload, `Ta` is interpolated from cells to faces. The implemented face
+relation differs from the cell relation by multiplying by `J`:
+
+```text
+A0f          = f0f (x) f0f
+Jf           = det(Ff)
+sigmaf       = sigmaf_passive
+             + Jf*symm(Ff & (Taf_current*A0f) & Ff^T)
+```
+
+The `volSymmTensorField` and `surfaceSymmTensorField` overloads are
+implemented. The inherited `pointSymmTensorField` overload aborts with
+`notImplemented`. On OpenFOAM.com and OpenFOAM.org, the inherited
+`CompactListList` overload also aborts with `notImplemented`; that overload is
+not compiled for foam-extend.
+
+### Model options
+
+| Entry | Required | Description |
+| --- | --- | --- |
+| `rho` | yes | Density, `[1 -3 0 0 0 0 0]` |
+| `activeTension` | yes | Constant active tension, `[1 -1 -2 0 0 0 0]` |
+| `rampTime` | yes | Ramp duration in simulation-time units |
+| `passiveMechanicalLaw` | yes | Passive nonlinear-law sub-dictionary |
+| `passiveMechanicalLaw.type` | yes | Runtime type of the passive law |
+| `solvePressureEqn` | no | Base-class switch; default `false` |
+| `pressureSmoothingScaleFactor` | no | Base-class scalar; default `100` |
+| `regionName` | no | Base mesh region used to find the solid model |
+
+`activeTension` and `rampTime` remain required when a `Ta` field will be used,
+because the constructor reads both before checking the registry. A negative
+`rampTime` is rejected. A zero value applies the full constant tension without
+division by zero because the ramp branch is then not entered for non-negative
+simulation time.
+
+The top-level base-class pressure options are constructed, but this wrapper
+does not call `updateSigmaHyd()`. Options needed by the selected passive law
+belong inside `passiveMechanicalLaw`. If `regionName` is absent, the base class
+selects `solid`, then `region0`; construction fails if neither region exists.
+
+The law also requires `volVectorField` `f0` and `surfaceVectorField` `f0f` in
+the initial time directory. They are read independently and are not normalised
+by this class.
+
+### Recommended dictionary setup
+
+This setup follows the `idealisedVentricle` tutorial and uses a Guccione law
+for passive heart tissue:
+
+```text
+planeStress     no;
+
+mechanical
+(
+    heartTissue
+    {
+        type            electroMechanicalLaw;
+        rho             rho [1 -3 0 0 0 0 0] 3000;
+        activeTension   activeTension [1 -1 -2 0 0 0 0] 0;
+        rampTime        0;
+
+        passiveMechanicalLaw
+        {
+            type            GuccioneElastic;
+            k               k [1 -1 -2 0 0 0 0] 10e3;
+            cf              1;
+            ct              1;
+            cfs             1;
+            uniformFibreField yes;
+            f0              (0 0 1);
+            bulkModulus     bulkModulus [1 -1 -2 0 0 0 0] 1e6;
+        }
+
+        // Optional base-class entries
+        // regionName                    solid;
+        // solvePressureEqn              no;
+        // pressureSmoothingScaleFactor  100;
+    }
+);
+```
+
+The outer law still requires separate `f0` and `f0f` field files even when the
+passive law uses its own uniform fibre setting. Set `activeTension` to the
+fallback value required when no coupling model registers `Ta`.
+
+### Field glossary
+
+- `f0`: reference fibre direction at cell centres, read with `MUST_READ` and
+  written automatically.
+- `f0f`: reference fibre direction at faces, read separately with `MUST_READ`
+  and written automatically.
+- `f0f0`, `f0f0f`: cell- and face-centred structural tensors formed by
+  `sqr(f0)` and `sqr(f0f)`.
+- `Ta`: optional cell-centred active-tension field supplied through the object
+  registry; this law does not create it.
+- `F_`, `Ff_`: deformation gradients accessed through the base class for the
+  cell- and face-centred active-stress transformations.
+- Fields belonging to the passive law are maintained by that nested law.
+
+---
+
+## Developer Notes
+
+### Class role
+
+`electroMechanicalLaw` derives directly from `mechanicalLaw` and is registered
+in the `nonLinGeomMechLaw` selection table. It owns an `autoPtr<mechanicalLaw>`
+for the passive law, the `f0`, `f0f`, `f0f0` and `f0f0f` fields, the constant
+`Ta_`, the scalar `rampTime_`, and two mutable flags that cache the registry
+check for field-based active tension.
+
+There are no fork-specific guards in this class. Its source is listed in both
+`Make/files.openfoam` and `Make/files.foamextend`. The base-class
+`CompactListList` interface is guarded by `#ifndef FOAMEXTEND`.
+
+### Construction
+
+Construction proceeds in this order:
+
+1. The `mechanicalLaw` base reads `solvePressureEqn` with default `false` and
+   `pressureSmoothingScaleFactor` with default `100`, then resolves
+   `regionName`.
+2. The `passiveMechanicalLaw` sub-dictionary and its required `type` entry are
+   used to construct a nonlinear mechanical law through the runtime table.
+3. `f0` is read and `f0f0` is formed as `sqr(f0)`.
+4. `f0f` is read independently and `f0f0f` is formed as `sqr(f0f)`.
+5. The required `activeTension` dimensioned scalar and `rampTime` scalar are
+   read, and the registry-check flags are initialised to `false`.
+6. A negative `rampTime` triggers `FatalError` with the message that it should
+   be greater than or equal to zero.
+
+The base class also emits a fatal error if it cannot identify `solid` or
+`region0` and no `regionName` is supplied. It prints an informational message
+when `solvePressureEqn` is enabled. On the first stress correction, this law
+prints whether it selected field-based or constant active tension.
+
+### Key methods
+
+- `impK()` delegates to the passive law. It is the diffusivity used for the
+  solid model's implicit Laplacian term and affects the outer-iteration
+  convergence rate rather than the converged answer.
+- `correct(volSymmTensorField&)` obtains passive stress, accesses `F`, and adds
+  either registry-field or ramped constant active stress divided by `det(F)`.
+- `correct(surfaceSymmTensorField&)` follows the same sequence with `Ff`,
+  interpolates a registry `Ta` to faces, and multiplies the active term by
+  `det(Ff)` as implemented.
+- `materialTangentField()` delegates the complete face list to the passive
+  law. The singular inherited `materialTangent()` is not overridden and aborts
+  with `notImplemented`.
+- `bulkModulus()` and `shearModulus()` delegate to the passive law.
+
+### Extension points
+
+A related active-passive wrapper can be made by copying this class, retaining
+the nonlinear runtime construction of the passive law, and replacing the
+active tensor assembled in the two `correct` overloads. New implementations
+should decide explicitly which registry fields are detected, whether that
+choice may change after the first correction, and which cell, face, point and
+quadrature interfaces they support. A consistent Newton implementation also
+needs the active contribution in its material tangent rather than only the
+passive-law tangent.
+
+The source is at
+[electroMechanicalLaw.C](https://github.com/solids4foam/solids4foam/blob/master/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/electroMechanicalLaw/electroMechanicalLaw.C).
+
+---
+
+## Tutorials
+
+- `solids/hyperelasticity/idealisedVentricle/caseOptions/petsc`

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/isotropicFungElastic/README.md
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/isotropicFungElastic/README.md
@@ -1,0 +1,193 @@
+---
+sort: 22
+---
+
+# isotropicFungElastic
+
+This page documents the compressible isotropic Fung-like hyperelastic law. The
+runtime type is:
+
+```text
+isotropicFungElastic
+```
+
+---
+
+## User Guide
+
+### What it computes
+
+The law forms an isochoric left Cauchy-Green tensor and its first invariant,
+then updates the Cauchy stress as follows:
+
+```text
+J       = det(F)
+isoB    = J^(-2/3)*symm(F & F.T)
+isoI1   = tr(isoB)
+psi1    = c1*exp(0.5*c2*(isoI1 - 3))
+sigmaHydExplicit = 0.5*K*(J^2 - 1)
+sigma   = (1/J)*(psi1*dev(isoB) + sigmaHyd*I
+          + symm(F & sigma0 & F.T))
+```
+
+For the cell-centred overload, `sigmaHyd` is passed through
+`updateSigmaHyd()`. It equals `sigmaHydExplicit` unless `solvePressureEqn` is
+enabled, in which case the base class obtains it from a smoothed Laplacian
+equation. The face-centred overload uses `Ff`, interpolated material fields and
+the explicit hydrostatic term directly.
+
+The law implements `correct(volSymmTensorField&)` and
+`correct(surfaceSymmTensorField&)`. The inherited point-centred overload aborts
+with `notImplemented`. On OpenFOAM.com and OpenFOAM.org, the inherited
+`CompactListList` quadrature-point overload also aborts with `notImplemented`;
+that overload is excluded from foam-extend by `#ifndef FOAMEXTEND` in the base
+class.
+
+### Model options
+
+`c1` and `c2` are required. The bulk response is specified by either `K` or
+`nu`; when both are present, `K` takes precedence.
+
+| Entry | Required | Description |
+| --- | --- | --- |
+| `c1` | yes | Shear parameter, `[1 -1 -2 0 0 0 0]` |
+| `c2` | yes | Exponential parameter, `[0 0 0 0 0 0 0]` |
+| `K` | `K` or `nu` | Bulk modulus, `[1 -1 -2 0 0 0 0]` |
+| `nu` | `K` or `nu` | Poisson's ratio, `[0 0 0 0 0 0 0]` |
+| `rho` | yes | Density, `[1 -3 0 0 0 0 0]` |
+| `solvePressureEqn` | no | Solve for hydrostatic stress; default `no` |
+| `pressureSmoothingScaleFactor` | no | Pressure smoothing; default `100` |
+| `regionName` | no | Base mesh region name |
+
+The `c1` dictionary value supplies the uniform fallback for a `c1` volume
+field. A `c1` field in the current time directory is read instead when
+present. The field is written automatically.
+
+When `nu` is used, the constructor sets `mu = c1`, forms `E = 3*c1`, and
+computes:
+
+```text
+K = E/(3*(1 - 2*nu)) = c1/(1 - 2*nu)
+```
+
+The constructor does not validate the signs or ranges of `c1`, `c2`, `K` or
+`nu`. The inherited `regionName` selection first uses an explicit entry, then
+looks for `solid`, and finally `region0`; construction aborts if none exists.
+
+### Recommended dictionary setup
+
+The following example represents a generic nearly incompressible soft tissue:
+
+```text
+mechanical
+(
+    softTissue
+    {
+        type            isotropicFungElastic;
+        rho             rho [1 -3 0 0 0 0 0] 1000;
+        c1              c1 [1 -1 -2 0 0 0 0] 10e3;
+        c2              c2 [0 0 0 0 0 0 0] 5;
+        nu              nu [0 0 0 0 0 0 0] 0.49;
+
+        // Alternative to nu
+        // K             K [1 -1 -2 0 0 0 0] 1e6;
+
+        // Optional
+        // solvePressureEqn no;
+        // pressureSmoothingScaleFactor 100;
+        // regionName    region0;
+    }
+);
+```
+
+### Field glossary
+
+- `c1`: cell-centred shear-parameter field, read if present and written
+  automatically.
+- `c1f`: face interpolation of `c1`, formed during construction.
+- `mu`, `muf`: linearised cell and face shear-modulus fields; `mu` is set to
+  `c1` and `muf` is interpolated from it.
+- `K`, `Kf`: cell and face bulk-modulus fields; `Kf` is interpolated from `K`.
+- `F`, `Ff`: total deformation gradients at cell centres and faces, created by
+  the base class and written for restart.
+- `relF`, `relFf`: relative deformation gradients maintained by the base
+  class.
+- `sigmaHyd`: cell-centred hydrostatic stress, written automatically.
+- `sigma0`: initial stress read from the field file when present; the law
+  pushes it forward as `symm(F & sigma0 & F.T)/J`.
+- `impK`: implicit stiffness field, read if present and not written.
+
+---
+
+## Developer Notes
+
+### Class role
+
+`isotropicFungElastic` derives directly from `mechanicalLaw` and is registered
+in the `nonLinGeomMechLaw` runtime-selection table. It stores `c1_` as a
+`volScalarField`, `c1f_` as a `surfaceScalarField`, and `c2_` as a constant
+`dimensionedScalar`.
+
+The class has no fork-specific preprocessor guards. Its source appears in both
+`Make/files.openfoam` and `Make/files.foamextend`. The inherited
+quadrature-point interface is guarded by `#ifndef FOAMEXTEND` in
+`mechanicalLaw`.
+
+### Construction
+
+The base constructor first reads or inserts `solvePressureEqn` and
+`pressureSmoothingScaleFactor`, then selects the base mesh region. The derived
+constructor proceeds in this order:
+
+1. It constructs `c1_` from a field file when present, using the required
+   dictionary value as its fallback, interpolates `c1f_`, and reads `c2_`.
+2. It sets the base-class linearised shear modulus to `c1_`.
+3. It reads `K` when present. Otherwise it reads `nu`, forms `E = 3*c1_`, and
+   sets `K = E/(3*(1 - 2*nu))`.
+4. It prints the maxima of `c1`, `mu` and `K`, together with the value of `c2`.
+5. It interpolates `mu` and `K` to their face fields and forces `sigma0` to be
+   created or read.
+
+If neither `K` nor `nu` is present, construction terminates with a fatal error
+stating that one must be specified. The base constructor terminates with a
+fatal error if it cannot identify the solid region. Creating `sigma0` for a
+single material whose material mesh differs from the base mesh emits a warning
+that the field may not be correct. There are no law-specific parameter-range
+checks or warnings.
+
+### Key methods
+
+- `impK()`: returns the field `(4/3)*mu + K`. This is the diffusivity of the
+  solid model's implicit Laplacian term and affects outer-iteration convergence
+  rate rather than the converged answer.
+- `correct(volSymmTensorField&)`: updates `F`, calculates the isochoric tensor
+  and exponential response, passes the volumetric stress to
+  `updateSigmaHyd()`, pushes forward `sigma0`, and assigns the Cauchy stress.
+- `correct(surfaceSymmTensorField&)`: performs the corresponding calculation
+  on faces, but uses the explicit hydrostatic term instead of
+  `updateSigmaHyd()`.
+- `materialTangent()`: is not overridden. The inherited implementation aborts
+  with `notImplemented`, so this law does not provide a 6x6 Newton tangent.
+
+Both `correct()` implementations first call the base-class `updateF()`. That
+method can return early after applying linear elasticity when the solid model
+enforces linearity. It also rejects a non-incremental updated-Lagrangian call
+with a fatal error.
+
+### Extension points
+
+A related invariant-based law can copy this class, replace `psi1` and the
+stress expressions in both `correct()` overloads, and add any required cell
+properties and face interpolations. It should retain registration in the
+`nonLinGeomMechLaw` table and entries in both build lists. Implement the point,
+quadrature-point and material-tangent interfaces if the target solid models
+require them.
+
+The source is at
+[isotropicFungElastic.C](https://github.com/solids4foam/solids4foam/blob/master/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/isotropicFungElastic/isotropicFungElastic.C).
+
+---
+
+## Tutorials
+
+No tutorial currently uses `isotropicFungElastic`.

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/neoHookeanElastic/README.md
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/neoHookeanElastic/README.md
@@ -1,0 +1,220 @@
+---
+sort: 17
+---
+
+# neoHookeanElastic
+
+This page documents the compressible neo-Hookean hyperelastic law. The runtime
+type is:
+
+```text
+neoHookeanElastic
+```
+
+The law uses the volumetric-isochoric split of Simo and Hughes (1998), Eqn
+9.2.6. It is the default choice for large-strain rubber-like materials in
+solids4foam, and it is also the elastic backbone of several other laws in the
+toolbox.
+
+Reference: J. C. Simo and T. J. R. Hughes, _Computational Inelasticity_,
+Springer, 1998,
+[10.1007/b98904](https://doi.org/10.1007/b98904).
+
+---
+
+## User Guide
+
+### Strain energy function
+
+The stored energy is split into an isochoric and a volumetric part:
+
+```text
+Psi = 0.5*mu*(tr(bBar) - 3) + U(J)
+
+bBar = J^(-2/3)*b,   b = F & F.T(),   J = det(F)
+```
+
+with the default volumetric part
+
+```text
+U(J) = 0.5*K*(0.5*(J^2 - 1) - ln(J))
+```
+
+The resulting Cauchy stress, which is what the code evaluates, is
+
+```text
+sigma = (1/J)*(0.5*K*(J^2 - 1)*I + mu*dev(bBar))
+```
+
+Setting `alternatePressureDefinition` replaces the Kirchhoff hydrostatic term
+`0.5*K*(J^2 - 1)` by `K*(J - 1)`, which corresponds to
+`U(J) = K*(J - ln(J) - 1)`.
+
+The law is registered in the nonlinear-geometry table, so it works with both
+total-Lagrangian and updated-Lagrangian solid models; the base class
+`updateF()` selects the right deformation-gradient update. It is not available
+to linear-geometry solid models.
+
+### Model options
+
+Elastic constants must be given as **either** `E` and `nu` **or** `mu` and
+`K`. Mixing the two pairs is a fatal error.
+
+| Entry | Requirement | Description |
+| --- | --- | --- |
+| `E` | with `nu` | Young's modulus, `[1 -1 -2 0 0 0 0]` |
+| `nu` | with `E` | Poisson's ratio, dimensionless |
+| `mu` | with `K` | Shear modulus, `[1 -1 -2 0 0 0 0]` |
+| `K` | with `mu` | Bulk modulus, `[1 -1 -2 0 0 0 0]` |
+| `rho` | required | Density, `[1 -3 0 0 0 0 0]` |
+
+When `E` and `nu` are given, `mu = E/(2*(1 + nu))` and `K` follows from the
+plane-stress or plane-strain relation, as set by the top-level `planeStress`
+entry of `constant/mechanicalProperties`.
+
+Optional entries:
+
+| Entry | Default | Description |
+| --- | --- | --- |
+| `alternatePressureDefinition` | `false` | Use `K*(J - 1)` instead |
+| `pressureDisplacement` | `false` | Pressure-displacement coupling |
+| `pressureDisplacementCoeff` | `-1` | Negative means auto `3*nu/(1 + nu)` |
+| `tangentEps` | none | Perturbation for `materialTangentField()` |
+| `solvePressureEqn` | `false` | Smooth `sigmaHyd` with a Laplacian |
+| `pressureSmoothingScaleFactor` | `100` | Scale factor for that smoothing |
+
+`tangentEps` is read with `lookup()` inside `materialTangentField()`, so it is
+only required by solid models that ask for the material tangent; it is not
+read at construction.
+
+### Pressure-displacement mode
+
+Setting `pressureDisplacement true` switches the law into the form expected by
+[coupledPressureDisplacementSolid](https://www.solids4foam.com/documentation/solid-models/coupledPressureDisplacementSolid.html).
+In that mode:
+
+- the deviatoric stress becomes `mu*(b - I)/J`, i.e. the full left
+  Cauchy-Green tensor is used rather than its isochoric part;
+- the hydrostatic part is taken from the separately solved `p` field (`pf` on
+  faces) and multiplied by `pressureDisplacementCoeff`;
+- `impK()` returns `mu` alone rather than `(4/3)*mu + K`;
+- if `E` and `nu` are supplied with `nu` at or above `0.5 - SMALL`, `K` is set
+  to `GREAT`, which allows a truly incompressible material to be specified.
+
+`pressureDisplacementCoeff` defaults to `3*nu/(1 + nu)`, with `nu` recovered
+from `mu` and `K`, or taken as `0.5` when `K` has been set to `GREAT`.
+
+### Recommended dictionary setup
+
+Minimal example for `constant/mechanicalProperties`:
+
+```text
+planeStress     no;
+
+mechanical
+(
+    rubber
+    {
+        type            neoHookeanElastic;
+        rho             rho [1 -3 0 0 0 0 0] 1000;
+        E               E [1 -1 -2 0 0 0 0] 2e+06;
+        nu              nu [0 0 0 0 0 0 0] 0.45;
+    }
+);
+```
+
+For a nearly incompressible material solved with a pressure equation, add
+`solvePressureEqn yes;` and, if needed, `pressureSmoothingScaleFactor`.
+
+### Field glossary
+
+- `F`, `Ff`: total deformation gradient at cell centres and faces.
+- `relF`, `relFf`: relative deformation gradient, used in the updated
+  Lagrangian formulation.
+- `sigmaHyd`: hydrostatic Cauchy stress, `-p`; written when
+  `solvePressureEqn` is enabled.
+- `sigma`: Cauchy stress tensor returned to the solid model.
+- `impK`: implicit stiffness used as the Laplacian diffusivity.
+
+---
+
+## Developer Notes
+
+### Class role
+
+`neoHookeanElastic` inherits from `mechanicalLaw` and is added to the
+`nonLinGeomMechLaw` runtime selection table. It stores `mu_` and `K_` as
+uniform `dimensionedScalar` values, so the law is homogeneous within a given
+material entry; heterogeneity is obtained by using several `mechanical`
+entries with the multi-material machinery.
+
+### Construction
+
+The constructor reads the two switches and the coefficient first, then decides
+between the `(E, nu)` and `(mu, K)` branches. It finishes by calling
+`F().storeOldTime()` and `Ff().storeOldTime()`, which forces the old-time
+deformation gradients to exist from the first time step.
+
+### `correct()` walkthrough
+
+`correct(volSymmTensorField&)`:
+
+1. calls `updateF(sigma, mu_, K_)`; if that returns `true` the solid model has
+   requested enforced linearity for stability, the base class has already set
+   a Hooke's law stress, and the function returns immediately;
+2. materialises `FT` explicitly before contracting, to avoid a `tmp<>`
+   evaluation problem documented in `StVenantKirchhoffElastic.C`;
+3. forms `J`, `b`, and `bBar`, then the deviatoric stress `s`;
+4. in pressure-displacement mode looks up `p` and returns
+   `-pressureDisplacementCoeff*p*I + s` directly;
+5. otherwise calls `updateSigmaHyd()` with either `K*(J - 1)` or
+   `0.5*K*(J^2 - 1)`, then assembles `sigma = (1/J)*(sigmaHyd*I + s)`.
+
+The surface overloads route through the private `correctF()` helper, which is
+also used by the `correct(sigma, gradD)` overload that builds `F` from a
+supplied displacement gradient.
+
+### Implicit stiffness
+
+`impK()` returns `(4/3)*mu + K`, which equals `2*mu + lambda` and is the
+standard choice for the segregated Laplacian operator. In
+pressure-displacement mode it returns `mu` only, because the volumetric
+response is carried by the pressure equation.
+
+`bulkModulus()` and `shearModulus()` return uniform fields built from `K_` and
+`mu_`.
+
+### Material tangent
+
+`materialTangentField()` builds a face-based `6x6` tangent by finite
+differences: each component of `grad(D)f` is perturbed by `tangentEps` and the
+resulting change in `sigmaf` is divided by the perturbation. It looks up
+`sigmaf` and `grad(D)f` from the registry, so it only works with solid models
+that create those surface fields.
+
+### Extension points
+
+- `correctF()` is the single place where the constitutive relation is
+  evaluated for surface fields; a new volumetric-isochoric split can be added
+  there and in `correct(volSymmTensorField&)`.
+- `setRestart()` sets `AUTO_WRITE` on `F` and `Ff` so a restart reproduces the
+  same deformation state.
+
+---
+
+## Tutorials
+
+Cases that select `neoHookeanElastic`:
+
+- `solids/hyperelasticity/blockPunch`
+- `solids/hyperelasticity/cantileverBeam`
+- `solids/hyperelasticity/cylindricalPressureVessel`, in the three
+  `caseOptions/pressureDisplacement` variants (`cylinder`, `cylinderLin`
+  and `cylinderUnsteady`)
+- `solids/linearElasticity/plateHole`, in both
+  `caseOptions/pressureDisplacement` variants (`compressible` and
+  `incompressible`)
+- `fluidSolidInteraction/beamInCrossFlow`
+- `fluidSolidInteraction/fillingElasticContainer`
+- `fluidSolidInteraction/flexibleDamBreak`
+- `fluidSolidInteraction/HronTurekFsi3`

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/neoHookeanElasticMisesPlastic/README.md
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/neoHookeanElasticMisesPlastic/README.md
@@ -1,0 +1,262 @@
+---
+sort: 25
+---
+
+# neoHookeanElasticMisesPlastic
+
+This law combines compressible neo-Hookean elasticity with finite-strain
+Mises plasticity and isotropic hardening. The runtime type is:
+
+```text
+neoHookeanElasticMisesPlastic
+```
+
+---
+
+## User Guide
+
+### What it computes
+
+The law updates the isochoric elastic left Cauchy-Green tensor incrementally.
+For a relative deformation gradient `relF` and Jacobian `J`, the trial state is
+
+```text
+relJ         = J/J_old
+relFbar      = relJ^(-1/3)*relF
+bEbar_trial  = relFbar bEbar_old relFbar^T
+s_trial      = mu*dev(bEbar_trial)
+Ibar         = tr(bEbar_trial)/3
+muBar        = mu*Ibar
+f_trial      = |s_trial| - sqrt(2/3)*J*sigmaY
+```
+
+An elastic step has `DLambda = 0`. For a plastic step, the return direction is
+`N = s_trial/|s_trial|`. A nonlinear hardening table is integrated by solving
+
+```text
+0 = |s_trial| - 2*muBar*DLambda
+    - sqrt(2/3)*J*sigmaY(epsilonPEq_old + sqrt(2/3)*DLambda)
+
+DEpsilonPEq = sqrt(2/3)*DLambda
+DEpsilonP   = Ibar*DLambda*N
+s           = s_trial - 2*mu*DEpsilonP
+```
+
+The tabulated `sigmaY` values are treated as Cauchy yield stress versus true
+plastic strain. The return calculation multiplies the tabulated stress by `J`
+to obtain Kirchhoff yield stress. One table point gives perfect plasticity,
+two points give linear hardening, and more than two points activate the Newton
+iteration for nonlinear hardening.
+
+The final Cauchy stress is
+
+```text
+sigmaHyd = 0.5*K*(J^2 - 1)
+sigma    = (sigmaHyd*I + s)/J
+```
+
+When `updateBEbarConsistent` is enabled, the spherical part of `bEbar` is
+obtained from a cubic equation so that `det(bEbar) = 1`. Otherwise, the trial
+value `Ibar` is retained.
+
+The law implements `correct(volSymmTensorField&)` and
+`correct(surfaceSymmTensorField&)`. It does not override the point-field or
+quadrature-point forms. The point-field form therefore aborts with
+`notImplemented`; on non-foam-extend forks the `CompactListList` form also
+aborts with `notImplemented`, while that interface is not compiled for
+foam-extend.
+
+### Model options
+
+Elastic constants are given as either `E` and `nu`, or `mu` and `K`. The
+stress-plastic-strain table is stored in a separate OpenFOAM-format file.
+
+| Entry | Required | Description |
+| --- | --- | --- |
+| `E` | with `nu` | Young's modulus, `[1 -1 -2 0 0 0 0]` |
+| `nu` | with `E` | Poisson's ratio, dimensionless |
+| `mu` | with `K` | Shear modulus, `[1 -1 -2 0 0 0 0]` |
+| `K` | with `mu` | Bulk modulus, `[1 -1 -2 0 0 0 0]` |
+| `"fileName\|file"` | yes | Portable key for the hardening-table file |
+| `outOfBounds` | yes | Table bounds handling, for example `clamp` |
+| `rho` | yes | Density, `[1 -3 0 0 0 0 0]` |
+| `updateBEbarConsistent` | no | Enforce unit determinant; default `yes` |
+| `solvePressureEqn` | no | Solve for hydrostatic stress; default `no` |
+| `pressureSmoothingScaleFactor` | no | Pressure scale; default `100` |
+| `regionName` | conditional | Base solid region if it cannot be detected |
+
+The regular-expression key `"fileName|file"` works with forks that request
+either `fileName` or `file`. `outOfBounds` is required by foam-extend; the
+OpenFOAM implementation otherwise defaults to `warn`.
+
+The stress table contains pairs of equivalent true plastic strain and Cauchy
+yield stress in pressure units. Its strain coordinate is dimensionless. With
+two points, the code calculates the linear plastic modulus from their slope.
+
+The `planeStress` entry is read from the enclosing `mechanicalProperties`
+dictionary. It changes the conversion from `E` and `nu` to `K`. The law does
+not validate the supplied Poisson's ratio. The `maxDeltaErr` entry is read from
+`controlDict`, defaults to `0.01`, and controls the time-step recommendation
+returned by `newDeltaT()`.
+
+### Recommended dictionary setup
+
+For a steel billet with a separate true-plastic-strain/Cauchy-stress table:
+
+```text
+planeStress     no;
+
+mechanical
+(
+    steel
+    {
+        type            neoHookeanElasticMisesPlastic;
+        rho             rho [1 -3 0 0 0 0 0] 7833;
+        E               E [1 -1 -2 0 0 0 0] 200e9;
+        nu              nu [0 0 0 0 0 0 0] 0.3;
+        "fileName|file" "$FOAM_CASE/constant/plasticStrainVsYieldStress";
+        outOfBounds     clamp;
+
+        // Optional
+        // updateBEbarConsistent yes;
+        // solvePressureEqn no;
+        // pressureSmoothingScaleFactor 100;
+    }
+);
+```
+
+The referenced table can, for example, contain two points for linear
+hardening:
+
+```text
+(
+    (0 700e6)
+    (10 3700e6)
+)
+```
+
+### Field glossary
+
+- `F_`, `Ff_`: total deformation gradients at cells and faces, maintained by
+  the base class and read on restart.
+- `lawJ`, `lawJf`: cell and face Jacobians, created lazily and stored with an
+  old-time value.
+- `sigmaY`, `sigmaYf`: current Cauchy yield stress; restartable and written.
+- `DSigmaY`, `DSigmaYf`: current increments of Cauchy yield stress.
+- `epsilonP`, `epsilonPf`: accumulated plastic strain tensors.
+- `DEpsilonP`, `DEpsilonPf`: current plastic strain increments, relaxed during
+  the stress correction.
+- `epsilonPEq`, `epsilonPEqf`: accumulated equivalent plastic strain.
+- `DEpsilonPEq`, `DEpsilonPEqf`: current equivalent plastic strain increments.
+- `DLambda`, `DLambdaf`: plastic multiplier increments.
+- `bEbarTrial`, `bEbarTrialf`: trial isochoric elastic left Cauchy-Green
+  tensors.
+- `bEbar`, `bEbarf`: corrected isochoric elastic left Cauchy-Green tensors.
+- `plasticN`, `plasticNf`: return directions; the cell field stores old-time
+  values for the time-integration error estimate.
+- `activeYield`: cell yielding flag, set to one where `DEpsilonPEq` is
+  positive and zero elsewhere at the end of a time step.
+- `sigmaHyd`: cell hydrostatic stress maintained by the base class.
+
+---
+
+## Developer Notes
+
+### Class role
+
+`neoHookeanElasticMisesPlastic` derives directly from `mechanicalLaw` and is
+registered in its `nonLinGeomMechLaw` selection table. It stores uniform shear
+and bulk moduli, the hardening interpolation table, cell and face plastic
+history, trial and corrected elastic strain tensors, return directions, and
+the plastic integration controls.
+
+The `OPENFOAM_NOT_EXTEND` preprocessor branches select field-access APIs and
+surface-field boundary correction behavior for OpenFOAM versus foam-extend.
+They do not remove either implemented stress-correction interface. The law is
+listed in both `Make/files.openfoam` and `Make/files.foamextend`.
+
+### Construction
+
+The base constructor first reads `solvePressureEqn` and
+`pressureSmoothingScaleFactor`, then selects `regionName` or detects `solid` or
+`region0`. The derived member initializers then load the hardening table,
+construct the cell and face history fields, read `updateBEbarConsistent`, and
+read `maxDeltaErr` from `controlDict`. The body stores the old return direction,
+forces creation of the cell and face deformation gradients, and reads either
+`E` with `nu` or `mu` with `K`.
+
+For `E` and `nu`, the constructor calculates
+
+```text
+mu = E/(2*(1 + nu))
+K  = nu*E/((1 + nu)*(1 - 2*nu)) + 2*mu/3   // plane strain or 3-D
+K  = nu*E/((1 + nu)*(1 - nu)) + 2*mu/3     // planeStress yes
+```
+
+It then classifies the table as perfect, linear, or nonlinear plasticity and
+calculates `Hp` for a two-point table. Missing both complete elastic-constant
+pairs is a fatal error. Failure to find a base solid region is also fatal.
+Construction reports the selected plasticity form and consistent-`bEbar`
+setting but performs no Poisson-ratio validation.
+
+At run time, `updateF()` gives fatal errors for a non-incremental updated
+Lagrangian model or an unknown nonlinear-geometry type. It warns when a solid
+model temporarily enforces linear elasticity. `newDeltaT()` warns when its
+plastic-strain integration error exceeds 50 times `maxDeltaErr`.
+
+### Key methods
+
+- `impK()`: returns `scaleFactor*(4*mu/3) + K`, where
+  `scaleFactor = 1 - 2*muBar*DLambda/|s_trial|`. It is the diffusivity of the
+  solid model's implicit Laplacian term and affects the outer-iteration
+  convergence rate rather than the converged answer.
+- `correct(volSymmTensorField&)`: updates `F`, `J`, the trial elastic state,
+  the plastic return, `bEbar`, hydrostatic stress, and cell Cauchy stress. It
+  can use the base-class pressure equation for the hydrostatic part.
+- `correct(surfaceSymmTensorField&)`: performs the corresponding face update.
+  It evaluates the hydrostatic stress directly because the pressure equation
+  is not implemented for surface fields.
+- `curYieldStress()` and `yieldFunction()`: interpolate the Cauchy hardening
+  curve, convert it to Kirchhoff stress, and form the return residual.
+- `newtonLoop()`: solves for `DLambda` by a first-order finite-difference
+  Newton iteration when the hardening curve has more than two points.
+- `Ibar()`: solves a cubic equation for the spherical part of `bEbar` when
+  consistent unit-determinant updating is enabled.
+- `residual()`: measures the relative change in the current cell or face
+  plastic strain increment between outer iterations.
+- `updateTotalFields()`: accumulates yield stress and plastic strain and
+  updates `activeYield` at the end of the time step.
+- `newDeltaT()`: estimates plastic integration error from the change in return
+  direction and proposes a scaled time step.
+- `materialTangent()`: is not overridden; the base implementation aborts with
+  `notImplemented`, so Newton methods requiring this tangent cannot use the
+  law.
+
+### Extension points
+
+A related finite-strain plastic law can copy this class and replace the trial
+stress, yield function, and return update while retaining the cell and face
+history pattern. New history variables must be accumulated in
+`updateTotalFields()`, included in `residual()` where needed, and given restart
+write settings in `setRestart()`. A law intended for point-based or
+quadrature-point solid models must also implement those `correct` overloads;
+one intended for Newton solvers must implement `materialTangent()`.
+
+The new class must be registered in the `nonLinGeomMechLaw` table and added to
+the appropriate OpenFOAM and foam-extend build lists.
+
+The source is at
+[neoHookeanElasticMisesPlastic.C](https://github.com/solids4foam/solids4foam/blob/master/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/neoHookeanElasticMisesPlastic/neoHookeanElasticMisesPlastic.C).
+
+---
+
+## Tutorials
+
+- `solids/elastoplasticity/pipeCrush`
+- `solids/elastoplasticity/cooksMembrane`
+- `solids/elastoplasticity/cylinderCrush`
+- `solids/elastoplasticity/curvedBeams`
+- `solids/elastoplasticity/neckingBar`
+- `solids/elastoplasticity/impactBar`
+- `solids/elastoplasticity/cylinderExpansion`
+- `solids/elastoplasticity/upsetBillet`

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/viscoNeoHookeanElastic/README.md
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/viscoNeoHookeanElastic/README.md
@@ -1,0 +1,231 @@
+---
+sort: 26
+---
+
+# viscoNeoHookeanElastic
+
+This law combines a finite-strain nonlinear deviatoric response with a
+generalised Maxwell relaxation model and an elastic volumetric response. The
+runtime type is:
+
+```text
+viscoNeoHookeanElastic
+```
+
+---
+
+## User Guide
+
+### What it computes
+
+The law first forms the total deformation gradient, its determinant and its
+volume-preserving part:
+
+```text
+J    = det(F)
+Fbar = J^(-1/3)*F
+C    = F^T*F
+lambdaBar_a = J^(-1/3)*sqrt(eigenvalue_a(C))
+```
+
+For `m = 0, 1, 2`, the three supplied modulus/exponent pairs define a diagonal
+tensor `D` and the current deviatoric response `S`:
+
+```text
+D_aa = sum_m mu_m*lambdaBar_a^(alpha_m - 1)
+S    = dev(2*Fbar*D*Fbar^T)
+s    = inv(Fbar)*S*inv(Fbar)^T
+```
+
+For each Maxwell branch `i`, the internal variables are updated from their
+old-time values using the current time-step `deltaT`:
+
+```text
+H_i = exp(-deltaT/tau_i)*h_i.oldTime()
+    - exp(-deltaT/(2*tau_i))*s.oldTime()
+
+h_i = H_i + exp(-deltaT/(2*tau_i))*s
+```
+
+The relative moduli, relaxation factor, pressure and stress assigned by the
+code are:
+
+```text
+E0       = EInfinity + sum_i E_i
+gammaInf = EInfinity/E0
+gamma_i  = E_i/E0
+g        = gammaInf + sum_i gamma_i*exp(-deltaT/(2*tau_i))
+p        = k/(beta*J)*(1 - J^(-beta))
+
+sigma = J*p*I + (1 + g)*S
+      + sum_i gamma_i*dev(Fbar*H_i*Fbar^T)
+```
+
+The class implements both `correct(volSymmTensorField&)` and
+`correct(surfaceSymmTensorField&)`. The inherited point-centred overload aborts
+with `notImplemented`. On OpenFOAM.com and OpenFOAM.org, the inherited
+`CompactListList` quadrature-point overload also aborts with `notImplemented`;
+that overload is not compiled for foam-extend.
+
+### Model options
+
+| Entry | Required | Description |
+| --- | --- | --- |
+| `EInfinity` | yes | Long-term modulus, `[1 -1 -2 0 0 0 0]` |
+| `E` | yes | Maxwell moduli; scalar list used to form relative weights |
+| `relaxationTimes` | yes | Positive scalar list, one value per `E` value |
+| `nu` | yes | Long-term Poisson's ratio, dimensionless |
+| `mu0` | yes | First nonlinear modulus, `[1 -1 -2 0 0 0 0]` |
+| `mu1` | yes | Second nonlinear modulus, `[1 -1 -2 0 0 0 0]` |
+| `mu2` | yes | Third nonlinear modulus, `[1 -1 -2 0 0 0 0]` |
+| `alpha` | yes | Dimensionless exponent list; entries 0 through 2 are used |
+| `beta` | yes | Dimensionless volumetric exponent |
+| `k` | yes | Bulk modulus used by the stress law, `[1 -1 -2 0 0 0 0]` |
+| `rho` | yes | Density, `[1 -3 0 0 0 0 0]` |
+| `solvePressureEqn` | no | Base switch, default `no`; unused by `correct()` |
+| `pressureSmoothingScaleFactor` | no | Default `100`; unused here |
+| `regionName` | no | Base mesh region when it cannot be detected |
+
+The `E` and `relaxationTimes` lists must have the same non-zero length. Every
+entry of each list must be positive. The values in `E` are plain scalars, so
+they must use the same numerical modulus unit as `EInfinity`.
+
+The implementation indexes the first three `alpha` values without checking the
+list length. Supply at least three values; later values are not used. The
+constructor requires `k`, warns that it is read directly, and uses it instead
+of the bulk modulus derived from `EInfinity` and `nu`.
+
+`planeStress` is read from the enclosing `mechanicalProperties` dictionary. It
+changes the derived `lambda`, but the supplied `k` still replaces the derived
+bulk modulus. The pressure-equation entries are constructed by the base class,
+but this law does not call `updateSigmaHyd()`.
+
+### Recommended dictionary setup
+
+The following values define an illustrative three-branch silicone-like
+material:
+
+```text
+planeStress     no;
+
+mechanical
+(
+    siliconeLike
+    {
+        type            viscoNeoHookeanElastic;
+        rho             rho [1 -3 0 0 0 0 0] 1100;
+        EInfinity       EInfinity [1 -1 -2 0 0 0 0] 1.0e6;
+        E               (5.0e5 2.0e5 1.0e5);
+        relaxationTimes (0.1 1 10);
+        nu              nu [0 0 0 0 0 0 0] 0.49;
+        mu0             mu0 [1 -1 -2 0 0 0 0] 3.0e5;
+        mu1             mu1 [1 -1 -2 0 0 0 0] 1.0e5;
+        mu2             mu2 [1 -1 -2 0 0 0 0] 5.0e4;
+        alpha           (2 4 6);
+        beta            beta [0 0 0 0 0 0 0] 2;
+        k               k [1 -1 -2 0 0 0 0] 5.0e7;
+
+        // Optional base-class entries
+        // solvePressureEqn             no;
+        // pressureSmoothingScaleFactor 100;
+        // regionName                   region0;
+    }
+);
+```
+
+### Field glossary
+
+- `F_`, `Ff_`: total deformation gradients at cell centres and faces, created
+  by the base class and read on restart when present.
+- `relF_`, `relFf_`: relative deformation gradients maintained by the base
+  class while updating `F_` and `Ff_`.
+- `s`, `sf`: pull-backs of the current deviatoric response at cells and faces;
+  their old-time values enter the relaxation update.
+- `h<i>`, `hf<i>`: internal stress variables for Maxwell branch `i`; their
+  old-time values are stored.
+- `H<i>`, `Hf<i>`: intermediate branch-history fields calculated during each
+  stress correction.
+- `transformH<i>`, `transformHf<i>`: transformed branch-history fields used in
+  the final stress sum.
+- `transformNeeded`, `transformNeededf`: diagonal nonlinear response tensors
+  assembled from the modified principal stretches.
+- `transformFbar`, `transformFbarf`: transformed nonlinear response tensors
+  whose deviatoric parts give `S`.
+- `impK`: implicit stiffness supplied to the solid model's Laplacian term.
+
+---
+
+## Developer Notes
+
+### Class role
+
+`viscoNeoHookeanElastic` derives directly from `mechanicalLaw` and is
+registered in the nonlinear-geometry mechanical-law selection table. It stores
+the long-term modulus and Poisson's ratio, Maxwell moduli and times, relative
+weights, three nonlinear moduli, the exponent list, the volumetric exponent,
+the bulk modulus, and cell- and face-centred history fields.
+
+The class is listed in both `Make/files.openfoam` and `Make/files.foamextend`.
+The header includes `surfaceFields.H` only under `OPENFOAM_NOT_EXTEND`. The
+source uses `realEigenValues` under `OPENFOAM_COM` and fork-specific field
+accessors under `OPENFOAM_NOT_EXTEND`; the constitutive algorithm is otherwise
+present for all three forks.
+
+### Construction
+
+The base constructor first reads or inserts `solvePressureEqn` and
+`pressureSmoothingScaleFactor`, then selects `regionName`. The derived
+constructor reads `EInfinity`, `E`, `relaxationTimes`, `nu`, `mu0`, `mu1`,
+`mu2`, `alpha`, `beta` and `k`, in that order, and creates the cell and face
+history fields.
+
+It then performs the following operations:
+
+- a `nu` outside `[-1, 0.5]` causes a fatal error;
+- `nu == 0.5` prints an incompressibility message, sets `lambda` and `k` to
+  `GREAT`, and then encounters the fatal independent-`k` check;
+- otherwise it derives `lambda` and a bulk modulus, warns that `k` is read
+  directly, and replaces the derived bulk modulus with the supplied `k`;
+- unequal `E` and `relaxationTimes` list lengths cause a fatal error;
+- it computes `gammaInf` and each `gamma_i` from the total modulus;
+- a relaxation time below `SMALL` causes a fatal error;
+- an `E` value below `SMALL` causes a fatal error;
+- it prints the relative moduli, allocates one set of history fields per
+  Maxwell branch, and stores the old-time `h`, `hf`, `s` and `sf` fields.
+
+The constructor does not validate `EInfinity`, `beta`, the total modulus, or
+the length of `alpha`.
+
+### Key methods
+
+- `impK()`: returns `2*mu` when `nu == 0.5` or a cell field named `p` exists;
+  otherwise it returns `2*mu + 4*k/3`. It is the diffusivity of the solid
+  model's Laplacian term and affects the outer-iteration convergence rate
+  rather than the converged answer.
+- `K()`: returns a uniform cell field containing the stored `k` value.
+- `correct()`: updates `F` or `Ff`, evaluates the nonlinear deviatoric
+  response from the three modulus/exponent pairs, advances the Maxwell
+  histories, and assigns the stress shown above. If the solid model enforces
+  linear material behavior, the base-class `updateF()` assigns an elastic
+  stress using `mu` and `k` and the method returns immediately.
+- `materialTangent()`: is not overridden; the inherited implementation aborts
+  with `notImplemented`.
+- `setRestart()`: sets `F` and `Ff` to `AUTO_WRITE`.
+
+### Extension points
+
+A related law can copy this class and replace the nonlinear response and
+history updates in the two `correct()` methods. New branch properties should
+be read and validated before allocating matching cell and face history lists.
+Implement the point and quadrature-point overloads, and `materialTangent()`, if
+the new law must support vertex-centred or tangent-based solid models. Keep the
+source in both build lists when all three OpenFOAM forks are supported.
+
+The source is at
+[viscoNeoHookeanElastic.C](https://github.com/solids4foam/solids4foam/blob/master/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/viscoNeoHookeanElastic/viscoNeoHookeanElastic.C).
+
+---
+
+## Tutorials
+
+No tutorial currently uses `viscoNeoHookeanElastic`.


### PR DESCRIPTION
Phase 3 of the website documentation work. Adds twenty-nine pages covering the
`materialModels` subtree, following the structure established by the solid
model pages in #324:

- a section landing page for `materialModels`
- a page for the `mechanicalLaw` base class, covering the entries every law
  understands
- an index for each of `linearGeometryLaws` and `nonLinearGeometryLaws`
- one page per mechanical law, twenty-five in all

Markdown only — no source changes.

## How the pages were written

Each page was written against the `.H` and `.C` of its law rather than from the
class name, so the documented behaviour is the implemented behaviour. Where a
class header disagrees with its own code, the page follows the code.

The following were then checked mechanically across all twenty-nine pages:

| Check | Result |
| --- | --- |
| Run-time selection name matches `addToRunTimeSelectionTable` | 25/25 |
| Every documented dictionary entry traced to a lookup in the source | pass |
| Every cited tutorial path exists | 30/30 |
| Every cited tutorial actually selects that law | 30/30 |
| `markdownlint-cli2` over `src/**` | 0 errors |

## Issues found while writing

Documenting the laws surfaced a number of discrepancies, filed separately as
#334 to #344. None is fixed here — this PR is documentation only — but three
were serious enough that the affected page carries a warning linking its issue:

- **#334** `anisotropicBiotElastic` selects its 2-D and 3-D branches on an
  inverted test, so a 3-D case silently computes zero out-of-plane stress. The
  shipped `rodAndSeabed` tutorial is affected.
- **#335** `linearElasticFromFile` sets `mu = E/(1 + nu)` and then forms the
  stress with `twoSymm`, giving twice the Hookean shear stress.
- **#336** `linearElasticCt` is in neither fork's build list, so it cannot be
  selected at run time. The page documents the law and says so.

The remaining issues (#337-#344) cover `electroMechanicalLaw`,
`neoHookeanElasticMisesPlastic`, `viscousHookeanElastic`,
`viscoNeoHookeanElastic`, `linearElasticMohrCoulombPlastic`, `GentElastic`,
`diffusionHyperElastic`, and a group of header/implementation mismatches.

## Note on sort values

The `sort:` front matter is unique across the whole section rather than
restarting per subdirectory, because the website flattens each documentation
section into a single directory of pages. The two subsection indices sit at
sorts 2 and 14, ahead of the laws they introduce.

## Website side

The corresponding site change — manifest entries and symlinks — is held on a
local `docs-phase3` branch of solids4foam.github.io and is **not** yet proposed.
As in Phase 2, it cannot land until this PR merges and the automated submodule
bump reaches the site's `master`, otherwise its symlinks dangle.

Verified locally with the site's submodule checked out at this branch: 159
pages build under `--safe`, up from 130, with the material models sidebar
numbered 1-28 in the intended order and no dangling symlinks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)