### PR TITLE
Persist non-zero mechanicalLaw::sigma0 for restart

### DIFF
--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/mechanicalLaw/mechanicalLaw.C
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/mechanicalLaw/mechanicalLaw.C
@@ -160,6 +160,8 @@ void Foam::mechanicalLaw::makeSigma0() const
             << "pointer already set" << abort(FatalError);
     }
 
+    bool mappedFromBaseMesh = false;
+
     // Check if a single
     if
     (
@@ -218,6 +220,8 @@ void Foam::mechanicalLaw::makeSigma0() const
     }
     else
     {
+        mappedFromBaseMesh = true;
+
         // Read sigma0 from the baseMesh
         const volSymmTensorField sigma0BaseMesh
         (
@@ -247,6 +251,16 @@ void Foam::mechanicalLaw::makeSigma0() const
                 )()
             )
         );
+    }
+
+    if
+    (
+        !mappedFromBaseMesh
+     && lookupSolidModel(mesh(), baseMeshRegionName_).restart()
+     && gMax(mag(sigma0Ptr_())()) > SMALL
+    )
+    {
+        sigma0Ptr_->writeOpt() = IOobject::AUTO_WRITE;
     }
 }
 


### PR DESCRIPTION
## Pull Request Description

`mechanicalLaw::sigma0` is read from the selected start time but never written
to later checkpoints. A single-material solid restarted from such a checkpoint
therefore uses the zero fallback instead of its initial stress.

This change selects `AUTO_WRITE` when `makeSigma0()` directly constructs a
non-zero field for a solid model with `restart yes`.

## Related Issues and Discussions

- Closes #372
- Related to #68 and #184

## Changes Made

- [x] Bug Fix

### Summary of Changes

- **File modified:** `mechanicalLaw.C`
- **Patch size:** 14 insertions
- **Behavioral change:** with `restart yes`, a non-zero single-material
  `sigma0` is written to later checkpoints. Zero initial stress and cases
  without `restart` retain the existing output set.

## Checklist

- [x] Builds with OpenFOAM v2512.
- [x] Stock `patchTest` sigma0 round-trip passes.
- [x] A checkpoint without `restart yes` retains the previous output set.
- [x] A `restart yes` case with zero sigma0 retains the previous output set.
- [x] Multi-material sigma0 mapping is explicitly excluded.
- [x] `git diff --check` passes.
- [x] Builds on the remaining supported OpenFOAM and foam-extend variants.
- [x] GitHub Actions CI passes.

## Test Cases and Results

The stock `solids/linearElasticity/patchTest` tutorial provides the
single-material linear-geometry check described in the related issue. Its
calculated `sigma` field is reused as a non-zero `0/sigma0` input.

The clean build and four test arms produced:

| build and case | written `1/sigma0` |
| --- | --- |
| current `development`, non-zero `sigma0`, `restart yes` | absent |
| candidate, non-zero `sigma0`, `restart yes` | present |
| candidate, non-zero `sigma0`, restart disabled | absent |
| candidate, zero `sigma0`, `restart yes` | absent |

The positive candidate arm also reports `Reading sigma0 stress field`,
confirming that the written field came from the supplied initial stress.

## Additional Notes

The multi-material branch maps `sigma0` from a temporary field on the base mesh;
persisting that state requires a separate design and is unchanged here.

`sigma0f` remains derived from `sigma0`. The change adds one magnitude reduction
when a directly constructed `sigma0` is created with restart output enabled. A
non-zero initial stress adds six scalars per cell to each checkpoint,
approximately 48 bytes per cell in double-precision binary output before
headers and compression.
