### PR TITLE
foamPetscSnesHelper: fix uninitialised Vec in storeSolutionBackup()

### DIFF
--- a/src/solids4FoamModels/numerics/foamPetscSnesHelper/foamPetscSnesHelper.H
+++ b/src/solids4FoamModels/numerics/foamPetscSnesHelper/foamPetscSnesHelper.H
@@ -252,13 +252,17 @@ public:
                 return x_.v;
             }
 
-            //- Non-const access to the PETSc solution vector
+            //- Non-const access to the PETSc solution backup vector
             Vec solutionBackup()
             {
                 if (!xBackup_.v)
                 {
                     // Initialise based on x
-                    VecDuplicate(x_.v, xBackup_.put());
+                    // Note: we call solution() rather than accessing x_.v
+                    // directly, as x_ is lazily created by solution(); this
+                    // way, the backup vector can be created before the first
+                    // call to solve()
+                    VecDuplicate(solution(), xBackup_.put());
                 }
 
                 return xBackup_.v;
@@ -312,7 +316,14 @@ public:
             //- Store the solution to the solution backup
             void storeSolutionBackup()
             {
-                VecCopy(solution(), solutionBackup());
+                // Note: the solution vector is lazily created, so we take a
+                // copy of it before calling solutionBackup(); the evaluation
+                // order of function arguments is unspecified in C++, so
+                // passing solution() and solutionBackup() directly to VecCopy
+                // would not guarantee that x is created first
+                Vec x = solution();
+
+                VecCopy(x, solutionBackup());
             }
 
             //- Reset the solution and snes object


### PR DESCRIPTION
Fixes #346.

## Problem

`foamPetscSnesHelper::storeSolutionBackup()` was:

```cpp
VecCopy(solution(), solutionBackup());
```

`solution()` is what lazily creates `x_` (it calls `initialiseSnes()` when `x_.v` is null), while `solutionBackup()` read `x_.v` directly in order to `VecDuplicate()` it. The evaluation order of function arguments is unspecified in C++, so a compiler that evaluates the right-hand argument first (gcc 11.5.0, as reported) passes a null `Vec` to `VecDuplicate()` on the *first* call — the only time `x_` does not yet exist. Against a PETSc built with `--with-debugging=no` there is no null check, so it surfaces as a bare `SIGSEGV` with an unhelpful backtrace.

This is compiler-dependent rather than universal: a minimal reproducer of the same pattern built with Apple clang evaluates left-to-right and does not crash, which is why the bug has stayed latent.

No caller on `development` currently reaches `storeSolutionBackup()` before its first `solve()`, so the crash is not reproducible on this branch; the caller that does (`newtonMonolithicCouplingInterface`) lives on `feature-block-coupled-incompressible`. The hazard is in the shared helper, so it is fixed here.

## Fix

Both changes suggested in the issue, as they are complementary:

- `solutionBackup()` now duplicates `solution()` rather than reading `x_.v` directly, so the backup vector can be created before the first solve regardless of the caller.
- `storeSolutionBackup()` sequences the two calls explicitly via a local `Vec x = solution();`, making the ordering requirement obvious at the call site.

## Testing

`foamPetscSnesHelper.C` compiles cleanly against OpenFOAM v2512 (ESI) with PETSc 3.23, using the same defines as the normal build (`-DUSE_PETSC -DOPENFOAM=2512 -DOPENFOAM_COM -DOPENFOAM_NOT_EXTEND`). No runtime case was run, since no caller on `development` exercises the affected path.

Thanks to @failed33 for the clear report and diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)