### PR TITLE
Fuse the evaluation of cell-centre MLS derivatives

### DIFF
--- a/src/solids4FoamModels/functionObjects/solidPointDisplacement/solidPointDisplacement.C
+++ b/src/solids4FoamModels/functionObjects/solidPointDisplacement/solidPointDisplacement.C
@@ -97,42 +97,38 @@ void Foam::solidPointDisplacement::extrapolatedPointDisplacement()
              && solMod.displacementMLS().polynomialOrder() >= 2
             )
             {
-                volScalarField Dx(D.component(vector::X));
-                volScalarField Dy(D.component(vector::Y));
-                volScalarField Dz(D.component(vector::Z));
+                const bool thirdOrder =
+                    solMod.displacementMLS().polynomialOrder() >= 3;
 
-                tmp<volSymmTensorField> tSecondGradDx =
-                    solMod.displacementMLS().secondGrad(Dx);
-                tmp<volSymmTensorField> tSecondGradDy =
-                    solMod.displacementMLS().secondGrad(Dy);
-                tmp<volSymmTensorField> tSecondGradDz =
-                    solMod.displacementMLS().secondGrad(Dz);
+                // The higher derivatives of all three components share a
+                // single halo exchange and a single traversal of the stencil.
+                // Only the cell values are needed here, so no fields are built
+                FixedList<symmTensorField, 3> secondGradD;
+                FixedList<List<symmTensor3rdOrder>, 3> thirdGradD;
+
+                solMod.displacementMLS().cellDerivatives
+                (
+                    D,
+                    nullptr,
+                    &secondGradD,
+                    thirdOrder ? &thirdGradD : nullptr
+                );
 
                 pointDValue.x() +=
-                    0.5*(distance & tSecondGradDx().internalField()[cellID_]
-                      & distance);
+                    0.5*(distance & secondGradD[0][cellID_] & distance);
                 pointDValue.y() +=
-                    0.5*(distance & tSecondGradDy().internalField()[cellID_]
-                      & distance);
+                    0.5*(distance & secondGradD[1][cellID_] & distance);
                 pointDValue.z() +=
-                    0.5*(distance & tSecondGradDz().internalField()[cellID_]
-                      & distance);
+                    0.5*(distance & secondGradD[2][cellID_] & distance);
 
-                if (solMod.displacementMLS().polynomialOrder() >= 3)
+                if (thirdOrder)
                 {
-                    autoPtr<List<symmTensor3rdOrder>> tThirdGradDx =
-                        solMod.displacementMLS().thirdGrad(Dx);
-                    autoPtr<List<symmTensor3rdOrder>> tThirdGradDy =
-                        solMod.displacementMLS().thirdGrad(Dy);
-                    autoPtr<List<symmTensor3rdOrder>> tThirdGradDz =
-                        solMod.displacementMLS().thirdGrad(Dz);
-
                     pointDValue.x() +=
-                        (1.0/6.0)*cubicForm((*tThirdGradDx)[cellID_], distance);
+                        (1.0/6.0)*cubicForm(thirdGradD[0][cellID_], distance);
                     pointDValue.y() +=
-                        (1.0/6.0)*cubicForm((*tThirdGradDy)[cellID_], distance);
+                        (1.0/6.0)*cubicForm(thirdGradD[1][cellID_], distance);
                     pointDValue.z() +=
-                        (1.0/6.0)*cubicForm((*tThirdGradDz)[cellID_], distance);
+                        (1.0/6.0)*cubicForm(thirdGradD[2][cellID_], distance);
                 }
             }
         }

--- a/src/solids4FoamModels/higherOrderHelpers/movingLeastSquares/movingLeastSquares.C
+++ b/src/solids4FoamModels/higherOrderHelpers/movingLeastSquares/movingLeastSquares.C
@@ -1330,6 +1330,275 @@ autoPtr<List<symmTensor3rdOrder>> movingLeastSquares::thirdGrad
     return tThirdGrad;
 }
 
+
+void movingLeastSquares::cellDerivatives
+(
+    const volScalarField& s,
+    vectorField* gradPtr,
+    symmTensorField* secondGradPtr,
+    List<symmTensor3rdOrder>* thirdGradPtr
+) const
+{
+    if (!gradPtr && !secondGradPtr && !thirdGradPtr)
+    {
+        return;
+    }
+
+    const fvMesh& mesh = mesh_;
+    const globalIndex& globalCells = stencil().globalCells();
+    const Map<FixedList<label, 2>>& remoteLoc = stencil().remoteCellLocation();
+
+    const CompactListList<label>& stencils = stencil().cellsStencil();
+
+    const scalarField& sI = s.internalField();
+
+    // A single halo exchange, shared by every requested derivative order
+    const List<Field<scalar>> remoteField = stencil().remoteFieldPerProc(sI);
+
+    // Only the coefficients of the requested orders are accessed, so that an
+    // order which is not requested is not calculated on demand
+    const CompactListList<vector>* gradCoeffsPtr = nullptr;
+    const CompactListList<symmTensor>* secondGradCoeffsPtr = nullptr;
+    const CompactListList<symmTensor3rdOrder>* thirdGradCoeffsPtr = nullptr;
+
+    if (gradPtr)
+    {
+        gradCoeffsPtr = &cellGradCoeffs();
+        gradPtr->setSize(mesh.nCells());
+        *gradPtr = vector::zero;
+    }
+
+    if (secondGradPtr)
+    {
+        secondGradCoeffsPtr = &cellSecondGradCoeffs();
+        secondGradPtr->setSize(mesh.nCells());
+        *secondGradPtr = symmTensor::zero;
+    }
+
+    if (thirdGradPtr)
+    {
+        thirdGradCoeffsPtr = &cellThirdGradCoeffs();
+        thirdGradPtr->setSize(mesh.nCells());
+        *thirdGradPtr = symmTensor3rdOrder::zero;
+    }
+
+    // Field values at the stencil points of the current cell. Resolving a
+    // stencil point to a local or a remote value is the expensive part of the
+    // loop, so it is done once per point and reused by every order
+    scalarField stencilValues;
+
+    forAll(stencils, cellI)
+    {
+        const UList<label>& stencilCells = stencils[cellI];
+
+        if (stencilCells.size() > stencilValues.size())
+        {
+            stencilValues.setSize(stencilCells.size());
+        }
+
+        forAll(stencilCells, cI)
+        {
+            stencilValues[cI] =
+                fieldValue
+                (
+                    stencilCells[cI],
+                    globalCells,
+                    remoteLoc,
+                    sI,
+                    remoteField
+                );
+        }
+
+        if (gradPtr)
+        {
+            const UList<vector>& coeffs = (*gradCoeffsPtr)[cellI];
+            vector& cellGrad = (*gradPtr)[cellI];
+
+            // Stencil contribution
+            forAll(stencilCells, cI)
+            {
+                cellGrad += coeffs[cI]*stencilValues[cI];
+            }
+
+            // Cell-centre contribution
+            cellGrad += coeffs[stencilCells.size()]*sI[cellI];
+        }
+
+        if (secondGradPtr)
+        {
+            const UList<symmTensor>& coeffs = (*secondGradCoeffsPtr)[cellI];
+            symmTensor& cellSecondGrad = (*secondGradPtr)[cellI];
+
+            // Stencil contribution
+            forAll(stencilCells, cI)
+            {
+                cellSecondGrad += coeffs[cI]*stencilValues[cI];
+            }
+
+            // Cell-centre contribution
+            cellSecondGrad += coeffs[stencilCells.size()]*sI[cellI];
+        }
+
+        if (thirdGradPtr)
+        {
+            const UList<symmTensor3rdOrder>& coeffs =
+                (*thirdGradCoeffsPtr)[cellI];
+            symmTensor3rdOrder& cellThirdGrad = (*thirdGradPtr)[cellI];
+
+            // Stencil contribution
+            forAll(stencilCells, cI)
+            {
+                cellThirdGrad += coeffs[cI]*stencilValues[cI];
+            }
+
+            // Cell-centre contribution
+            cellThirdGrad += coeffs[stencilCells.size()]*sI[cellI];
+        }
+    }
+}
+
+
+void movingLeastSquares::cellDerivatives
+(
+    const volVectorField& v,
+    tensorField* gradPtr,
+    FixedList<symmTensorField, 3>* secondGradPtr,
+    FixedList<List<symmTensor3rdOrder>, 3>* thirdGradPtr
+) const
+{
+    if (!gradPtr && !secondGradPtr && !thirdGradPtr)
+    {
+        return;
+    }
+
+    const fvMesh& mesh = mesh_;
+    const globalIndex& globalCells = stencil().globalCells();
+    const Map<FixedList<label, 2>>& remoteLoc = stencil().remoteCellLocation();
+
+    const CompactListList<label>& stencils = stencil().cellsStencil();
+
+    const vectorField& vI = v.internalField();
+
+    // A single halo exchange, shared by the gradient and by all three
+    // components of the higher derivatives
+    const List<Field<vector>> remoteField = stencil().remoteFieldPerProc(vI);
+
+    const CompactListList<vector>* gradCoeffsPtr = nullptr;
+    const CompactListList<symmTensor>* secondGradCoeffsPtr = nullptr;
+    const CompactListList<symmTensor3rdOrder>* thirdGradCoeffsPtr = nullptr;
+
+    if (gradPtr)
+    {
+        gradCoeffsPtr = &cellGradCoeffs();
+        gradPtr->setSize(mesh.nCells());
+        *gradPtr = tensor::zero;
+    }
+
+    if (secondGradPtr)
+    {
+        secondGradCoeffsPtr = &cellSecondGradCoeffs();
+
+        for (direction cmpt = 0; cmpt < vector::nComponents; cmpt++)
+        {
+            (*secondGradPtr)[cmpt].setSize(mesh.nCells());
+            (*secondGradPtr)[cmpt] = symmTensor::zero;
+        }
+    }
+
+    if (thirdGradPtr)
+    {
+        thirdGradCoeffsPtr = &cellThirdGradCoeffs();
+
+        for (direction cmpt = 0; cmpt < vector::nComponents; cmpt++)
+        {
+            (*thirdGradPtr)[cmpt].setSize(mesh.nCells());
+            (*thirdGradPtr)[cmpt] = symmTensor3rdOrder::zero;
+        }
+    }
+
+    vectorField stencilValues;
+
+    forAll(stencils, cellI)
+    {
+        const UList<label>& stencilCells = stencils[cellI];
+
+        if (stencilCells.size() > stencilValues.size())
+        {
+            stencilValues.setSize(stencilCells.size());
+        }
+
+        forAll(stencilCells, cI)
+        {
+            stencilValues[cI] =
+                fieldValue
+                (
+                    stencilCells[cI],
+                    globalCells,
+                    remoteLoc,
+                    vI,
+                    remoteField
+                );
+        }
+
+        if (gradPtr)
+        {
+            const UList<vector>& coeffs = (*gradCoeffsPtr)[cellI];
+            tensor& cellGrad = (*gradPtr)[cellI];
+
+            // Stencil contribution
+            forAll(stencilCells, cI)
+            {
+                cellGrad += coeffs[cI]*stencilValues[cI];
+            }
+
+            // Cell-centre contribution
+            cellGrad += coeffs[stencilCells.size()]*vI[cellI];
+        }
+
+        if (secondGradPtr)
+        {
+            const UList<symmTensor>& coeffs = (*secondGradCoeffsPtr)[cellI];
+
+            for (direction cmpt = 0; cmpt < vector::nComponents; cmpt++)
+            {
+                symmTensor& cellSecondGrad = (*secondGradPtr)[cmpt][cellI];
+
+                // Stencil contribution
+                forAll(stencilCells, cI)
+                {
+                    cellSecondGrad += coeffs[cI]*stencilValues[cI][cmpt];
+                }
+
+                // Cell-centre contribution
+                cellSecondGrad +=
+                    coeffs[stencilCells.size()]*vI[cellI][cmpt];
+            }
+        }
+
+        if (thirdGradPtr)
+        {
+            const UList<symmTensor3rdOrder>& coeffs =
+                (*thirdGradCoeffsPtr)[cellI];
+
+            for (direction cmpt = 0; cmpt < vector::nComponents; cmpt++)
+            {
+                symmTensor3rdOrder& cellThirdGrad =
+                    (*thirdGradPtr)[cmpt][cellI];
+
+                // Stencil contribution
+                forAll(stencilCells, cI)
+                {
+                    cellThirdGrad += coeffs[cI]*stencilValues[cI][cmpt];
+                }
+
+                // Cell-centre contribution
+                cellThirdGrad +=
+                    coeffs[stencilCells.size()]*vI[cellI][cmpt];
+            }
+        }
+    }
+}
+
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
 } // End namespace Foam

--- a/src/solids4FoamModels/higherOrderHelpers/movingLeastSquares/movingLeastSquares.C
+++ b/src/solids4FoamModels/higherOrderHelpers/movingLeastSquares/movingLeastSquares.C
@@ -1331,6 +1331,39 @@ autoPtr<List<symmTensor3rdOrder>> movingLeastSquares::thirdGrad
 }
 
 
+// Create a zeroed second derivative field, matching what secondGrad() returns
+static tmp<volSymmTensorField> newZeroedSecondGrad
+(
+    const fvMesh& mesh,
+    const word& name,
+    const dimensionSet& dims
+)
+{
+    return tmp<volSymmTensorField>
+    (
+        new volSymmTensorField
+        (
+            IOobject
+            (
+                name,
+                mesh.time().timeName(),
+                mesh,
+                IOobject::NO_READ,
+                IOobject::AUTO_WRITE
+            ),
+            mesh,
+            dimensionedSymmTensor
+            (
+                "zero",
+                dims/sqr(dimLength),
+                symmTensor::zero
+            ),
+            "zeroGradient"
+        )
+    );
+}
+
+
 void movingLeastSquares::cellDerivatives
 (
     const volScalarField& s,
@@ -1595,6 +1628,118 @@ void movingLeastSquares::cellDerivatives
                 cellThirdGrad +=
                     coeffs[stencilCells.size()]*vI[cellI][cmpt];
             }
+        }
+    }
+}
+
+
+void movingLeastSquares::cellDerivatives
+(
+    const volScalarField& s,
+    tmp<volSymmTensorField>* secondGradPtr,
+    autoPtr<List<symmTensor3rdOrder>>* thirdGradPtr
+) const
+{
+    if (!secondGradPtr && !thirdGradPtr)
+    {
+        return;
+    }
+
+    // A single halo exchange and stencil traversal, via the internal-field
+    // overload
+    symmTensorField secondGradI;
+    List<symmTensor3rdOrder> thirdGradI;
+
+    cellDerivatives
+    (
+        s,
+        nullptr,
+        secondGradPtr ? &secondGradI : nullptr,
+        thirdGradPtr ? &thirdGradI : nullptr
+    );
+
+    if (secondGradPtr)
+    {
+        *secondGradPtr = newZeroedSecondGrad
+        (
+            mesh_,
+            "secondGrad(" + s.name() + ')',
+            s.dimensions()
+        );
+
+        volSymmTensorField& secondGrad = tmpRef(*secondGradPtr);
+        primitiveFieldRef(secondGrad).transfer(secondGradI);
+        secondGrad.correctBoundaryConditions();
+    }
+
+    if (thirdGradPtr)
+    {
+        *thirdGradPtr =
+            autoPtr<List<symmTensor3rdOrder>>
+            (
+                new List<symmTensor3rdOrder>()
+            );
+
+        autoPtrRef(*thirdGradPtr).transfer(thirdGradI);
+    }
+}
+
+
+void movingLeastSquares::cellDerivatives
+(
+    const volVectorField& v,
+    FixedList<tmp<volSymmTensorField>, 3>* secondGradPtr,
+    FixedList<autoPtr<List<symmTensor3rdOrder>>, 3>* thirdGradPtr
+) const
+{
+    if (!secondGradPtr && !thirdGradPtr)
+    {
+        return;
+    }
+
+    // A single halo exchange and stencil traversal for all three components,
+    // via the internal-field overload
+    FixedList<symmTensorField, 3> secondGradI;
+    FixedList<List<symmTensor3rdOrder>, 3> thirdGradI;
+
+    cellDerivatives
+    (
+        v,
+        nullptr,
+        secondGradPtr ? &secondGradI : nullptr,
+        thirdGradPtr ? &thirdGradI : nullptr
+    );
+
+    for (direction cmpt = 0; cmpt < vector::nComponents; cmpt++)
+    {
+        if (secondGradPtr)
+        {
+            const word cmptName
+            (
+                v.name() + ".component(" + Foam::name(label(cmpt)) + ')'
+            );
+
+            (*secondGradPtr)[cmpt] = newZeroedSecondGrad
+            (
+                mesh_,
+                "secondGrad(" + cmptName + ')',
+                v.dimensions()
+            );
+
+            volSymmTensorField& secondGrad = tmpRef((*secondGradPtr)[cmpt]);
+            primitiveFieldRef(secondGrad).transfer(secondGradI[cmpt]);
+            secondGrad.correctBoundaryConditions();
+        }
+
+        if (thirdGradPtr)
+        {
+            (*thirdGradPtr)[cmpt] =
+                autoPtr<List<symmTensor3rdOrder>>
+                (
+                    new List<symmTensor3rdOrder>()
+                );
+
+            autoPtrRef((*thirdGradPtr)[cmpt]).transfer(thirdGradI[cmpt]);
         }
     }
 }

--- a/src/solids4FoamModels/higherOrderHelpers/movingLeastSquares/movingLeastSquares.H
+++ b/src/solids4FoamModels/higherOrderHelpers/movingLeastSquares/movingLeastSquares.H
@@ -453,6 +453,28 @@ private:
             FixedList<symmTensorField, 3>* secondGradPtr,
             FixedList<List<symmTensor3rdOrder>, 3>* thirdGradPtr
         ) const;
+
+        //- As the scalar overload above, but returning the second derivative
+        //  as a complete field with its boundary conditions evaluated, for
+        //  callers that also need the boundary values. Either output may be
+        //  null. The results are identical to secondGrad() and thirdGrad().
+        void cellDerivatives
+        (
+            const volScalarField& s,
+            tmp<volSymmTensorField>* secondGradPtr,
+            autoPtr<List<symmTensor3rdOrder>>* thirdGradPtr
+        ) const;
+
+        //- As the vector overload above, but returning the second derivative
+        //  of each component as a complete field with its boundary conditions
+        //  evaluated. Either output may be null. The results are identical to
+        //  calling secondGrad() and thirdGrad() on each component.
+        void cellDerivatives
+        (
+            const volVectorField& v,
+            FixedList<tmp<volSymmTensorField>, 3>* secondGradPtr,
+            FixedList<autoPtr<List<symmTensor3rdOrder>>, 3>* thirdGradPtr
+        ) const;
 };
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //

--- a/src/solids4FoamModels/higherOrderHelpers/movingLeastSquares/movingLeastSquares.H
+++ b/src/solids4FoamModels/higherOrderHelpers/movingLeastSquares/movingLeastSquares.H
@@ -343,6 +343,32 @@ private:
             return faceGradCoeffs();
         }
 
+        // Read-only access to the cell-centre coefficient tables. These allow
+        // a solver to assemble its own high-order operators directly, rather
+        // than going through the evaluation functions below. Row cellI is
+        // indexed by stencilData().cellsStencil()[cellI], and carries one
+        // extra trailing entry, at index cellsStencil()[cellI].size(),
+        // holding the coefficient of the cell itself.
+
+        //- Read-only access to cell-centre gradient coefficients
+        const CompactListList<vector>& cellGradCoeffsData() const
+        {
+            return cellGradCoeffs();
+        }
+
+        //- Read-only access to cell-centre second derivative coefficients
+        const CompactListList<symmTensor>& cellSecondGradCoeffsData() const
+        {
+            return cellSecondGradCoeffs();
+        }
+
+        //- Read-only access to cell-centre third derivative coefficients
+        const CompactListList<symmTensor3rdOrder>&
+        cellThirdGradCoeffsData() const
+        {
+            return cellThirdGradCoeffs();
+        }
+
         //- Clear owned MLS data and cached coefficient data
         void clear() const;
 

--- a/src/solids4FoamModels/higherOrderHelpers/movingLeastSquares/movingLeastSquares.H
+++ b/src/solids4FoamModels/higherOrderHelpers/movingLeastSquares/movingLeastSquares.H
@@ -424,6 +424,35 @@ private:
         //  field. For vector fields we apply this per component.
         autoPtr<List<symmTensor3rdOrder>>
         thirdGrad(const volScalarField& s) const;
+
+        //- Evaluate the cell-centre gradient, second derivative and third
+        //  derivative of a scalar field, using a single halo exchange and
+        //  resolving each stencil point once. Any output pointer may be null,
+        //  in which case that derivative is not evaluated and its coefficients
+        //  are not calculated. The outputs are resized and zeroed on entry,
+        //  and the contributions are accumulated in the same order as grad(),
+        //  secondGrad() and thirdGrad(), so the results are identical to
+        //  calling those functions separately.
+        void cellDerivatives
+        (
+            const volScalarField& s,
+            vectorField* gradPtr,
+            symmTensorField* secondGradPtr,
+            List<symmTensor3rdOrder>* thirdGradPtr
+        ) const;
+
+        //- As above, for a vector field, with a single halo exchange shared by
+        //  the gradient and by all three components of the higher derivatives.
+        //  The gradient is identical to grad(), and the second and third
+        //  derivatives are indexed by component and are identical to calling
+        //  secondGrad() and thirdGrad() on each component of the field.
+        void cellDerivatives
+        (
+            const volVectorField& v,
+            tensorField* gradPtr,
+            FixedList<symmTensorField, 3>* secondGradPtr,
+            FixedList<List<symmTensor3rdOrder>, 3>* thirdGradPtr
+        ) const;
 };
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //

--- a/src/solids4FoamModels/numerics/stabilisationModels/alphaStab/alphaStabTemplates.H
+++ b/src/solids4FoamModels/numerics/stabilisationModels/alphaStab/alphaStabTemplates.H
@@ -88,19 +88,23 @@ inline void Foam::alphaStab::computeDiffStencilHighOrderScalar
     autoPtr<List<symmTensor3rdOrder>> tThirdGrad;
     const List<symmTensor3rdOrder>* thirdGrad = nullptr;
 
-    // Second gradient is computed on demand by MLS
+    // The higher derivatives are computed on demand by MLS, sharing a single
+    // halo exchange and a single traversal of the stencil
     if (polynomialOrder >= 2)
     {
-        tSecondGrad = displacementMLS.secondGrad(field);
-        tmpRef(tSecondGrad).correctBoundaryConditions();
-        secondGradI = &tSecondGrad().internalField();
-    }
+        displacementMLS.cellDerivatives
+        (
+            field,
+            &tSecondGrad,
+            polynomialOrder >= 3 ? &tThirdGrad : nullptr
+        );
 
-    // Third gradient is computed on demand by MLS
-    if (polynomialOrder >= 3)
-    {
-        tThirdGrad = displacementMLS.thirdGrad(field);
-        thirdGrad = &tThirdGrad();
+        secondGradI = &tSecondGrad().internalField();
+
+        if (polynomialOrder >= 3)
+        {
+            thirdGrad = &tThirdGrad();
+        }
     }
 
     forAll(owner, facei)
@@ -312,52 +316,39 @@ inline void Foam::alphaStab::computeDiffStencilHighOrderVector
     const labelUList& owner = mesh.owner();
     const labelUList& neighbour = mesh.neighbour();
 
-    // Decompose vector field into scalar components
-    volScalarField fieldX(field.component(vector::X));
-    volScalarField fieldY(field.component(vector::Y));
-    volScalarField fieldZ(field.component(vector::Z));
-
-    // Initialise storage for second gradint
-    tmp<volSymmTensorField> tSecondGradX;
-    tmp<volSymmTensorField> tSecondGradY;
-    tmp<volSymmTensorField> tSecondGradZ;
+    // Initialise storage for second gradint, indexed by component
+    FixedList<tmp<volSymmTensorField>, 3> tSecondGrad;
     const symmTensorField* secondGradXI = nullptr;
     const symmTensorField* secondGradYI = nullptr;
     const symmTensorField* secondGradZI = nullptr;
 
-    // Initialise storage for third gradient
-    autoPtr<List<symmTensor3rdOrder>> tThirdGradX;
-    autoPtr<List<symmTensor3rdOrder>> tThirdGradY;
-    autoPtr<List<symmTensor3rdOrder>> tThirdGradZ;
+    // Initialise storage for third gradient, indexed by component
+    FixedList<autoPtr<List<symmTensor3rdOrder>>, 3> tThirdGrad;
     const List<symmTensor3rdOrder>* thirdGradX = nullptr;
     const List<symmTensor3rdOrder>* thirdGradY = nullptr;
     const List<symmTensor3rdOrder>* thirdGradZ = nullptr;
 
-    // Second gradient is computed on demand by MLS
+    // The higher derivatives of all three components are computed on demand by
+    // MLS, sharing a single halo exchange and a single traversal of the stencil
     if (polynomialOrder >= 2)
     {
-        tSecondGradX = displacementMLS.secondGrad(fieldX);
-        tSecondGradY = displacementMLS.secondGrad(fieldY);
-        tSecondGradZ = displacementMLS.secondGrad(fieldZ);
-        tmpRef(tSecondGradX).correctBoundaryConditions();
-        tmpRef(tSecondGradY).correctBoundaryConditions();
-        tmpRef(tSecondGradZ).correctBoundaryConditions();
+        displacementMLS.cellDerivatives
+        (
+            field,
+            &tSecondGrad,
+            polynomialOrder >= 3 ? &tThirdGrad : nullptr
+        );
 
-        secondGradXI = &tSecondGradX().internalField();
-        secondGradYI = &tSecondGradY().internalField();
-        secondGradZI = &tSecondGradZ().internalField();
-    }
+        secondGradXI = &tSecondGrad[0]().internalField();
+        secondGradYI = &tSecondGrad[1]().internalField();
+        secondGradZI = &tSecondGrad[2]().internalField();
 
-    // Third gradient is computed on demand by MLS
-    if (polynomialOrder >= 3)
-    {
-        tThirdGradX = displacementMLS.thirdGrad(fieldX);
-        tThirdGradY = displacementMLS.thirdGrad(fieldY);
-        tThirdGradZ = displacementMLS.thirdGrad(fieldZ);
-
-        thirdGradX = &tThirdGradX();
-        thirdGradY = &tThirdGradY();
-        thirdGradZ = &tThirdGradZ();
+        if (polynomialOrder >= 3)
+        {
+            thirdGradX = &tThirdGrad[0]();
+            thirdGradY = &tThirdGrad[1]();
+            thirdGradZ = &tThirdGrad[2]();
+        }
     }
 
     forAll(owner, facei)
@@ -447,11 +438,14 @@ inline void Foam::alphaStab::computeDiffStencilHighOrderVector
             if (polynomialOrder >= 2)
             {
                 tNeiProcSecondGradX =
-                    tSecondGradX().boundaryField()[patchi].patchNeighbourField();
+                    tSecondGrad[0]().boundaryField()[patchi]
+                   .patchNeighbourField();
                 tNeiProcSecondGradY =
-                    tSecondGradY().boundaryField()[patchi].patchNeighbourField();
+                    tSecondGrad[1]().boundaryField()[patchi]
+                   .patchNeighbourField();
                 tNeiProcSecondGradZ =
-                    tSecondGradZ().boundaryField()[patchi].patchNeighbourField();
+                    tSecondGrad[2]().boundaryField()[patchi]
+                   .patchNeighbourField();
 
                 neiProcSecondGradX = &tNeiProcSecondGradX();
                 neiProcSecondGradY = &tNeiProcSecondGradY();


### PR DESCRIPTION
# `solids4foam` Pull Request

## Pull Request Description 🚀

`movingLeastSquares::grad()`, `secondGrad()` and `thirdGrad()` each perform their own halo exchange and their own traversal of the cell stencil. When several derivative orders of the same field are needed, that work is repeated.

`alphaStab` is the stabilisation used by `linGeomTotalDispSolid`, `nonLinGeomUpdatedLagSolid` and `nonLinGeomTotalLagTotalDispSolid`, and with a matrix-free SNES it runs on every residual evaluation, that is, on every Krylov iteration. Its vector variant makes **six calls** — `secondGrad` and `thirdGrad` for each of three components — plus three component fields built only to feed them. `solidPointDisplacement` does the same **six calls**.

This PR adds `cellDerivatives()`, which evaluates several derivative orders with a single halo exchange and a single resolution of the stencil points, and moves both internal consumers onto it. Measured improvement in total run time is 7% to 25%, depending on how much of the run the stabilisation accounts for, with results unchanged byte for byte.

One detail worth stating, because it doubles the saving: each call to `movingLeastSquaresStencil::remoteFieldPerProc() `is a two-round-trip exchange. Phase one sends the list of requested global cell IDs, phase two replies with the values. That ID list comes from the cached `remoteCellsPerProc()` and is identical on every call, yet it is re-sent each time. Collapsing six calls into one therefore removes twelve message rounds, not six.

---

## Changes Made 🛠️

- **New Feature:** `cellDerivatives()` on `movingLeastSquares` — four public overloads that evaluate the gradient, second and third derivatives of a field in one pass. Plus three read-only accessors to the cached cell-centre coefficient tables, so an external solver can assemble its own high-order operators without duplicating the library (I used this for cardiacFoam).
- **Refactoring:** `alphaStab` (both scalar and vector variants) and `solidPointDisplacement` now use the fused path.
- **Documentation:** doc comments on all new members.

### Summary of Changes

**Files Modified**
|file|change|
| --- | --- |
| higherOrderHelpers/movingLeastSquares/movingLeastSquares.H	|7 new public members|
| higherOrderHelpers/movingLeastSquares/movingLeastSquares.C	|their implementation|
| numerics/stabilisationModels/alphaStab/alphaStabTemplates.H	|both variants use the fused path|
| functionObjects/solidPointDisplacement/solidPointDisplacement.C	|uses the fused path|

Four files, 553 insertions, 72 deletions.

**Additions to the public interface:** Seven additive members on movingLeastSquares; nothing removed, no existing signature or behaviour changed. Three coefficient accessors (`cellGradCoeffsData()`, `cellSecondGradCoeffsData()`, `cellThirdGradCoeffsData()`), and four `cellDerivatives()` overloads: two returning internal fields, two returning complete `GeometricFields`. Both forms are needed by the two consumers — `alphaStab` reads `boundaryField()[patchi].patchNeighbourField() `on coupled patches and so needs the boundary values, while `solidPointDisplacement` reads only cell values and should not pay for field construction. `grad()`, `secondGrad()` and `thirdGrad()` are untouched and remain available.

**Behavioural changes:** None in output: verified byte for byte, see below. In performance: 7–25% faster, and improved parallel scaling on the communication-bound case.

---

## Checklist ✅

- Code compiles successfully with **OpenFOAM v2312**, with no new warnings. **foam-extend:** the modified code is excluded from that build by construction — `movingLeastSquares.C` is commented out in `Make/files.foamextend`, and the high-order blocks in both consumers are inside `#ifndef FOAMEXTEND` — so there is nothing new to compile there.
 - I tested the changes with the `cantilever2d` tutorial and with two additional high-order cases (details below).
 - Added relevant comments and documentation for clarity.
 - The PR passes existing `GitHub Actions CI checks` — to be confirmed by this PR's run.
 - Code follows the project's coding style and conventions (I hope so).
 
---

## Test Cases and Results 📊

The property to demonstrate is that nothing changes: same coefficients, same accumulation order, therefore the same numbers. Fields were compared with `diff -r` over the time directories — per processor directory in the parallel runs, without reconstruction, so the comparison is on what each rank actually wrote.

### Correctness

`cantilever2d` (repository tutorial, `polynomialOrder 3`, 5120 cells) — fields identical byte for byte in serial, on 2 ranks and on 3 ranks. On 4 ranks this case diverges in the linear solver, identically before and after the change; see the note on preconditioners below.

**Manufactured solution** (trigonometric MMS on a cube, linear elastic, 91 125 hexahedra, `polynomialOrder 3`) — fields identical byte for byte in serial and on 2, 3 and 4 ranks. The error norms against the exact solution are unchanged to the last printed digit, and the linear solver converges in the same number of iterations.

**Pressurised cylinder** (neo-Hookean hyperelastic, 32 736 hexahedra, `polynomialOrder 3`, 10 load steps) — fields identical byte for byte in serial and on 2, 3 and 4 ranks.

### Performance: why two cases

The two cases sit at opposite ends of one variable — how much of the run time `alphaStab` accounts for.

The **manufactured solution** converges in 2 nonlinear iterations and 2 linear solves. The one-off cost of building the MLS stencils and coefficients, which this PR does not touch, dominates the run.

The **pressurised cylinder** performs 10 load steps and ~30 linear solves, so that fixed set-up cost is amortised over far more calls into the path that was optimised.

Both are 3D, both use BoomerAMG, both run to completion. Each number is the **median of five repetitions** of the same configuration; the spread between repetitions stayed under 3%. Measured on an i7-12700H with OpenFOAM v2312 and PETSc 3.23.2, wall-clock time and peak RSS from `/usr/bin/time`.

**Manufactured solution — few linear solves**
| | before | after | improvement | max RSS before | max RSS after |
|---|---|---|---|---|---|
| serial | 116.47 s | 108.41 s | **6.9%** | 3.97 GB | 3.97 GB |
| 2 ranks | 64.85 s | 60.89 s | **6.1%** | 2.09 GB | 2.09 GB |
| 3 ranks | 48.35 s | 44.64 s | **7.7%** | 1.46 GB | 1.45 GB |
| 4 ranks | 38.70 s | 36.28 s | **6.3%** | 1.13 GB | 1.13 GB |

**Pressurised cylinder — many linear solves**
| |before	|after|	improvement|	max RSS before|	max RSS after|
| --- | --- | --- | --- | --- | --- |
|serial	|430.13 s	|340.41 s	|**20.9%**	|0.88 GB	|0.88 GB|
|2 ranks	|239.79 s	|175.02 s	|**27.0%**	|0.52 GB	|0.51 GB|
|3 ranks	|198.69 s	|148.51 s	|**25.3%**	|0.40 GB	|0.40 GB|
|4 ranks	|155.45 s	|117.05 s	|**24.7%**	|0.34 GB	|0.34 GB|

The honest statement is therefore a range rather than a single figure: **about 7% when the solver takes few nonlinear iterations, about 25% when it takes many**. Peak memory is unchanged in both — what the fusion removes are transient allocations, not the peak.

**Effect on parallel scaling**
| | 2 ranks | 3 ranks | 4 ranks |
|---|---|---|---|
| MMS, before | 1.80× | 2.41× | 3.01× |
| MMS, after | 1.78× | 2.43× | 2.99× |
| cylinder, before | 1.79× | 2.16× | 2.77× |
| cylinder, after | 1.94× | 2.29× | 2.91× |

On the hyperelastic case scaling improves at every rank count, which is what removing communication rather than only local work looks like. On the compute-bound manufactured solution it is unchanged, as expected. These columns show that the change does not disturb scaling; they are not offered as a scalability study, since all configurations share one machine.

---

## Additional Notes 💡

**Backward compatibility:** No concerns. The change is purely additive to the public interface, and all three existing derivative functions keep their signatures and behaviour. External code compiles and produces the same results without modification.

**Dependencies:** None new. OpenFOAM.com; the modified code is not part of the foam-extend build.

**Two observations made while preparing the measurements**, unrelated to this change but possibly of interest:

- `MooneyRivlinElastic` does not implement the quadrature-point `correct(CompactListList<symmTensor>&, ...) `overload that the high-order path requires, so a hyperelastic case using it aborts with "Not implemented". `neoHookeanElastic` does implement it, and was used for the cylinder.

- The high-order tutorials use `pc_type bjacobi` with `sub_pc_type lu`. In serial that is a direct factorisation of the whole system and an excellent preconditioner, but its quality collapses under decomposition: on `cantilever2d` with `polynomialOrder 3` the linear solves go from ~90 iterations in serial to 4694 on 2 ranks, and diverge on 4. This is why the timing measurements above were taken on cases configured with an algebraic multigrid preconditioner instead.

**Remaining task, deliberately left out of this PR**. `alphaStab::exchangeProcessorPatchField() `is blocking and is called once per processor patch from inside the patch loop — **three times per patch** in the vector variant. Posting all sends for all patches with `PstreamBuffers` and then receiving, as a single non-blocking phase, would remove that serialisation. It concerns the processor-boundary exchange rather than the stencil halo, so it belongs in a separate change (future change) with its own verification.

---
