### PR TITLE
Build AMI correspondence on reference geometry

### DIFF
--- a/src/solids4FoamModels/fluidSolidInterfaces/fluidSolidInterface/interfaceToInterfaceMapping/amiInterfaceToInterfaceMapping/amiInterfaceToInterfaceMapping.C
+++ b/src/solids4FoamModels/fluidSolidInterfaces/fluidSolidInterface/interfaceToInterfaceMapping/amiInterfaceToInterfaceMapping/amiInterfaceToInterfaceMapping.C
@@ -24,6 +24,7 @@ License
 #include "FieldField.H"
 #include "pointIOField.H"
 #include "polyMesh.H"
+#include "Time.H"
 #include "triPointRef.H"
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //

--- a/src/solids4FoamModels/fluidSolidInterfaces/fluidSolidInterface/interfaceToInterfaceMapping/amiInterfaceToInterfaceMapping/amiInterfaceToInterfaceMapping.C
+++ b/src/solids4FoamModels/fluidSolidInterfaces/fluidSolidInterface/interfaceToInterfaceMapping/amiInterfaceToInterfaceMapping/amiInterfaceToInterfaceMapping.C
@@ -22,6 +22,8 @@ License
 #include "amiInterfaceToInterfaceMapping.H"
 #include "addToRunTimeSelectionTable.H"
 #include "FieldField.H"
+#include "pointIOField.H"
+#include "polyMesh.H"
 #include "triPointRef.H"
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
@@ -43,6 +45,81 @@ addToRunTimeSelectionTable
 
 // * * * * * * * * * * * * * Private Member Functions  * * * * * * * * * * * //
 
+autoPtr<standAlonePatch>
+amiInterfaceToInterfaceMapping::makeReferenceZone
+(
+    const globalPolyPatch& globalPatch
+) const
+{
+    const polyMesh& mesh = globalPatch.mesh();
+    const pointIOField referencePoints
+    (
+        IOobject
+        (
+            "points",
+            mesh.time().constant(),
+            polyMesh::meshSubDir,
+            mesh,
+            IOobject::MUST_READ,
+            IOobject::NO_WRITE,
+            false
+        )
+    );
+
+    if (referencePoints.size() != mesh.nPoints())
+    {
+        FatalErrorInFunction
+            << "Reference mesh points do not correspond to the current mesh"
+            << nl
+            << "    reference points : " << referencePoints.size() << nl
+            << "    current points   : " << mesh.nPoints() << nl
+            << "    patch            : " << globalPatch.patchName()
+            << abort(FatalError);
+    }
+
+    const labelList& meshPoints = globalPatch.patch().meshPoints();
+    pointField patchPoints(meshPoints.size());
+
+    forAll(meshPoints, pointI)
+    {
+        patchPoints[pointI] = referencePoints[meshPoints[pointI]];
+    }
+
+    return autoPtr<standAlonePatch>
+    (
+        new standAlonePatch
+        (
+            globalPatch.globalPatch().localFaces(),
+            globalPatch.patchPointToGlobal(patchPoints)()
+        )
+    );
+}
+
+
+const standAlonePatch&
+amiInterfaceToInterfaceMapping::zoneARef() const
+{
+    if (zoneARefPtr_.empty())
+    {
+        zoneARefPtr_ = makeReferenceZone(globalPatchA());
+    }
+
+    return zoneARefPtr_();
+}
+
+
+const standAlonePatch&
+amiInterfaceToInterfaceMapping::zoneBRef() const
+{
+    if (zoneBRefPtr_.empty())
+    {
+        zoneBRefPtr_ = makeReferenceZone(globalPatchB());
+    }
+
+    return zoneBRefPtr_();
+}
+
+
 void amiInterfaceToInterfaceMapping::makeInterpolator() const
 {
     if (interpolatorPtr_.valid())
@@ -60,8 +137,8 @@ void amiInterfaceToInterfaceMapping::makeInterpolator() const
     (
         new amiZoneInterpolation
         (
-            zoneA(),
-            zoneB(),
+            zoneARef(),
+            zoneBRef(),
             faceAreaIntersect::tmMesh, // triMode
             true,   // requireMatch
             //amiZoneInterpolation::imFaceAreaWeight, // interpolationMethodNames
@@ -143,7 +220,7 @@ void amiInterfaceToInterfaceMapping::calcZoneAPointAddressing() const
     zoneAPointAddressingPtr_ =
         new List<labelPair>
         (
-            zoneA().nPoints(), labelPair(-1,-1)
+            zoneARef().nPoints(), labelPair(-1,-1)
         );
     List<labelPair>& zoneAPointAddr = *zoneAPointAddressingPtr_;
 
@@ -155,10 +232,10 @@ void amiInterfaceToInterfaceMapping::calcZoneAPointAddressing() const
     // scalarField& zoneAPointDist = *zoneAPointDistancePtr_;
 
     const labelListList& zoneAFaceAddr = interpolator().srcAddress();
-    const labelListList& pointFaces = zoneA().pointFaces();
-    const faceList& zoneBFaces = zoneB().localFaces();
-    const pointField& zoneBPoints = zoneB().localPoints();
-    const pointField& zoneAPoints = zoneA().localPoints();
+    const labelListList& pointFaces = zoneARef().pointFaces();
+    const faceList& zoneBFaces = zoneBRef().localFaces();
+    const pointField& zoneBPoints = zoneBRef().localPoints();
+    const pointField& zoneAPoints = zoneARef().localPoints();
 
     forAll(zoneAPointAddr, pointI)
     {
@@ -242,9 +319,9 @@ void amiInterfaceToInterfaceMapping::calcZoneAPointAddressing() const
 
     // Check orientation
 
-    const pointField& zoneAPointNormals = zoneA().pointNormals();
+    const pointField& zoneAPointNormals = zoneARef().pointNormals();
 
-    const vectorField& zoneBFaceNormals = zoneB().faceNormals();
+    const vectorField& zoneBFaceNormals = zoneBRef().faceNormals();
 
     scalarField orientation(zoneAPointAddr.size(), 0);
 
@@ -285,12 +362,12 @@ void amiInterfaceToInterfaceMapping::calcZoneAPointWeights() const
     //     new FieldField<Field, scalar>(zoneA().nPoints());
     // FieldField<Field, scalar>& zoneAPointWeights = *zoneAPointWeightsPtr_;
     zoneAPointWeightsPtr_ =
-        new FieldField<Field, scalar>(zoneA().nPoints());
+        new FieldField<Field, scalar>(zoneARef().nPoints());
     FieldField<Field, scalar>& zoneAPointWeights = *zoneAPointWeightsPtr_;
 
-    const faceList& zoneBFaces = zoneB().localFaces();
-    const pointField& zoneBPoints = zoneB().localPoints();
-    const pointField& zoneAPoints = zoneA().localPoints();
+    const faceList& zoneBFaces = zoneBRef().localFaces();
+    const pointField& zoneBPoints = zoneBRef().localPoints();
+    const pointField& zoneAPoints = zoneARef().localPoints();
 
     const List<labelPair>& addr = this->zoneAPointAddr();
 
@@ -346,7 +423,7 @@ void amiInterfaceToInterfaceMapping::calcZoneBPointAddressing() const
     zoneBPointAddressingPtr_ =
         new List<labelPair>
         (
-            zoneB().nPoints(), labelPair(-1,-1)
+            zoneBRef().nPoints(), labelPair(-1,-1)
         );
     List<labelPair>& zoneBPointAddr = *zoneBPointAddressingPtr_;
 
@@ -358,10 +435,10 @@ void amiInterfaceToInterfaceMapping::calcZoneBPointAddressing() const
     // scalarField& zoneBPointDist = *zoneBPointDistancePtr_;
 
     const labelListList& zoneBFaceAddr = interpolator().tgtAddress();
-    const labelListList& pointFaces = zoneB().pointFaces();
-    const faceList& zoneAFaces = zoneA().localFaces();
-    const pointField& zoneAPoints = zoneA().localPoints();
-    const pointField& zoneBPoints = zoneB().localPoints();
+    const labelListList& pointFaces = zoneBRef().pointFaces();
+    const faceList& zoneAFaces = zoneARef().localFaces();
+    const pointField& zoneAPoints = zoneARef().localPoints();
+    const pointField& zoneBPoints = zoneBRef().localPoints();
 
     forAll(zoneBPointAddr, pointI)
     {
@@ -445,9 +522,9 @@ void amiInterfaceToInterfaceMapping::calcZoneBPointAddressing() const
 
     // Check orientation
 
-    const pointField& zoneBPointNormals = zoneB().pointNormals();
+    const pointField& zoneBPointNormals = zoneBRef().pointNormals();
 
-    const vectorField& zoneAFaceNormals = zoneA().faceNormals();
+    const vectorField& zoneAFaceNormals = zoneARef().faceNormals();
 
     scalarField orientation(zoneBPointAddr.size(), 0);
 
@@ -488,12 +565,12 @@ void amiInterfaceToInterfaceMapping::calcZoneBPointWeights() const
     //     new FieldField<Field, scalar>(zoneB().nPoints());
     // FieldField<Field, scalar>& zoneBPointWeights = *zoneBPointWeightsPtr_;
     zoneBPointWeightsPtr_ =
-        new FieldField<Field, scalar>(zoneB().nPoints());
+        new FieldField<Field, scalar>(zoneBRef().nPoints());
     FieldField<Field, scalar>& zoneBPointWeights = *zoneBPointWeightsPtr_;
 
-    const faceList& zoneAFaces = zoneA().localFaces();
-    const pointField& zoneAPoints = zoneA().localPoints();
-    const pointField& zoneBPoints = zoneB().localPoints();
+    const faceList& zoneAFaces = zoneARef().localFaces();
+    const pointField& zoneAPoints = zoneARef().localPoints();
+    const pointField& zoneBPoints = zoneBRef().localPoints();
     const List<labelPair>& addr = this->zoneBPointAddr();
 
     forAll(zoneBPointWeights, pointI)
@@ -599,6 +676,8 @@ amiInterfaceToInterfaceMapping::amiInterfaceToInterfaceMapping
     (
         type, dict, patchA, patchB, globalPatchA, globalPatchB
     ),
+    zoneARefPtr_(),
+    zoneBRefPtr_(),
     interpolatorPtr_(nullptr),
     zoneAPointAddressingPtr_(nullptr),
     zoneAPointWeightsPtr_(nullptr),

--- a/src/solids4FoamModels/fluidSolidInterfaces/fluidSolidInterface/interfaceToInterfaceMapping/amiInterfaceToInterfaceMapping/amiInterfaceToInterfaceMapping.H
+++ b/src/solids4FoamModels/fluidSolidInterfaces/fluidSolidInterface/interfaceToInterfaceMapping/amiInterfaceToInterfaceMapping/amiInterfaceToInterfaceMapping.H
@@ -56,6 +56,10 @@ class amiInterfaceToInterfaceMapping
 {
     // Private data
 
+            //- Reference-configuration copies used to construct the mapping
+            mutable autoPtr<standAlonePatch> zoneARefPtr_;
+            mutable autoPtr<standAlonePatch> zoneBRefPtr_;
+
             //- AMI interpolator between two standAlone patches
             mutable autoPtr<amiZoneInterpolation> interpolatorPtr_;
 
@@ -72,6 +76,18 @@ class amiInterfaceToInterfaceMapping
             mutable FieldField<Field, scalar>* zoneBPointWeightsPtr_;
 
     // Private Member Functions
+
+        //- Build a zone from the constant mesh points
+        autoPtr<standAlonePatch> makeReferenceZone
+        (
+            const globalPolyPatch& globalPatch
+        ) const;
+
+        //- Return zoneA in the reference configuration
+        const standAlonePatch& zoneARef() const;
+
+        //- Return zoneB in the reference configuration
+        const standAlonePatch& zoneBRef() const;
 
         //- Make the AMI interpolator
         void makeInterpolator() const;


### PR DESCRIPTION
# Build AMI correspondence on reference geometry

## Pull Request Description

AMI correspondence is currently built from whichever configurations the two
meshes hold when the mapping is first used. After restart, a moving fluid mesh
can be deformed while a total-Lagrangian solid mesh remains in its reference
configuration.

This change constructs AMI face interpolation, point addressing, and point
weights from reference-configuration copies of both interface zones.

## Related Issues and Discussions

- Closes #367
- Related to #184

## Changes Made

- [x] Bug Fix

### Summary of Changes

- **Files modified:** `amiInterfaceToInterfaceMapping.H` and
  `amiInterfaceToInterfaceMapping.C`
- **Patch size:** 119 insertions and 24 deletions
- **Behavioral change:** for unchanged topology, AMI material correspondence
  no longer depends on the solver process start time

The reference zones are private to the AMI implementation and use
`constant/<region>/polyMesh/points`. The base mapping API and direct, GGI, and
RBF implementations are unchanged. Reference points are read with `MUST_READ`.
A point-count mismatch stops with `FatalErrorInFunction` instead of silently
constructing the known-wrong current-geometry mapping.

## Checklist

- [x] Builds with OpenFOAM v2512.
- [x] Builds on the remaining supported OpenFOAM variants.
- [x] Time-zero mapping is unchanged.
- [x] Restart-time production mapping matches the explicit reference mapping.
- [x] The focused reproducer is attached to the issue.
- [x] `git diff --check` passes.
- [x] GitHub Actions CI passes.

## Test Cases and Results

`interfaceMappingDiff` builds a current-geometry and a reference-geometry AMI
from the same checkpoint and transfers the same material-coordinate field
through both.

| start time | motion / face width | transfer difference / face width |
| --- | ---: | ---: |
| `0` | `0` | `0` |
| `0.01` | `0.252` | `0.116` |

The diagnostic result establishes the defect and the expected mapping. The
refactored two-file PR head still requires the checked build and runtime
comparisons above before submission.

## Additional Notes

This change fixes material correspondence only. Synchronizing the separate
current-geometry `globalPolyPatch` cache after fluid mesh motion is tracked in
a separate issue.

Topology-changing restart is outside this change. A topology mismatch fails
explicitly because the constant-mesh point indices no longer identify the
current topology.
