### PR TITLE
Fix elasticWallPressure restart state

### DIFF
--- a/src/solids4FoamModels/fluidModels/fvPatchFields/elasticWallPressure/elasticWallPressureFvPatchScalarField.C
+++ b/src/solids4FoamModels/fluidModels/fvPatchFields/elasticWallPressure/elasticWallPressureFvPatchScalarField.C
@@ -196,7 +196,7 @@ elasticWallPressureFvPatchScalarField::elasticWallPressureFvPatchScalarField
 
     if (dict.found("prevPressure"))
     {
-        Field<scalar>::operator=(scalarField("prevPressure", dict, p.size()));
+        prevPressure_ = scalarField("prevPressure", dict, p.size());
     }
 
     if (constantHs_ < SMALL)
@@ -403,6 +403,12 @@ void elasticWallPressureFvPatchScalarField::write(Ostream& os) const
 #else
     prevPressure_.writeEntry("prevPressure", os);
 #endif
+
+    if (constantHs_ >= SMALL)
+    {
+        os.writeKeyword("constantHs")
+            << constantHs_ << token::END_STATEMENT << nl;
+    }
 }
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //


### PR DESCRIPTION
## Pull Request Description

`elasticWallPressure` currently reads its written `prevPressure` entry into the
patch value and does not write an explicitly configured `constantHs`.

This change restores `prevPressure_` without overwriting the patch `value` and
writes `constantHs` when it is configured. Older checkpoints without
`constantHs` keep the existing `a_p*deltaT` fallback.

## Related Issues and Discussions

- Closes #359

## Changes Made

- [x] Bug Fix

### Summary of Changes

- **File modified:**
  `elasticWallPressureFvPatchScalarField.C`
- **Patch size:** 7 insertions, 1 deletion
- **Behavioral change:** the boundary restores its pressure history and
  configured constant wall thickness after a write/read cycle.

## Checklist

- [x] Builds with OpenFOAM v2512.
- [x] Tested with the stock `fluidSolidInteraction/3dTube` tutorial.
- [x] The patched checkpoint retains `constantHs`.
- [x] The density-scale restart force jump is removed.
- [x] The uninterrupted tutorial result is unchanged at printed precision.
- [ ] Builds on the remaining supported OpenFOAM and foam-extend variants.
- [ ] GitHub Actions CI passes.

## Test Cases and Results

The stock `3dTube` tutorial was run uninterrupted and from its `0.001`
checkpoint using OpenFOAM v2512 and one MPI rank.

| build | first force x, uninterrupted | first force x, restart | final displacement, uninterrupted | final displacement, restart |
| --- | ---: | ---: | ---: | ---: |
| current `development` | `-0.0355268` | `-34.9317` | `6.76097e-07` | `1.81402e-04` |
| proposed patch | `-0.0355268` | `-0.0349317` | `6.76097e-07` | `6.83484e-07` |

The current checkpoint omits `constantHs`; the patched checkpoint contains
`constantHs 0.0005`.

This change fixes the boundary-state defects in #359, but it does not make the
complete FSI restart identical. In this case, the patched first force x
component still differs by 1.7% and the final displacement by 1.1%. The
remaining differences are being investigated separately.

## Additional Notes

The change adds one scalar entry to written boundary dictionaries when
`constantHs` is configured. It adds no resident field or per-iteration work.

`prevAcceleration_` is intentionally unchanged. The audited coupling paths
update it before the next fluid solve, and restoring it produced no measured
change.
