### PR TITLE
Do not write meshPhi for a non-moving solid mesh (#184)

### DIFF
--- a/src/solids4FoamModels/solidModels/solidModel/solidModel.C
+++ b/src/solids4FoamModels/solidModels/solidModel/solidModel.C
@@ -1172,6 +1172,17 @@ Foam::solidModel::solidModel
     fvOptions_(fv::options::New(*meshPtr_))
 #endif
 {
+    // As far as the finite volume discretisation is concerned, the solid mesh
+    // is not a "moving mesh": the solid models which do update the mesh, e.g.
+    // the updated Lagrangian ones, explicitly clear the moving flag after each
+    // mesh motion, as the mesh motion is not a flow of material through the
+    // faces.
+    // On a restart, however, the fvMesh constructor marks the mesh as moving if
+    // it finds a 'meshPhi' or 'V0' field in the start time directory, and then,
+    // for example, backwardD2dt2Scheme stops with a "not implemented for a
+    // moving mesh" error (issue #184). So the flag is cleared here
+    mesh().moving(false);
+
     // Set the useBoundaryFaceValues fields
     forAll(useBoundaryFaceValuesD_, patchI)
     {
@@ -1545,97 +1556,53 @@ void Foam::solidModel::makeGlobalPatches
                 << abort(FatalError);
         }
 
+        // Lookup patch index
+        if (mesh().boundaryMesh().findPatchID(patchNames[i]) == -1)
+        {
+            FatalErrorIn("void Foam::solidModel::makeGlobalPatches(...)")
+                << "Patch " << patchNames[i] << " not found!"
+                << abort(FatalError);
+        }
+
+        // Create the global patch based on the undeformed mesh
+        globalPatchesPtrList_.set
+        (
+            i,
+            new globalPolyPatch(patchNames[i], mesh())
+        );
+
         if (currentConfiguration)
         {
-            // The global patch will create a standAlone zone based on the
-            // current point positions. So we will temporarily move the mesh to
-            // the deformed position, then create the globalPatch, then move the
-            // mesh back
-            const pointField pointsBackup = mesh().points();
-
-            // Lookup patch index
-            const label patchID =
-                mesh().boundaryMesh().findPatchID(patchNames[i]);
-            if (patchID == -1)
-            {
-                FatalErrorIn("void Foam::solidModel::makeGlobalPatches(...)")
-                    << "Patch not found!" << abort(FatalError);
-            }
-
-            // Patch point displacement
-            const vectorField pointDisplacement
-            (
-                pointDorPointDD().internalField(),
-                mesh().boundaryMesh()[patchID].meshPoints()
-            );
-
-            // Calculate deformation point positions
-            const pointField newPoints
-            (
-                mesh().points() + pointDorPointDD().internalField()
-            );
-
-            // Move the mesh to deformed position
-            // const_cast is justified as it is not our intention to permanently
-            // move the mesh; however, it would be better if we did not need it
-            mesh().V();
-            const_cast<dynamicFvMesh&>(mesh()).movePoints(newPoints);
-            const_cast<dynamicFvMesh&>(mesh()).moving(false);
-#ifdef FOAMEXTEND
-            const_cast<dynamicFvMesh&>(mesh()).changing(false);
-#endif
-
-#if (OPENFOAM >= 2206)
-            {
-                auto tmeshPhi(const_cast<dynamicFvMesh&>(mesh()).setPhi());
-                if (tmeshPhi)
-                {
-                    tmeshPhi.ref().writeOpt(IOobject::NO_WRITE);
-                }
-            }
-#else
-            const_cast<dynamicFvMesh&>(mesh()).setPhi().writeOpt() =
-                IOobject::NO_WRITE;
-#endif
-
-            // Create global patch based on deformed mesh
-            globalPatchesPtrList_.set
-            (
-                i,
-                new globalPolyPatch(patchNames[i], mesh())
-            );
-
-            // Force creation of standAlonePatch
+            // Force creation of standAlonePatch, so that its points can be set
+            // to the current configuration by syncGlobalPatches() below
             globalPatchesPtrList_[i].globalPatch();
+        }
+    }
 
-            // Move the mesh back
-            const_cast<dynamicFvMesh&>(mesh()).movePoints(pointsBackup);
-            mesh().V();
-            const_cast<dynamicFvMesh&>(mesh()).moving(false);
-#ifdef FOAMEXTEND
-            const_cast<dynamicFvMesh&>(mesh()).changing(false);
-#endif
-#if (OPENFOAM >= 2206)
-            {
-                auto tmeshPhi(const_cast<dynamicFvMesh&>(mesh()).setPhi());
-                if (tmeshPhi)
-                {
-                    tmeshPhi.ref().writeOpt(IOobject::NO_WRITE);
-                }
-            }
-#else
-            const_cast<dynamicFvMesh&>(mesh()).setPhi().writeOpt() =
-                IOobject::NO_WRITE;
-#endif
-        }
-        else
-        {
-            globalPatchesPtrList_.set
-            (
-                i,
-                new globalPolyPatch(patchNames[i], mesh())
-            );
-        }
+    if (currentConfiguration)
+    {
+        // The global patches are required in the current (deformed)
+        // configuration, so displace their points by pointD/pointDD
+        // Note: the global patches are always constructed on the undeformed
+        // mesh above and then moved here; previously, the mesh itself was
+        // temporarily moved to the deformed configuration while the global
+        // patches were constructed, and then moved back. That approach had two
+        // undesirable side-effects (issue #184):
+        //   - fvMesh::movePoints() creates the mesh motion flux field (meshPhi)
+        //     and marks the mesh points as AUTO_WRITE; consequently, meshPhi
+        //     and polyMesh/points were written to every time directory, even
+        //     though the solid mesh is not moved for linear geometry and total
+        //     Lagrangian approaches. On restart, the presence of meshPhi makes
+        //     OpenFOAM consider the solid mesh to be moving, e.g. causing
+        //     backwardD2dt2Scheme to stop with a "not implemented for a moving
+        //     mesh" error, and the reduced-precision points written to the time
+        //     directory can break the processor patch face matching checks in
+        //     parallel.
+        //   - globalPolyPatch merges coincident points across processor
+        //     boundaries using exact point coordinate comparisons; the
+        //     undeformed point coordinates are bit-identical on either side of
+        //     a processor boundary, whereas the deformed ones need not be.
+        syncGlobalPatches();
     }
 }
 


### PR DESCRIPTION
Fixes #184.

## Problem

Every FSI case writes `<time>/solid/meshPhi` and `<time>/solid/polyMesh/points`, even for linear geometry and total Lagrangian solid models, which never move the solid mesh. This breaks restarts in three different ways:

- the `fvMesh` constructor detects `meshPhi` in the start time directory and calls `moving(true)`, so `backwardD2dt2Scheme` stops with `not implemented for a moving mesh`;
- `decomposePar` cannot decompose the reconstructed solid `meshPhi`, as it has no processor boundary patch entries: `Cannot find patchField entry for procBoundary0to3`;
- the reduced-precision points written to the time directory (`writeFormat ascii`, `writePrecision 6`) can break the `processorPolyPatch::calcGeometry()` face area checks in parallel.

## Cause

`solidModel::makeGlobalPatches()` is called from the `fluidSolidInterface` constructor with `currentConfiguration = true`. It temporarily moved the whole solid mesh to the deformed configuration, created the `globalPolyPatch`, and then moved the mesh back:

```cpp
const_cast<dynamicFvMesh&>(mesh()).movePoints(newPoints);
...
const_cast<dynamicFvMesh&>(mesh()).movePoints(pointsBackup);
```

`fvMesh::movePoints()` creates the mesh motion flux field (`meshPhi`), and `polyMesh::movePoints()` marks `points_` as `AUTO_WRITE`. Both then persist for the rest of the run.

The existing mitigation of setting the `meshPhi` `writeOpt` to `NO_WRITE` cannot work on OpenFOAM.com &ge; v2206, because `fvMesh::writeObject()` writes the mesh motion flux unconditionally whenever the field exists:

```cpp
bool Foam::fvMesh::writeObject(...) const
{
    bool ok = true;
    if (phiPtr_)
    {
        ok = phiPtr_->write(writeOnProc);   // writeOpt is not consulted
    }
    ...
}
```

and `fvMesh::writeObject()` is always reached, because the `objectRegistry` constructor forces the mesh's own `writeOpt` to `AUTO_WRITE`.

## Fix

1. `makeGlobalPatches()` now constructs the global patches on the undeformed mesh and then displaces their points with the existing `syncGlobalPatches()`, which is what `fluidSolidInterface` already does at every outer iteration. The solid mesh is never moved, so neither `meshPhi` nor `polyMesh/points` is created.

   As a bonus, `globalPolyPatch::calcGlobalPatch()` merges coincident points across processor boundaries using exact point coordinate comparisons. The undeformed coordinates are bit-identical either side of a processor boundary, whereas the deformed ones need not be, so building the patch in the reference configuration is also more robust in parallel.

2. The `solidModel` constructor clears the mesh moving flag, so that restarts from data written by earlier versions, which contain a stale solid `meshPhi`, also work without the user having to delete files by hand.

The version-dependent `#if (OPENFOAM >= 2206)` / `setPhi()` blocks and the `const_cast<dynamicFvMesh&>` mesh juggling are all removed: 53 insertions, 86 deletions.

## Verification

OpenFOAM v2512, `tutorials/fluidSolidInteraction/cavityFlexibleBottom`, `nonLinearGeometryTotalLagrangianTotalDisplacement`, 4 processors, restart from `t = 1` with `d2dt2Schemes default backward`:

| test | before | after |
| --- | --- | --- |
| serial run to `t = 1` | `1/solid/meshPhi` and `1/solid/polyMesh/points` written | neither written; `D` and `U` bit-identical to before |
| serial restart, `backward` d2dt2 | `FOAM FATAL ERROR: not implemented for a moving mesh` | runs to `t = 1.5` |
| parallel restart from the existing `processor*` directories | fatal error on all ranks | runs to `t = 1.5` |
| restart from data written by the current release, so with a stale `solid/meshPhi` | fatal error | runs, thanks to fix 2 |
| `reconstructPar` then `decomposePar` of the solid region | `Cannot find patchField entry for procBoundary0to3` in `1/solid/meshPhi` | succeeds |

## Not addressed

`decomposePar` still cannot decompose a reconstructed *fluid* time directory of a moving mesh case, as it fails on `1/fluid/meshPhi`, which is legitimately written there. That is an OpenFOAM limitation rather than a solids4foam one. For a parallel restart, the case should be restarted directly from the existing `processor*` directories rather than reconstructed and re-decomposed. This was verified to work with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
