### PR TITLE
Map wall pressure history fields

### DIFF
--- a/src/solids4FoamModels/fluidModels/fvPatchFields/elasticWallPressure/elasticWallPressureFvPatchScalarField.C
+++ b/src/solids4FoamModels/fluidModels/fvPatchFields/elasticWallPressure/elasticWallPressureFvPatchScalarField.C
@@ -169,8 +169,13 @@ elasticWallPressureFvPatchScalarField::elasticWallPressureFvPatchScalarField
 )
 :
     robinFvPatchScalarField(ptf, p, iF, mapper),
-    prevPressure_(p.patch().size(), 0),
-    prevAcceleration_(p.patch().size(), vector::zero),
+#ifdef OPENFOAM_ORG
+    prevPressure_(mapper(ptf.prevPressure_)),
+    prevAcceleration_(mapper(ptf.prevAcceleration_)),
+#else
+    prevPressure_(ptf.prevPressure_, mapper),
+    prevAcceleration_(ptf.prevAcceleration_, mapper),
+#endif
     rhoSolidHsPtr_(),
     constantHs_(ptf.constantHs_)
 {}
@@ -249,7 +254,17 @@ void elasticWallPressureFvPatchScalarField::autoMap
     const fvPatchFieldMapper& m
 )
 {
-    fvPatchField<scalar>::autoMap(m);
+    robinFvPatchScalarField::autoMap(m);
+
+#ifdef OPENFOAM_ORG
+    m(prevPressure_, prevPressure_);
+    m(prevAcceleration_, prevAcceleration_);
+#else
+    prevPressure_.autoMap(m);
+    prevAcceleration_.autoMap(m);
+#endif
+
+    rhoSolidHsPtr_.clear();
 }
 
 
@@ -259,7 +274,15 @@ void elasticWallPressureFvPatchScalarField::rmap
     const labelList& addr
 )
 {
-    fvPatchField<scalar>::rmap(ptf, addr);
+    robinFvPatchScalarField::rmap(ptf, addr);
+
+    const elasticWallPressureFvPatchScalarField& mptf =
+        refCast<const elasticWallPressureFvPatchScalarField>(ptf);
+
+    prevPressure_.rmap(mptf.prevPressure_, addr);
+    prevAcceleration_.rmap(mptf.prevAcceleration_, addr);
+
+    rhoSolidHsPtr_.clear();
 }
 
 void elasticWallPressureFvPatchScalarField::updateCoeffs()

--- a/src/solids4FoamModels/fluidModels/fvPatchFields/movingWallPressure/movingWallPressureFvPatchScalarField.C
+++ b/src/solids4FoamModels/fluidModels/fvPatchFields/movingWallPressure/movingWallPressureFvPatchScalarField.C
@@ -103,6 +103,7 @@ movingWallPressureFvPatchScalarField
 
 // * * * * * * * * * * * * * * * Member Functions  * * * * * * * * * * * * * //
 
+
 void movingWallPressureFvPatchScalarField::autoMap
 (
     const fvPatchFieldMapper& m

--- a/src/solids4FoamModels/fluidModels/fvPatchFields/movingWallPressure/movingWallPressureFvPatchScalarField.C
+++ b/src/solids4FoamModels/fluidModels/fvPatchFields/movingWallPressure/movingWallPressureFvPatchScalarField.C
@@ -68,7 +68,11 @@ movingWallPressureFvPatchScalarField
 )
 :
     fixedGradientFvPatchScalarField(ptf, p, iF, mapper),
-    prevAcceleration_(p.patch().size(), vector::zero)
+#ifdef OPENFOAM_ORG
+    prevAcceleration_(mapper(ptf.prevAcceleration_))
+#else
+    prevAcceleration_(ptf.prevAcceleration_, mapper)
+#endif
 {}
 
 
@@ -98,6 +102,35 @@ movingWallPressureFvPatchScalarField
 
 
 // * * * * * * * * * * * * * * * Member Functions  * * * * * * * * * * * * * //
+
+void movingWallPressureFvPatchScalarField::autoMap
+(
+    const fvPatchFieldMapper& m
+)
+{
+    fixedGradientFvPatchScalarField::autoMap(m);
+
+#ifdef OPENFOAM_ORG
+    m(prevAcceleration_, prevAcceleration_);
+#else
+    prevAcceleration_.autoMap(m);
+#endif
+}
+
+
+void movingWallPressureFvPatchScalarField::rmap
+(
+    const fvPatchField<scalar>& ptf,
+    const labelList& addr
+)
+{
+    fixedGradientFvPatchScalarField::rmap(ptf, addr);
+
+    const movingWallPressureFvPatchScalarField& mptf =
+        refCast<const movingWallPressureFvPatchScalarField>(ptf);
+
+    prevAcceleration_.rmap(mptf.prevAcceleration_, addr);
+}
 
 
 // void movingWallPressureFvPatchScalarField::evaluate(const Pstream::commsTypes)

--- a/src/solids4FoamModels/fluidModels/fvPatchFields/movingWallPressure/movingWallPressureFvPatchScalarField.H
+++ b/src/solids4FoamModels/fluidModels/fvPatchFields/movingWallPressure/movingWallPressureFvPatchScalarField.H
@@ -139,6 +139,21 @@ public:
             return prevAcceleration_;
         }
 
+        // Mapping functions
+
+            //- Map (and resize as needed) from self given a mapping object
+            virtual void autoMap
+            (
+                const fvPatchFieldMapper&
+            );
+
+            //- Reverse map the given fvPatchField onto this fvPatchField
+            virtual void rmap
+            (
+                const fvPatchField<scalar>&,
+                const labelList&
+            );
+
 //         //- Evaluate the patch field
 //         virtual void evaluate
 //         (


### PR DESCRIPTION
# Map wall pressure history fields

## Pull Request Description

`elasticWallPressure` and `movingWallPressure` currently reset their history
fields when OpenFOAM maps a patch field. The `elasticWallPressure` mapping
overrides also bypass the Robin coefficients owned by their immediate base.

This change maps the boundary-condition histories in the mapper constructor,
`autoMap()`, and `rmap()`. `elasticWallPressure` now calls
`robinFvPatchScalarField` so its coefficients follow the same addressing, and
clears the patch-dependent `rhoSolidHs` cache after mapping.

## Related Issues and Discussions

- Closes #362
- Related restart discussion: #184
- Other boundary conditions with similar history state: #369

## Changes Made

- [x] Bug Fix

### Summary of Changes

- **Files modified:** `elasticWallPressureFvPatchScalarField.C`,
  `movingWallPressureFvPatchScalarField.C`, and
  `movingWallPressureFvPatchScalarField.H`
- **Patch size:** 76 insertions, 5 deletions
- **Behavioral change:** mapped wall-pressure fields retain their history and
  Robin coefficient state; derived wall properties are rebuilt for the mapped
  patch.

The implementation follows the existing `normalDisplacement` mapping pattern,
including the OpenFOAM.org-specific mapper calls.

## Checklist

- [x] Full models library builds with OpenFOAM v2406.
- [x] Mapper constructors preserve all affected history fields.
- [x] `autoMap()` and `rmap()` preserve the histories and Robin coefficients.
- [x] Patch-dependent `rhoSolidHs` data are invalidated after mapping.
- [x] The unmodified `development` control reproduces the dropped state.
- [x] `git diff --check` passes.
- [ ] Builds on the remaining supported OpenFOAM and foam-extend variants.
- [ ] GitHub Actions CI passes.

## Test Cases and Results

A focused utility assigns non-uniform history and coefficient fields on the
stock `3dTube` fluid wall, applies a reversed face mapping through each API,
and compares the result with the expected addressing.

| tested state | current `development`, maximum difference | proposed fix |
| --- | ---: | ---: |
| `elasticWallPressure` histories, all mapping paths | `5797` | `0` |
| `elasticWallPressure` Robin coefficients, `autoMap` and `rmap` | `21589` | `0` |
| `movingWallPressure` history, all mapping paths | `5986.92` | `0` |

The values are differences in synthetic non-uniform fields, not physical
errors. The utility exits non-zero for the control and zero with this change.

## Additional Notes

This changes mapping only. It adds no stored fields or per-iteration work; the
wall-property cache is rebuilt once after a map. It does not claim complete
restart invariance. The focused diagnostic is not included in this pull
request.

Edit: added `wallHistoryMappingDiff` reproducibility test harness
[wall_pressure_history_mapping_reproducer.zip](https://github.com/user-attachments/files/30918137/wall_pressure_history_mapping_reproducer.zip)
