### PR TITLE
Preserve elasticWallVelocity restart history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,10 @@ release. For complete commit-level details and contributor information, see the
 - Fixed the `RBFMeshMotionSolver` setup for fluid-solid interaction, and
   documented a verified configuration.
 - Fixed `tmp<fvMatrix>` assembly on OpenFOAM.org.
+- Fixed the restart behaviour of the `elasticWallVelocity` boundary condition,
+  which previously discarded its face-centre history and so restarted with a
+  zero interface velocity. The history is now written to, and read from, the
+  time directories, and is mapped by `decomposePar` and `reconstructPar`.
 
 ### Removed in v2.4
 

--- a/src/solids4FoamModels/fluidModels/fvPatchFields/elasticWallVelocity/elasticWallVelocityFvPatchVectorField.C
+++ b/src/solids4FoamModels/fluidModels/fvPatchFields/elasticWallVelocity/elasticWallVelocityFvPatchVectorField.C
@@ -94,8 +94,17 @@ elasticWallVelocityFvPatchVectorField::elasticWallVelocityFvPatchVectorField
         Fc_[i] = patch().patch()[i].centre(points);
     }
 
-    oldFc_ = Fc_;
-    oldOldFc_ = Fc_;
+    if (dict.found("oldFaceCentres"))
+    {
+        oldFc_ = vectorField("oldFaceCentres", dict, p.size());
+        oldOldFc_ = vectorField("oldOldFaceCentres", dict, p.size());
+        timeIndex_ = mesh.time().timeIndex();
+    }
+    else
+    {
+        oldFc_ = Fc_;
+        oldOldFc_ = Fc_;
+    }
 }
 
 
@@ -467,8 +476,12 @@ void elasticWallVelocityFvPatchVectorField::write(Ostream& os) const
     fvPatchVectorField::write(os);
 #ifdef OPENFOAM_ORG
     writeEntry(os, "value", *this);
+    writeEntry(os, "oldFaceCentres", oldFc_);
+    writeEntry(os, "oldOldFaceCentres", oldOldFc_);
 #else
     writeEntry("value", os);
+    oldFc_.writeEntry("oldFaceCentres", os);
+    oldOldFc_.writeEntry("oldOldFaceCentres", os);
 #endif
 }
 

--- a/src/solids4FoamModels/fluidModels/fvPatchFields/elasticWallVelocity/elasticWallVelocityFvPatchVectorField.C
+++ b/src/solids4FoamModels/fluidModels/fvPatchFields/elasticWallVelocity/elasticWallVelocityFvPatchVectorField.C
@@ -29,6 +29,23 @@ License
 namespace Foam
 {
 
+// * * * * * * * * * * * * * Private Member Functions  * * * * * * * * * * * //
+
+void elasticWallVelocityFvPatchVectorField::setCurrentFaceCentres()
+{
+#ifdef OPENFOAM_NOT_EXTEND
+    const pointField& points = internalField().mesh().points();
+#else
+    const pointField& points = dimensionedInternalField().mesh().allPoints();
+#endif
+
+    forAll(Fc_, i)
+    {
+        Fc_[i] = patch().patch()[i].centre(points);
+    }
+}
+
+
 // * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
 
 elasticWallVelocityFvPatchVectorField::elasticWallVelocityFvPatchVectorField
@@ -46,7 +63,13 @@ elasticWallVelocityFvPatchVectorField::elasticWallVelocityFvPatchVectorField
     Fc_(p.patch().size(),vector::zero),
     oldFc_(p.patch().size(),vector::zero),
     oldOldFc_(p.patch().size(),vector::zero)
-{}
+{
+    // The face-centre histories are written by write(): initialise them from
+    // the current patch geometry so that a zero history is never written
+    setCurrentFaceCentres();
+    oldFc_ = Fc_;
+    oldOldFc_ = Fc_;
+}
 
 
 elasticWallVelocityFvPatchVectorField::elasticWallVelocityFvPatchVectorField
@@ -62,7 +85,49 @@ elasticWallVelocityFvPatchVectorField::elasticWallVelocityFvPatchVectorField
     Fc_(p.patch().size(),vector::zero),
     oldFc_(p.patch().size(),vector::zero),
     oldOldFc_(p.patch().size(),vector::zero)
-{}
+{
+    // Initialise the histories from the current patch geometry: this is the
+    // fallback used when the source histories cannot be mapped
+    setCurrentFaceCentres();
+    oldFc_ = Fc_;
+    oldOldFc_ = Fc_;
+
+    // Map the face-centre histories from the source patch when every face has a
+    // source face, as is the case for decomposePar and reconstructPar;
+    // otherwise the fallback above is retained. Note: the histories are written
+    // by write(), so they must not be left as zero, as this would give a
+    // spurious wall velocity of the order of the face-centre position divided
+    // by the time-step
+#ifdef OPENFOAM_ORG
+    if (!mapper.hasUnmapped())
+    {
+        mapper(oldFc_, ptf.oldFc_);
+        mapper(oldOldFc_, ptf.oldOldFc_);
+    }
+#else
+    if (mapper.direct())
+    {
+        const auto& addr = mapper.directAddressing();
+        const label nSourceFaces = ptf.oldFc_.size();
+
+        if (addr.size() == Fc_.size() && ptf.oldOldFc_.size() == nSourceFaces)
+        {
+            forAll(addr, i)
+            {
+                const label sourceFaceI = addr[i];
+
+                // Unmapped faces are flagged with a negative index and keep the
+                // fallback set above
+                if (sourceFaceI >= 0 && sourceFaceI < nSourceFaces)
+                {
+                    oldFc_[i] = ptf.oldFc_[sourceFaceI];
+                    oldOldFc_[i] = ptf.oldOldFc_[sourceFaceI];
+                }
+            }
+        }
+    }
+#endif
+}
 
 
 elasticWallVelocityFvPatchVectorField::elasticWallVelocityFvPatchVectorField
@@ -83,25 +148,40 @@ elasticWallVelocityFvPatchVectorField::elasticWallVelocityFvPatchVectorField
 
 #ifdef OPENFOAM_NOT_EXTEND
     const fvMesh& mesh = internalField().mesh();
-    const pointField& points = mesh.points();
 #else
     const fvMesh& mesh = dimensionedInternalField().mesh();
-    const pointField& points = mesh.allPoints();
 #endif
 
-    forAll(Fc_, i)
-    {
-        Fc_[i] = patch().patch()[i].centre(points);
-    }
+    setCurrentFaceCentres();
 
-    if (dict.found("oldFaceCentres"))
+    if (dict.found("oldFaceCentres") && dict.found("oldOldFaceCentres"))
     {
+        // Restore the face-centre histories written by write(): the current
+        // time index is also restored, as the histories have already been
+        // shifted for the current time
         oldFc_ = vectorField("oldFaceCentres", dict, p.size());
         oldOldFc_ = vectorField("oldOldFaceCentres", dict, p.size());
         timeIndex_ = mesh.time().timeIndex();
     }
     else
     {
+        if (dict.found("oldFaceCentres") || dict.found("oldOldFaceCentres"))
+        {
+            WarningInFunction
+                << "Only one of oldFaceCentres and oldOldFaceCentres is given"
+                << " for patch " << p.name() << " of field "
+#ifdef OPENFOAM_NOT_EXTEND
+                << internalField().name()
+#else
+                << dimensionedInternalField().name()
+#endif
+                << ": both entries are required to restore the face-centre"
+                << " history" << nl
+                << "    The current face centres will be used instead" << endl;
+        }
+
+        // Fields written before the histories were stored, or written by a
+        // utility that cannot map them: assume a stationary interface
         oldFc_ = Fc_;
         oldOldFc_ = Fc_;
     }

--- a/src/solids4FoamModels/fluidModels/fvPatchFields/elasticWallVelocity/elasticWallVelocityFvPatchVectorField.H
+++ b/src/solids4FoamModels/fluidModels/fvPatchFields/elasticWallVelocity/elasticWallVelocityFvPatchVectorField.H
@@ -60,7 +60,7 @@ class elasticWallVelocityFvPatchVectorField
     vectorField oldOldFc_;
 
 
-    // Private member functions
+    // Private Member Functions
 
         //- Set Fc_ to the current patch face centres
         void setCurrentFaceCentres();

--- a/src/solids4FoamModels/fluidModels/fvPatchFields/elasticWallVelocity/elasticWallVelocityFvPatchVectorField.H
+++ b/src/solids4FoamModels/fluidModels/fvPatchFields/elasticWallVelocity/elasticWallVelocityFvPatchVectorField.H
@@ -60,6 +60,12 @@ class elasticWallVelocityFvPatchVectorField
     vectorField oldOldFc_;
 
 
+    // Private member functions
+
+        //- Set Fc_ to the current patch face centres
+        void setCurrentFaceCentres();
+
+
 public:
 
     //- Runtime type information


### PR DESCRIPTION
# Preserve `elasticWallVelocity` restart history

## Pull Request Description

`elasticWallVelocity` uses two face-centre history fields for the backward time
scheme, but currently writes neither field. Reconstructing the boundary from a
checkpoint therefore replaces both histories with the current face centres.

This change writes and restores `oldFaceCentres` and `oldOldFaceCentres` for
unchanged patch topology. Older checkpoints without these entries keep the
existing fallback to the current face centres.

## Related Issues and Discussions

- Closes #363
- Related mapping-state work: #362

## Changes Made

- [x] Bug Fix

### Summary of Changes

- **File modified:** `elasticWallVelocityFvPatchVectorField.C`
- **Patch size:** 15 insertions, 2 deletions
- **Behavioral change:** fixed-topology checkpoints preserve the two
  face-centre histories used by the boundary condition.

## Checklist

- [x] Builds with OpenFOAM v2406.
- [x] Tested with the backward time scheme and unchanged topology.
- [x] Both history fields survive a write/read cycle exactly.
- [x] Older checkpoints without the entries retain the existing fallback.
- [x] `git diff --check` passes.
- [ ] Builds on the remaining supported OpenFOAM and foam-extend variants.
- [ ] GitHub Actions CI passes.

## Test Cases and Results

A focused one-rank fixture advanced the boundary for two steps, wrote a
checkpoint, reconstructed `U`, and advanced once more. The uninterrupted and
restarted boundary conditions then contained byte-identical `oldFaceCentres`
and `oldOldFaceCentres` fields.

A checkpoint without either entry reconstructed successfully and initialized
both histories from the current geometry, preserving the previous behavior.

This test covers the history round-trip fixed here. Other restart-lifecycle
differences can still make the complete wall value and FSI trajectory differ.

## Additional Notes

The two fields already exist in memory, so the change adds no resident state or
solve-loop work. For a 3,072-face wall, the binary `U` checkpoint increased by
147,574 bytes, consistent with two vectors per face plus entry overhead.

The mapped constructor remains unchanged. Mapping and topology-changing
restart require a separately validated policy and are tracked with #362.
