### PR TITLE
Fix electroMechanicalLaw deformation gradient

### DIFF
--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/mechanicalLaw/mechanicalLaw.C
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/mechanicalLaw/mechanicalLaw.C
@@ -964,11 +964,35 @@ Foam::volTensorField& Foam::mechanicalLaw::F()
 }
 
 
+const Foam::volTensorField& Foam::mechanicalLaw::F() const
+{
+    if (FPtr_.empty())
+    {
+        FatalErrorIn("const volTensorField& " + type() + "::F() const")
+            << "F is not stored by this mechanical law" << abort(FatalError);
+    }
+
+    return FPtr_();
+}
+
+
 Foam::surfaceTensorField& Foam::mechanicalLaw::Ff()
 {
     if (FfPtr_.empty())
     {
         makeFf();
+    }
+
+    return FfPtr_();
+}
+
+
+const Foam::surfaceTensorField& Foam::mechanicalLaw::Ff() const
+{
+    if (FfPtr_.empty())
+    {
+        FatalErrorIn("const surfaceTensorField& " + type() + "::Ff() const")
+            << "Ff is not stored by this mechanical law" << abort(FatalError);
     }
 
     return FfPtr_();

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/mechanicalLaw/mechanicalLaw.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/mechanicalLaw/mechanicalLaw.H
@@ -484,6 +484,12 @@ public:
 
     // Member Functions
 
+        //- Return the total deformation gradient stored by this law
+        const volTensorField& F() const;
+
+        //- Return the total face deformation gradient stored by this law
+        const surfaceTensorField& Ff() const;
+
         //- Return name
         const word& name() const
         {

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/electroMechanicalLaw/electroMechanicalLaw.C
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/electroMechanicalLaw/electroMechanicalLaw.C
@@ -150,8 +150,9 @@ void Foam::electroMechanicalLaw::correct(volSymmTensorField& sigma)
     // Calculate passive stress
     passiveMechLawPtr_->correct(sigma);
 
-    // Take a reference to the deformation gradient
-    const volTensorField& F = this->F();
+    // Take a reference to the deformation gradient maintained by the passive law
+    const mechanicalLaw& passiveLaw = passiveMechLawPtr_();
+    const volTensorField& F = passiveLaw.F();
 
     // Calculate the Jacobian of the deformation gradient
     const volScalarField J(det(F));
@@ -203,8 +204,10 @@ void Foam::electroMechanicalLaw::correct(surfaceSymmTensorField& sigma)
     // Calculate passive stress
     passiveMechLawPtr_->correct(sigma);
 
-    // Take a reference to the deformation gradient
-    const surfaceTensorField& F = this->Ff();
+    // Take a reference to the face deformation gradient maintained by the
+    // passive law
+    const mechanicalLaw& passiveLaw = passiveMechLawPtr_();
+    const surfaceTensorField& F = passiveLaw.Ff();
 
     // Calculate the Jacobian of the deformation gradient
     const surfaceScalarField J(det(F));

--- a/tutorials/fluidSolidInteraction/cerebralAneurysm/README.md
+++ b/tutorials/fluidSolidInteraction/cerebralAneurysm/README.md
@@ -1,6 +1,6 @@
-----
+---
 sort: 9
-----
+---
 
 # Cerebral aneurysm fluid-solid interaction: `cerebralAneurysm`
 


### PR DESCRIPTION
## Summary

- read the deformation gradient maintained and updated by the passive mechanical law when computing active stress
- add const, fail-fast `mechanicalLaw::F()` and `Ff()` accessors for this read-only access
- apply the same ownership correction to both volume and face stress calculations
- correct the cerebral-aneurysm tutorial YAML front-matter delimiters so MarkdownLint passes

`electroMechanicalLaw` previously read its own lazily-created deformation-gradient fields after correcting the passive law. Those fields are not updated by the wrapper, so active stress could be evaluated with an identity/stale gradient.

## Validation

- `git diff --check`
- `npx markdownlint-cli2@0.15.0 tutorials/fluidSolidInteraction/cerebralAneurysm/README.md` (0 errors)
- GitHub Actions build and regression jobs rerun after the push.