### PR TITLE
Restore predictor velocity on linGeomTotalDispSolid restart

### DIFF
--- a/src/solids4FoamModels/solidModels/linGeomTotalDispSolid/linGeomTotalDispSolid.C
+++ b/src/solids4FoamModels/solidModels/linGeomTotalDispSolid/linGeomTotalDispSolid.C
@@ -642,6 +642,9 @@ linGeomTotalDispSolid::linGeomTotalDispSolid
 
     if (predictor_)
     {
+        // Construct U while the run time still points at the restart directory
+        U();
+
         // Check ddt scheme for D is not steadyState
         const word ddtDScheme
         (


### PR DESCRIPTION
# Restore predictor velocity on `linGeomTotalDispSolid` restart

## Pull Request Description

`linGeomTotalDispSolid` first accesses the demand-driven `U` field from
`predict()`. On restart, this occurs after the run time advances beyond the
selected checkpoint, so `makeU()` cannot find the checkpointed field and
initializes it to zero.

This change constructs `U` during model setup when the predictor is enabled,
while the run time still names the selected checkpoint. Fresh starts without a
`U` file retain the existing zero initialization.

## Related Issues and Discussions

- Closes #365
- Related general FSI restart discussion: #184

## Changes Made

- [x] Bug Fix

### Summary of Changes

- **File modified:** `linGeomTotalDispSolid.C`
- **Patch size:** 3 insertions
- **Behavioral change:** the first restart predictor consumes the selected
  checkpoint's `U` field instead of a zero-valued fallback.

## Checklist

- [x] Builds with OpenFOAM v2406.
- [x] Tested with the stock `solids/elastoplasticity/perforatedPlate` tutorial.
- [x] Restarted predictor `U` matches the uninterrupted run exactly.
- [x] Fresh predictor-enabled output is unchanged.
- [x] Predictor-disabled restart output is unchanged.
- [x] `git diff --check` passes.
- [ ] Builds on the remaining supported OpenFOAM and foam-extend variants.
- [ ] GitHub Actions CI passes.

## Test Cases and Results

The stock `perforatedPlate` tutorial was run uninterrupted from `0` to `0.3`
and restarted in a new process from its `0.2` checkpoint using OpenFOAM v2406
and one rank.

| build | predictor `U` max, uninterrupted | predictor `U` max, restarted |
| --- | ---: | ---: |
| current `development` | `4.776979386202344e-06` | `0` |
| proposed patch | `4.776979386202344e-06` | `4.776979386202344e-06` |

The current restarted first residual was `1.9420075e-02`, compared with
`3.0739019e-07` uninterrupted. Restoring `U` reduced it to `1.0103307e-02` but
did not make the complete solid solve identical. This change is limited to the
predictor velocity defect.

Fresh predictor-enabled `D`, `U`, `pointD`, and `sigma` files were
byte-identical between the current and patched builds. The same fields were
also byte-identical for a predictor-disabled restart.

## Additional Notes

The change moves construction of an existing demand-driven field from the first
prediction to model setup. It adds no field or per-iteration work.
