### PR TITLE
CI: log the runner hardware in the build-and-test matrix

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -90,6 +90,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Record the hardware this job landed on, so that intermittent tutorial
+      # failures can be correlated with the CPU rather than inferred from the
+      # Azure region printed in the "Set up job" group. See issue #352.
+      # Every command is best-effort: this step must never fail a build.
+      - name: Runner hardware
+        run: |
+          lscpu | grep -E 'Model name|^Flags|^CPU\(s\)' || true
+          free -g || true
+          cat /proc/cpuinfo | grep -m1 'model name' || true
+
       - name: Allwmake
         shell: bash -l {0}
         run: |


### PR DESCRIPTION
## Description

Adds a `Runner hardware` step to every job in the **Build and test** matrix,
logging the CPU model, CPU flags and available memory.

This is diagnostic support for #352: `cantilever2d` and `narrowTmember`
(`petscSnes`) fail intermittently in `Alltest`, including on
documentation-only pull requests such as #350. Every failure observed so far
landed on a runner in the Azure region `centralus`, and none of the
non-`centralus` jobs failed — but region is only a proxy for the CPU pool, and
the correlation is currently inferred from the region string that the runner
happens to print in its "Set up job" group.

Logging the processor directly lets the next few runs settle whether a specific
microarchitecture is implicated. If it is, the follow-up is a one-line
`OPENBLAS_CORETYPE` pin in the workflow `env:` to remove OpenBLAS runtime kernel
dispatch as a variable across pools.

## Points worth a comment

- Placed immediately after `checkout` so it is recorded even when `Allwmake`
  fails, and so it applies to the non-PETSc entries too — useful as a control,
  since those jobs do not run the affected cases.
- `free -g` rounds to whole gigabytes. That is enough to confirm the runner
  class; it is not intended as a measurement of what the cases consume. Peak RSS
  for `narrowTmember` is ~1 GB locally, so memory is already ruled out as the
  cause (see #352).

## Testing

Diagnostic only — no build or test behaviour changes. Every command is guarded
with `|| true`, so the step cannot fail a job even on the older Ubuntu 20.04
images (OpenFOAM-9, foam-extend-4.1) if `lscpu` or `free` are unavailable.
The workflow file was checked to be valid YAML.

The step's own output in this PR's run is the first useful data point.
