### PR TITLE
Fix mechanical law geometry diagnostics

### DIFF
--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/mechanicalLaw/newMechanicalLaw.C
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/mechanicalLaw/newMechanicalLaw.C
@@ -55,7 +55,7 @@ autoPtr<mechanicalLaw> mechanicalLaw::NewLinGeomMechLaw
         {
             FatalIOErrorInFunction(dict)
                 << "The mechanicalLaw " << modelType
-                << " can only be used with a linear geometry solid model"
+                << " can only be used with a non-linear geometry solid model"
                 << endl << endl
                 << "Valid linearGeometry mechanicalLaws are : " << endl
                 << linGeomMechLawConstructorTablePtr_->sortedToc()
@@ -144,14 +144,14 @@ autoPtr<mechanicalLaw> mechanicalLaw::NewNonLinGeomMechLaw
 
     if (!ctorPtr)
     {
-        // Check if the user inadvertently specified a nonlinear law
+        // Check if the user inadvertently specified a linear law
         auto* ctorPtrOther = linGeomMechLawConstructorTable(modelType);
 
         if (ctorPtrOther)
         {
             FatalIOErrorInFunction(dict)
                 << "The mechanicalLaw " << modelType
-                << " can only be used with a non-linear geometry solid model"
+                << " can only be used with a linear geometry solid model"
                 << endl << endl
                 << "Valid nonLinearGeometry mechanicalLaws are : " << endl
                 << nonLinGeomMechLawConstructorTablePtr_->sortedToc()
@@ -177,7 +177,7 @@ autoPtr<mechanicalLaw> mechanicalLaw::NewNonLinGeomMechLaw
 
     if (cstrIter == nonLinGeomMechLawConstructorTablePtr_->end())
     {
-        // Check if the user inadvertently specified a nonlinear law
+        // Check if the user inadvertently specified a linear law
         linGeomMechLawConstructorTable::iterator lgLawIter =
             linGeomMechLawConstructorTablePtr_->find(modelType);
 


### PR DESCRIPTION
## Summary

  Fix misleading error messages in `newMechanicalLaw.C` when a mechanical law is
  selected with an incompatible geometry formulation.

  The diagnostics now correctly report:

  - nonlinear mechanical laws as requiring a non-linear geometry solid model;
  - linear mechanical laws as requiring a linear geometry solid model.

  The corresponding runtime-selection comments were also corrected.

  ## Testing

  Not run, as this change only updates diagnostic strings and comments and does
  not affect runtime behaviour.
