### PR TITLE
CI: stabilise PETSc tests on Granite Rapids runners

### DIFF
--- a/.github/workflows/buildAndRegressionTest.yml
+++ b/.github/workflows/buildAndRegressionTest.yml
@@ -10,6 +10,7 @@ jobs:
     name: Build and regression test on ${{ matrix.container-image.name }}
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
         container-image:
           - name: "OpenFOAM-v2512-PETSc"
@@ -52,6 +53,8 @@ jobs:
         shell: bash -l {0}
         run: |
           source ${{ matrix.container-image.source }}
+          export OPENBLAS_CORETYPE=Haswell
+          echo "OPENBLAS_CORETYPE = $OPENBLAS_CORETYPE"
           export OMP_NUM_THREADS=1
           export OPENBLAS_NUM_THREADS=1
           export MKL_NUM_THREADS=1

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -14,6 +14,7 @@ jobs:
     name: Build on ${{ matrix.container-image.name }}
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
         container-image:
           # --------------------------------------------------
@@ -116,12 +117,21 @@ jobs:
           echo "PETSC_DIR = $PETSC_DIR"
           test -d "$PETSC_DIR/include"
 
+      - name: Pin OpenBLAS core type
+        if: contains(matrix.container-image.name, 'PETSc')
+        run: |
+          echo "OPENBLAS_CORETYPE=Haswell" >> "$GITHUB_ENV"
+          echo "OPENBLAS_CORETYPE = Haswell"
+
       - name: Alltest
         shell: bash -l {0}
         run: |
           source ${{ matrix.container-image.source }}
           cd tutorials
-          export OMP_NUM_THREADS=1; export OPENBLAS_NUM_THREADS=1; export MKL_NUM_THREADS=1; ./Alltest
+          export OMP_NUM_THREADS=1
+          export OPENBLAS_NUM_THREADS=1
+          export MKL_NUM_THREADS=1
+          ./Alltest
 
       - name: Upload test logs
         if: ${{ failure() }}


### PR DESCRIPTION
## Summary

Pin OpenBLAS to its Haswell kernel for PETSc CI jobs and allow every matrix entry to finish when one job fails.

## Root cause

The intermittent `cantilever2d` and `narrowTmember` failures tracked in #352 correlate with Intel Xeon 6973P-C (Granite Rapids) runners. The affected PETSc images use an older OpenBLAS whose runtime CPU dispatch predates Granite Rapids support.

## Changes

- Set `OPENBLAS_CORETYPE=Haswell` only for PETSc jobs in the main build-and-test workflow.
- Set the same override in the PETSc regression workflow.
- Log the selected override.
- Disable matrix fail-fast in both workflows so one failure does not cancel unrelated jobs.

No tutorial tolerances, PETSc solver settings, C++ code, or Docker images are changed.

## Verification

- `git diff --check`
- Both edited workflows pass `actionlint` after excluding the pre-existing `SC2002` warning in the runner-hardware step.
- The exact OpenFOAM-v2412 PETSc image reports `Haswell` from `openblas_get_corename()` when the override is set.

## CI validation

Keep this PR in draft until repeated runs demonstrate that the affected PETSc jobs pass on Intel Xeon 6973P-C runners. Results should be recorded in #352.
