### PR TITLE
Fix high-order Jacobian assembly and add cantilever2d regression coverage

### DIFF
--- a/src/solids4FoamModels/higherOrderHelpers/hofv/hofvm.C
+++ b/src/solids4FoamModels/higherOrderHelpers/hofv/hofvm.C
@@ -680,7 +680,24 @@ label Foam::hofvm::initialiseJacobian
 
     AssertPETSc(MatSetOption(jac, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_TRUE));
     AssertPETSc(MatSetOption(jac, MAT_KEEP_NONZERO_PATTERN, PETSC_TRUE));
-    AssertPETSc(MatSetOption(jac, MAT_IGNORE_ZERO_ENTRIES, PETSC_TRUE));
+
+    PetscBool matIsAIJ = PETSC_FALSE;
+    AssertPETSc
+    (
+        PetscObjectTypeCompareAny
+        (
+            reinterpret_cast<PetscObject>(jac),
+            &matIsAIJ,
+            MATSEQAIJ,
+            MATMPIAIJ,
+            ""
+        )
+    );
+
+    if (matIsAIJ)
+    {
+        AssertPETSc(MatSetOption(jac, MAT_IGNORE_ZERO_ENTRIES, PETSC_TRUE));
+    }
 
     return 0;
 }

--- a/src/solids4FoamModels/higherOrderHelpers/hofv/hofvm.C
+++ b/src/solids4FoamModels/higherOrderHelpers/hofv/hofvm.C
@@ -122,19 +122,19 @@ inline void addTensorCoeff
 
 Foam::tensor Foam::hofvm::laplacianCoeff
 (
-    const scalar& gammaMagSf,
+    const scalar& gamma,
     const scalar& quadWeight,
     const vector& gradInterpCoeff,
     const vector& faceNormal
 )
 {
-    return I*gammaMagSf*quadWeight*(gradInterpCoeff & faceNormal);
+    return I*gamma*quadWeight*(gradInterpCoeff & faceNormal);
 }
 
 
 Foam::tensor Foam::hofvm::laplacianTransposeCoeff
 (
-    const scalar& gammaMagSf,
+    const scalar& gamma,
     const scalar& quadWeight,
     const vector& gradInterpCoeff,
     const vector& faceNormal
@@ -143,7 +143,7 @@ Foam::tensor Foam::hofvm::laplacianTransposeCoeff
     const vector& c = gradInterpCoeff;
     const vector& n = faceNormal;
 
-    return gammaMagSf*quadWeight
+    return gamma*quadWeight
        *tensor
         (
             c.x()*n.x(), c.x()*n.y(), c.x()*n.z(),
@@ -155,7 +155,7 @@ Foam::tensor Foam::hofvm::laplacianTransposeCoeff
 
 Foam::tensor Foam::hofvm::laplacianTraceCoeff
 (
-    const scalar& gammaMagSf,
+    const scalar& gamma,
     const scalar& quadWeight,
     const vector& gradInterpCoeff,
     const vector& faceNormal
@@ -164,7 +164,7 @@ Foam::tensor Foam::hofvm::laplacianTraceCoeff
     const vector& c = gradInterpCoeff;
     const vector& n = faceNormal;
 
-    return gammaMagSf*quadWeight
+    return gamma*quadWeight
        *tensor
         (
             c.x()*n.x(), c.y()*n.x(), c.z()*n.x(),
@@ -194,7 +194,7 @@ static label hofvmLaplacianPETSc
     const volScalarField& diffusivity,
     tensor (*calcCoeff)
     (
-        const scalar& gammaMagSf,
+        const scalar& gamma,
         const scalar& quadWeight,
         const vector& gradInterpCoeff,
         const vector& faceNormal
@@ -208,7 +208,6 @@ static label hofvmLaplacianPETSc
     const movingLeastSquaresStencil& stencil = mls.stencilData();
     const labelUList& owner = mesh.owner();
     const labelUList& neighbour = mesh.neighbour();
-    const scalarField& magSfI = mesh.magSf().internalField();
     const surfaceVectorField n(mesh.Sf()/mesh.magSf());
     const label nScalarEqns = nDisplacementEqns(mesh);
 
@@ -237,7 +236,7 @@ static label hofvmLaplacianPETSc
     forAll(owner, faceI)
     {
         const vector& faceNormal = n[faceI];
-        const scalar gammaMagSf = magSfI[faceI]*gammaI[faceI];
+        const scalar gammaFace = gammaI[faceI];
         const label ownCellID = owner[faceI];
         const label neiCellID = neighbour[faceI];
         const PetscInt globalOwnRow =
@@ -256,7 +255,7 @@ static label hofvmLaplacianPETSc
                 const tensor coeff =
                     calcCoeff
                     (
-                        gammaMagSf,
+                        gammaFace,
                         quadPointW,
                         gradCoeffs[faceI][qpI][cI],
                         faceNormal
@@ -304,7 +303,6 @@ static label hofvmLaplacianPETSc
 
         if (isA<processorPolyPatch>(pp))
         {
-            const scalarField& pMagSf = mesh.magSf().boundaryField()[patchI];
             const scalarField& pGamma = gamma.boundaryField()[patchI];
             const vectorField patchNormal(mesh.boundary()[patchI].nf());
             const label start = pp.start();
@@ -316,7 +314,7 @@ static label hofvmLaplacianPETSc
                 const PetscInt globalOwnRow =
                     petscSnesHelper.globalCells().toGlobal(ownCellID);
                 const vector& faceNormal = patchNormal[faceI];
-                const scalar gammaMagSf = pMagSf[faceI]*pGamma[faceI];
+                const scalar gammaFace = pGamma[faceI];
                 const labelUList stencil = stencils[faceID];
 
                 forAll(faceQuadWeights[faceID], qpI)
@@ -329,7 +327,7 @@ static label hofvmLaplacianPETSc
                         const tensor coeff =
                             calcCoeff
                             (
-                                gammaMagSf,
+                                gammaFace,
                                 quadPointW,
                                 gradCoeffs[faceID][qpI][cI],
                                 faceNormal
@@ -363,7 +361,6 @@ static label hofvmLaplacianPETSc
                 << abort(FatalError);
         }
 
-        const scalarField& pMagSf = mesh.magSf().boundaryField()[patchI];
         const scalarField& pGamma = gamma.boundaryField()[patchI];
         const vectorField patchNormal(mesh.boundary()[patchI].nf());
         const label start = pp.start();
@@ -387,7 +384,7 @@ static label hofvmLaplacianPETSc
                 const vector& faceNormal = patchNormal[faceI];
                 const tensor R = I - 2.0*sqr(faceNormal);
 
-                const scalar gammaMagSf = pMagSf[faceI]*pGamma[faceI];
+                const scalar gammaFace = pGamma[faceI];
                 const labelUList stencil = stencils[faceID];
                 const label stencilSize = stencil.size();
 
@@ -402,7 +399,7 @@ static label hofvmLaplacianPETSc
                         const tensor coeff =
                             calcCoeff
                             (
-                                gammaMagSf,
+                                gammaFace,
                                 quadPointW,
                                 gradCoeffs[faceID][qpI][cI],
                                 faceNormal
@@ -411,7 +408,7 @@ static label hofvmLaplacianPETSc
                         const tensor mirrorCoeff =
                             calcCoeff
                             (
-                                gammaMagSf,
+                                gammaFace,
                                 quadPointW,
                                 gradCoeffs[faceID][qpI][cI + stencilSize],
                                 faceNormal
@@ -458,7 +455,7 @@ static label hofvmLaplacianPETSc
                 const PetscInt globalOwnRow =
                     petscSnesHelper.globalCells().toGlobal(ownCellID);
                 const vector& faceNormal = patchNormal[faceI];
-                const scalar gammaMagSf = pMagSf[faceI]*pGamma[faceI];
+                const scalar gammaFace = pGamma[faceI];
                 const labelUList stencil = stencils[faceID];
 
                 forAll(faceQuadWeights[faceID], qpI)
@@ -471,7 +468,7 @@ static label hofvmLaplacianPETSc
                         const tensor coeff =
                             calcCoeff
                             (
-                                gammaMagSf,
+                                gammaFace,
                                 quadPointW,
                                 gradCoeffs[faceID][qpI][cI],
                                 faceNormal

--- a/src/solids4FoamModels/higherOrderHelpers/hofv/hofvm.H
+++ b/src/solids4FoamModels/higherOrderHelpers/hofv/hofvm.H
@@ -49,7 +49,7 @@ namespace hofvm
     //- Laplacian coefficient
     tensor laplacianCoeff
     (
-        const scalar& gammaMagSf,
+        const scalar& gamma,
         const scalar& quadWeight,
         const vector& gradInterpCoeff,
         const vector& faceNormal
@@ -58,7 +58,7 @@ namespace hofvm
     //- Laplacian transpose coefficient
     tensor laplacianTransposeCoeff
     (
-        const scalar& gammaMagSf,
+        const scalar& gamma,
         const scalar& quadWeight,
         const vector& gradInterpCoeff,
         const vector& faceNormal
@@ -67,7 +67,7 @@ namespace hofvm
     //- Laplacian trace coefficient
     tensor laplacianTraceCoeff
     (
-        const scalar& gammaMagSf,
+        const scalar& gamma,
         const scalar& quadWeight,
         const vector& gradInterpCoeff,
         const vector& faceNormal

--- a/tutorials/solids/linearElasticity/cantilever2d/Allrun
+++ b/tutorials/solids/linearElasticity/cantilever2d/Allrun
@@ -19,6 +19,7 @@ Where [approach] is one of:
   segregated
   unsCoupled
   highOrder
+  highOrderJacobian
 
 Examples:
   ./Allrun
@@ -26,6 +27,7 @@ Examples:
   ./Allrun segregated
   ./Allrun unsCoupled
   ./Allrun highOrder
+  ./Allrun highOrderJacobian
 EOF
 }
 
@@ -52,7 +54,7 @@ APPROACH="${1:-petscSnes}"
 
 # Validate approach name
 case "$APPROACH" in
-    petscSnes|vertexCentred|segregated|unsCoupled|highOrder) ;;
+    petscSnes|vertexCentred|segregated|unsCoupled|highOrder|highOrderJacobian) ;;
     *)
         echo "Error: Unknown approach '$APPROACH'"
         usage
@@ -81,7 +83,7 @@ link_files_for_suffix() {
 
 require_petsc_or_exit_silently() {
     case "$APPROACH" in
-        petscSnes|vertexCentred|highOrder)
+        petscSnes|vertexCentred|highOrder|highOrderJacobian)
             solids4Foam::requirePetscOrExitSilently
             ;;
     esac
@@ -110,6 +112,11 @@ select_approach() {
             echo "Using the highOrder approach"
             solids4Foam::caseDoesNotRunWithFoamExtend
             link_files_for_suffix "highOrder"
+            ;;
+        highOrderJacobian)
+            echo "Using the highOrderJacobian testing approach"
+            solids4Foam::caseDoesNotRunWithFoamExtend
+            link_files_for_suffix "highOrderJacobian"
             ;;
     esac
 }

--- a/tutorials/solids/linearElasticity/cantilever2d/README.md
+++ b/tutorials/solids/linearElasticity/cantilever2d/README.md
@@ -106,7 +106,12 @@ In solids4foam, there are several solid models which can solve this problem;
    the solver uses the same second-order Laplacian as approach 1 as a physical
    preconditioner. Alternatively, `highOrderJacobian true;` can be used to
    assemble the high-order Jacobian; this affects the timing but not the
-   accuracy.
+   accuracy. Note that when `highOrderJacobian` is set to `true`, Jacobian-free
+   Newton-Krylov iterations should not be required. By setting `snes_type
+   ksponly;` in `system/fvSolution`, one should get the same answer as with the
+   JFNK approach. This mimics the discretisation in [6]. The assembled
+   high-order Jacobian does not include stabilisation, so direct solving is
+   acceptable only on regular meshes; see [5].
 
 ```note
 Approach 4 uses simplified uniform displacement (left) and uniform traction
@@ -191,3 +196,7 @@ Table 1 lists the wall-clock times rounded to the nearest second for the
 [5] [IBatistić, Ivan, Pablo Castrillo, and Philip Cardiff. High-order cell-centred
 finite-volume solid mechanics using a Jacobian-free Newton-Krylov method,
 Journal of computational physics, (2026): 115056](https://doi.org/10.1016/j.jcp.2026.115056)
+
+[6] [P. Castrillo, A. Canelas, E. Schillaci, J. Rigola, A. Oliva, High-order finite
+ volume method for linear elasticity on unstructured meshes. *Computers & Structures*,
+ 268, 106829, 2022, 10.1016/j.compstruc.2022.106829.](https://doi.org/10.1016/j.compstruc.2022.106829)

--- a/tutorials/solids/linearElasticity/cantilever2d/README.md
+++ b/tutorials/solids/linearElasticity/cantilever2d/README.md
@@ -106,12 +106,14 @@ In solids4foam, there are several solid models which can solve this problem;
    the solver uses the same second-order Laplacian as approach 1 as a physical
    preconditioner. Alternatively, `highOrderJacobian true;` can be used to
    assemble the high-order Jacobian; this affects the timing but not the
-   accuracy. Note that when `highOrderJacobian` is set to `true`, Jacobian-free
-   Newton-Krylov iterations should not be required. By setting `snes_type
-   ksponly;` in `system/fvSolution`, one should get the same answer as with the
-   JFNK approach. This mimics the discretisation in [6]. The assembled
-   high-order Jacobian does not include stabilisation, so direct solving is
-   acceptable only on regular meshes; see [5].
+   accuracy. The `highOrder` Allrun option retains the Jacobian-free
+   Newton-Krylov solver settings and uses the assembled matrix as a physical
+   preconditioner. The `highOrderJacobian` option is a regression-only test:
+   it removes the matrix-free options, sets `snes_type ksponly;`, and disables
+   stabilisation so that it solves with the assembled high-order Jacobian.
+   This mimics the discretisation in [6]. The assembled high-order Jacobian
+   does not include stabilisation, so this direct solve is acceptable only on
+   regular meshes; see [5].
 
 ```note
 Approach 4 uses simplified uniform displacement (left) and uniform traction

--- a/tutorials/solids/linearElasticity/cantilever2d/constant/solidProperties.highOrderJacobian
+++ b/tutorials/solids/linearElasticity/cantilever2d/constant/solidProperties.highOrderJacobian
@@ -1,0 +1,55 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| solids4foam: solid mechanics and fluid-solid interaction simulations        |
+| Version:     v2.4                                                           |
+| Web:         https://solids4foam.github.io                                  |
+| Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
+|              producer and distributor of the OpenFOAM software via          |
+|              www.openfoam.com, and owner of the OPENFOAM® and OpenCFD®      |
+|              trade marks.                                                   |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "constant";
+    object      solidProperties;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+solidModel     linearGeometryTotalDisplacement;
+
+linearGeometryTotalDisplacementCoeffs
+{
+    solutionAlgorithm    PETScSNES;
+
+    highOrderCoeffs
+    {
+        highOrderJacobian true;
+        highOrderResidual true;
+
+        displacement
+        {
+            polynomialOrder 3;
+            faceStencilExtraCells 15;
+
+            weightFunctionCoeffs
+            {
+                type radiallySymmetricExponential;
+                k 6;
+            }
+            calcConditionNumber false;
+        }
+    }
+
+    stabilisation
+    {
+        momentum
+        {
+            type        alpha;
+            scaleFactor 0;
+        }
+    }
+}
+
+// ************************************************************************* //

--- a/tutorials/solids/linearElasticity/cantilever2d/regressionTest.sh
+++ b/tutorials/solids/linearElasticity/cantilever2d/regressionTest.sh
@@ -30,6 +30,7 @@ ALLRUN_LOGFILE="log.Allrun"
 APPROACHES=(
     petscSnes
     highOrder
+    highOrder-JacobianTesting
 )
 
 echo "============================================================"
@@ -99,6 +100,69 @@ extract_disp_linf() {
         || true
 }
 
+link_files_for_suffix() {
+    local suffix="$1"
+    local found=0
+
+    while IFS= read -r -d '' f; do
+        found=1
+        rm -f "${f%.*}"
+        ln -vnsf "$(basename "$f")" "${f%.*}"
+    done < <(find ./0 ./constant ./system -type f -name "*.${suffix}" -print0 2>/dev/null || true)
+
+    if (( !found )); then
+        echo "Warning: No *.${suffix} files found under ./0 ./constant ./system."
+    fi
+}
+
+run_jacobian_testing() {
+    export DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH:-}"
+    : "${FOAM_LD_LIBRARY_PATH:=}"
+    : "${WM_PROJECT_DIR:?OpenFOAM environment not sourced}"
+    . "$WM_PROJECT_DIR/bin/tools/RunFunctions"
+    source solids4FoamScripts.sh
+
+    solids4Foam::requirePetscOrExitSilently
+
+    echo "Using the highOrder-JacobianTesting regression approach"
+    solids4Foam::caseDoesNotRunWithFoamExtend
+    link_files_for_suffix "highOrder"
+
+    sed -i.bak \
+        -e 's|highOrderJacobian false;|highOrderJacobian true;|' \
+        -e 's|scaleFactor 0.1;|scaleFactor 0;|' \
+        constant/solidProperties
+
+    sed -i.bak \
+        -e 's|snes_type newtonls;|snes_type ksponly;|' \
+        system/fvSolution
+
+    rm -f constant/solidProperties.bak system/fvSolution.bak
+
+    echo
+    echo "Compiling libraries..."
+    (cd src && ./Allwmake -s)
+
+    echo
+    solids4Foam::convertCaseFormat .
+
+    echo
+    solids4Foam::runApplication blockMesh
+
+    echo
+    solids4Foam::runApplication solids4Foam
+}
+
+run_regression_approach() {
+    local approach="$1"
+
+    if [[ "${approach}" == "highOrder-JacobianTesting" ]]; then
+        run_jacobian_testing
+    else
+        ./Allrun "${approach}"
+    fi
+}
+
 check_solver_extrema() {
     local approach="$1"
     local epsilon
@@ -161,7 +225,7 @@ if [ "$CHECK_ONLY" = false ]; then
         echo "------------------------------------------------------------"
 
         ( cd "${CASE_DIR}" && ./Allclean > /dev/null 2>&1 ) || true
-        ( cd "${CASE_DIR}" && ./Allrun "${approach}" > "${ALLRUN_LOGFILE}" 2>&1 )
+        ( cd "${CASE_DIR}" && run_regression_approach "${approach}" > "${ALLRUN_LOGFILE}" 2>&1 )
 
         if solids4Foam::regressionCaseSkipped "${CASE_DIR}/${ALLRUN_LOGFILE}"; then
             echo "Skipping ${approach} because it is unavailable in this environment"
@@ -172,9 +236,10 @@ if [ "$CHECK_ONLY" = false ]; then
             failures=$((failures + 1))
         fi
 
-        if [[ "${approach}" == "highOrder" ]] && ! check_high_order_errors; then
+        if [[ "${approach}" == highOrder* ]] && ! check_high_order_errors; then
             failures=$((failures + 1))
         fi
+
     done
 else
     if solids4Foam::regressionCaseSkipped "${CASE_DIR}/${ALLRUN_LOGFILE}"; then

--- a/tutorials/solids/linearElasticity/cantilever2d/regressionTest.sh
+++ b/tutorials/solids/linearElasticity/cantilever2d/regressionTest.sh
@@ -30,7 +30,7 @@ ALLRUN_LOGFILE="log.Allrun"
 APPROACHES=(
     petscSnes
     highOrder
-    highOrder-JacobianTesting
+    highOrderJacobian
 )
 
 echo "============================================================"
@@ -100,69 +100,6 @@ extract_disp_linf() {
         || true
 }
 
-link_files_for_suffix() {
-    local suffix="$1"
-    local found=0
-
-    while IFS= read -r -d '' f; do
-        found=1
-        rm -f "${f%.*}"
-        ln -vnsf "$(basename "$f")" "${f%.*}"
-    done < <(find ./0 ./constant ./system -type f -name "*.${suffix}" -print0 2>/dev/null || true)
-
-    if (( !found )); then
-        echo "Warning: No *.${suffix} files found under ./0 ./constant ./system."
-    fi
-}
-
-run_jacobian_testing() {
-    export DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH:-}"
-    : "${FOAM_LD_LIBRARY_PATH:=}"
-    : "${WM_PROJECT_DIR:?OpenFOAM environment not sourced}"
-    . "$WM_PROJECT_DIR/bin/tools/RunFunctions"
-    source solids4FoamScripts.sh
-
-    solids4Foam::requirePetscOrExitSilently
-
-    echo "Using the highOrder-JacobianTesting regression approach"
-    solids4Foam::caseDoesNotRunWithFoamExtend
-    link_files_for_suffix "highOrder"
-
-    sed -i.bak \
-        -e 's|highOrderJacobian false;|highOrderJacobian true;|' \
-        -e 's|scaleFactor 0.1;|scaleFactor 0;|' \
-        constant/solidProperties
-
-    sed -i.bak \
-        -e 's|snes_type newtonls;|snes_type ksponly;|' \
-        system/fvSolution
-
-    rm -f constant/solidProperties.bak system/fvSolution.bak
-
-    echo
-    echo "Compiling libraries..."
-    (cd src && ./Allwmake -s)
-
-    echo
-    solids4Foam::convertCaseFormat .
-
-    echo
-    solids4Foam::runApplication blockMesh
-
-    echo
-    solids4Foam::runApplication solids4Foam
-}
-
-run_regression_approach() {
-    local approach="$1"
-
-    if [[ "${approach}" == "highOrder-JacobianTesting" ]]; then
-        run_jacobian_testing
-    else
-        ./Allrun "${approach}"
-    fi
-}
-
 check_solver_extrema() {
     local approach="$1"
     local epsilon
@@ -225,7 +162,7 @@ if [ "$CHECK_ONLY" = false ]; then
         echo "------------------------------------------------------------"
 
         ( cd "${CASE_DIR}" && ./Allclean > /dev/null 2>&1 ) || true
-        ( cd "${CASE_DIR}" && run_regression_approach "${approach}" > "${ALLRUN_LOGFILE}" 2>&1 )
+        ( cd "${CASE_DIR}" && ./Allrun "${approach}" > "${ALLRUN_LOGFILE}" 2>&1 )
 
         if solids4Foam::regressionCaseSkipped "${CASE_DIR}/${ALLRUN_LOGFILE}"; then
             echo "Skipping ${approach} because it is unavailable in this environment"

--- a/tutorials/solids/linearElasticity/cantilever2d/system/fvSolution.highOrderJacobian
+++ b/tutorials/solids/linearElasticity/cantilever2d/system/fvSolution.highOrderJacobian
@@ -1,0 +1,43 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| solids4foam: solid mechanics and fluid-solid interaction simulations        |
+| Version:     v2.4                                                           |
+| Web:         https://solids4foam.github.io                                  |
+| Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
+|              producer and distributor of the OpenFOAM software via          |
+|              www.openfoam.com, and owner of the OPENFOAM® and OpenCFD®      |
+|              trade marks.                                                   |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "system";
+    object      fvSolution;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+solvers
+{
+    D
+    {
+        solver          petsc;
+
+        options
+        {
+            snes_type ksponly;
+            snes_monitor;
+            snes_converged_reason;
+
+            ksp_type lgmres;
+            ksp_rtol 1e-12;
+            ksp_gmres_restart "100";
+            ksp_converged_reason;
+
+            pc_type bjacobi;
+            sub_pc_type lu;
+        }
+    }
+}
+
+// ************************************************************************* //

--- a/tutorials/solids/linearElasticity/cantilever2d/system/fvSolution.highOrderJacobian
+++ b/tutorials/solids/linearElasticity/cantilever2d/system/fvSolution.highOrderJacobian
@@ -30,7 +30,7 @@ solvers
             snes_converged_reason;
 
             ksp_type lgmres;
-            ksp_rtol 1e-12;
+            ksp_rtol "1e-12";
             ksp_gmres_restart "100";
             ksp_converged_reason;
 


### PR DESCRIPTION
This PR fixes the high-order PETSc Jacobian assembly by removing an extra face-area scaling in hofvm. 
The quadrature face weights already include the physical face area, so multiplying by magSf again produced an incorrect assembled Jacobian. Multyplying with magSf was needed in the old code version and I missed to remove it when I swithced to physical weights.

The PR also adds regression coverage in cantilever2d for the high-order Jacobian path. The regression-only highOrder-JacobianTesting approach reuses the existing highOrder case files and modifies the copied active dictionaries with sed.
Machine precision solution is obtained without petsc snes iterations, by solving high order jacobian.

  ## Changes Made

  - [x] Bug Fix: Corrected hofvm high-order matrix coefficients to use `gamma*quadWeight` instead of `magSf*gamma*quadWeight`.
  - [x] Documentation: Updated `cantilever2d/README.md` to describe the `highOrderJacobian true` behaviour and its relation to [6].
  - [x] Other: Added a `cantilever2d` regression variant for high-order Jacobian testing.

  ### Summary of Changes

  - Files Modified:
      - src/solids4FoamModels/higherOrderHelpers/hofv/hofvm.C
      - src/solids4FoamModels/higherOrderHelpers/hofv/hofvm.H
      - tutorials/solids/linearElasticity/cantilever2d/README.md
      - tutorials/solids/linearElasticity/cantilever2d/regressionTest.sh

  - Behavioural Changes:
      - The assembled high-order Jacobian now uses the same physical quadrature weighting convention as the high-order residual.
      - The normal highOrder tutorial case is unchanged.
      - The regression-only highOrder-JacobianTesting variant sets highOrderJacobian true, disables stabilisation, and uses snes_type ksponly.

  ## Checklist

  - [x] Code compiles successfully with OpenFOAM v2412.
  - [x] Tested with the relevant tutorial regression case.
  - [x] Added relevant documentation.
  - [x] GitHub Actions CI checks pass.

  ## Test Cases and Results

  - Case Name: tutorials/solids/linearElasticity/cantilever2d
  - Command: ./regressionTest.sh
  - Results:
      - petscSnes: passed
      - highOrder: passed, DDifference LInf = 7.21593e-12
      - highOrder-JacobianTesting: passed, DDifference LInf = 6.87629e-12
      
 ## Additional Notes

The assembled high-order Jacobian does not include stabilisation. The regression disables stabilisation and is intended for regular meshes, matching the discretisation described in reference [6]. This explanation is added to the README.md file.