### PR TITLE
Shadow state, working finite-difference tangents, and jacobianTangent selection

### DIFF
--- a/applications/test/mechanicalConstitutiveLaw/Test-mechanicalConstitutiveLaw.C
+++ b/applications/test/mechanicalConstitutiveLaw/Test-mechanicalConstitutiveLaw.C
@@ -45,7 +45,13 @@ Description
          the dual faces uses the material of the owning primary cell.
       6. A fourth-order tangent on the dual faces matches the closed-form
          isotropic stiffness, including with more than one material.
-      7. The misuse guards fire: a fourth-order tangent on a topology that
+      7. The finite-difference fourth-order tangent reproduces the analytical
+         one, which also checks its Voigt shear convention.
+      8. A tangent query leaves the constitutive state untouched, so a stress
+         evaluated before and after intervening queries at wildly different
+         kinematics is identical.
+      9. updateScalarTangent agrees with the tangent from a stress update.
+     10. The misuse guards fire: a fourth-order tangent on a topology that
          cannot carry one, a flat-list update on a topology whose integration
          points are shared between cells, a tangent request with no storage,
          and a duplicate registerTopology key.
@@ -213,16 +219,26 @@ int main(int argc, char *argv[])
     scalarField refMu(mesh.nCells(), 0.0);
     scalarField refLambda(mesh.nCells(), 0.0);
 
+    // The closed-form checks need a law whose stress and tangent are known
+    // here. Everything else - path agreement, state preservation, the
+    // topologies and the guards - applies to any law, and a history-dependent
+    // law is the only thing that exercises the shadow state properly
+    bool allLinearElastic = true;
+    forAll(lawEntries, lawI)
+    {
+        if (word(lawEntries[lawI].dict().lookup("type")) != "linearElastic")
+        {
+            allLinearElastic = false;
+        }
+    }
+
     forAll(lawEntries, lawI)
     {
         const dictionary& lawDict = lawEntries[lawI].dict();
 
-        if (word(lawDict.lookup("type")) != "linearElastic")
+        if (!allLinearElastic)
         {
-            FatalErrorInFunction
-                << "This test assumes every material is linearElastic, but "
-                << lawEntries[lawI].keyword() << " is of type "
-                << word(lawDict.lookup("type")) << exit(FatalError);
+            continue;
         }
 
         const scalar E = dimensionedScalar(lawDict.lookup("E")).value();
@@ -266,7 +282,8 @@ int main(int argc, char *argv[])
 
     Info<< "    materials: " << lawEntries.size()
         << ", planeStress: " << planeStress
-        << ", cells: " << mesh.nCells() << endl;
+        << ", cells: " << mesh.nCells()
+        << ", closed-form checks: " << Switch(allLinearElastic) << endl;
 
     // ---------------------------------------------------------------------
     // Construct the manager and the test kinematics
@@ -374,19 +391,27 @@ int main(int argc, char *argv[])
             refImpK[cellI] = 2.0*refMu[cellI] + refLambda[cellI];
         }
 
-        reportError
-        (
-            "stress matches the closed form",
-            relativeDifference(Foam::primitiveField(sigma), refSigma),
-            1e-12
-        );
+        if (allLinearElastic)
+        {
+            reportError
+            (
+                "stress matches the closed form",
+                relativeDifference(Foam::primitiveField(sigma), refSigma),
+                1e-12
+            );
 
-        reportError
-        (
-            "scalar tangent matches 2*mu + lambda",
-            relativeDifference(Foam::primitiveField(impK), refImpK),
-            1e-12
-        );
+            reportError
+            (
+                "scalar tangent matches 2*mu + lambda",
+                relativeDifference(Foam::primitiveField(impK), refImpK),
+                1e-12
+            );
+        }
+        else
+        {
+            Info<< "    SKIP: closed-form stress and tangent "
+                << "(not all materials are linearElastic)" << endl;
+        }
     }
 
     // ---------------------------------------------------------------------
@@ -672,12 +697,20 @@ int main(int argc, char *argv[])
               + refLambda[cellI]*tr(dualGradD[dualFaceI])*I;
         }
 
-        reportError
-        (
-            "dual-face stress uses the owning cell's material",
-            relativeDifference(dualSigma, refDualSigma),
-            1e-12
-        );
+        if (allLinearElastic)
+        {
+            reportError
+            (
+                "dual-face stress uses the owning cell's material",
+                relativeDifference(dualSigma, refDualSigma),
+                1e-12
+            );
+        }
+        else
+        {
+            Info<< "    SKIP: dual-face closed-form stress "
+                << "(not all materials are linearElastic)" << endl;
+        }
     }
 
     // ---------------------------------------------------------------------
@@ -686,6 +719,12 @@ int main(int argc, char *argv[])
 
     Info<< nl << "6. Fourth-order tangent on the dual faces" << endl;
 
+    if (!allLinearElastic)
+    {
+        Info<< "    SKIP: no analytical fourth-order tangent for these "
+            << "materials" << endl;
+    }
+    else
     {
         List<mat66> dualC(nInternalDualFaces);
 
@@ -731,19 +770,231 @@ int main(int argc, char *argv[])
             maxRelError = max(maxRelError, mag(C(XX, XY))/scale);
         }
 
+        if (allLinearElastic)
+        {
+            reportError
+            (
+                "the tangent matches the closed-form isotropic stiffness",
+                maxRelError,
+                1e-12
+            );
+        }
+        else
+        {
+            Info<< "    SKIP: closed-form isotropic stiffness "
+                << "(not all materials are linearElastic)" << endl;
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // 7. Finite-difference fourth-order tangent
+    // ---------------------------------------------------------------------
+
+    Info<< nl << "7. Finite-difference fourth-order tangent" << endl;
+
+    {
+        List<mat66> fdC(nInternalDualFaces);
+        List<mat66> fdCagain(nInternalDualFaces);
+
+        manager.updateTangentSmallStrain
+        (
+            dualTopo, dualGradD, dualGradD0, dt,
+            nullptr, &fdC, tangentRequest::fourthOrderFiniteDifference
+        );
+
+        if (allLinearElastic)
+        {
+            // Compare against the analytical tangent rather than a
+            // hand-written closed form, so the check is on the finite
+            // difference itself, including its Voigt shear convention
+            List<mat66> analyticC(nInternalDualFaces);
+
+            manager.updateTangentSmallStrain
+            (
+                dualTopo, dualGradD, dualGradD0, dt,
+                nullptr, &analyticC, tangentRequest::fourthOrder
+            );
+
+            scalar maxRelError = 0.0;
+            forAll(fdC, dualFaceI)
+            {
+                const label cellI = dualFaceToCell[dualFaceI];
+                const scalar scale = refLambda[cellI] + 2.0*refMu[cellI];
+
+                for (label i = 0; i < 6; ++i)
+                {
+                    for (label j = 0; j < 6; ++j)
+                    {
+                        maxRelError =
+                            max
+                            (
+                                maxRelError,
+                                mag
+                                (
+                                    fdC[dualFaceI](i, j)
+                                  - analyticC[dualFaceI](i, j)
+                                )/scale
+                            );
+                    }
+                }
+            }
+
+            reportError("matches the analytical tangent", maxRelError, 1e-6);
+        }
+
+        // With no analytical tangent to compare against, require that the
+        // finite difference is finite and that repeating it gives exactly the
+        // same answer. For a history-dependent law that is a direct check that
+        // the perturbed evaluations left no trace in the state
+        manager.updateTangentSmallStrain
+        (
+            dualTopo, dualGradD, dualGradD0, dt,
+            nullptr, &fdCagain, tangentRequest::fourthOrderFiniteDifference
+        );
+
+        bool finiteAndRepeatable = true;
+        forAll(fdC, dualFaceI)
+        {
+            for (label i = 0; i < 6; ++i)
+            {
+                for (label j = 0; j < 6; ++j)
+                {
+                    const scalar a = fdC[dualFaceI](i, j);
+
+                    if (a != a || mag(a) > GREAT)
+                    {
+                        finiteAndRepeatable = false;
+                    }
+
+                    if (a != fdCagain[dualFaceI](i, j))
+                    {
+                        finiteAndRepeatable = false;
+                    }
+                }
+            }
+        }
+
+        report
+        (
+            "is finite and exactly repeatable",
+            finiteAndRepeatable
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // 8. A tangent query leaves the constitutive state alone
+    // ---------------------------------------------------------------------
+
+    Info<< nl << "8. Tangent queries preserve constitutive state" << endl;
+
+    {
+        // A law is a function of the kinematics and the OLD-time state, so a
+        // stress evaluated straight after a tangent query cannot see anything
+        // the query wrote: it recomputes from the same history. The damage a
+        // query can do is to the CURRENT-time fields, which endTimeStep()
+        // reads and which storeOldTime() promotes to history at the next time
+        // step. So the query has to be straddled by a time step to be seen.
+        symmTensorField sigmaA(nInternalDualFaces, symmTensor::zero);
+        symmTensorField sigmaB(nInternalDualFaces, symmTensor::zero);
+
+        // Establish history at the working strain
+        manager.updateStressSmallStrain
+        (
+            dualTopo, dualGradD, dualGradD0, dt, sigmaA
+        );
+
+        // A tangent query at a strain far beyond the working one. Left in the
+        // current-time fields, this is what would be committed below
+        tensorField wildGradD(nInternalDualFaces, tensor::zero);
+        forAll(wildGradD, i)
+        {
+            wildGradD[i] = 50.0*dualGradD[i];
+        }
+
+        scalarField throwaway(nInternalDualFaces, 0.0);
+        List<mat66> throwawayC(nInternalDualFaces);
+
+        manager.updateTangentSmallStrain
+        (
+            dualTopo, wildGradD, dualGradD0, dt,
+            &throwaway, nullptr, tangentRequest::scalar
+        );
+
+        if (allLinearElastic)
+        {
+            manager.updateTangentSmallStrain
+            (
+                dualTopo, wildGradD, dualGradD0, dt,
+                nullptr, &throwawayC, tangentRequest::fourthOrder
+            );
+        }
+
+        manager.updateTangentSmallStrain
+        (
+            dualTopo, wildGradD, dualGradD0, dt,
+            nullptr, &throwawayC, tangentRequest::fourthOrderFiniteDifference
+        );
+
+        // Cross a time step, which commits the current-time fields to history,
+        // then evaluate the same strain again
+        runTime++;
+
+        manager.updateStressSmallStrain
+        (
+            dualTopo, dualGradD, dualGradD0, dt, sigmaB
+        );
+
         reportError
         (
-            "the tangent matches the closed-form isotropic stiffness",
-            maxRelError,
+            "the same strain gives the same stress across a committed "
+            "time step",
+            relativeDifference(sigmaA, sigmaB),
             1e-12
         );
     }
 
     // ---------------------------------------------------------------------
-    // 7. Misuse guards
+    // 9. updateScalarTangent, the cell-centred convenience form
     // ---------------------------------------------------------------------
 
-    Info<< nl << "7. Misuse guards" << endl;
+    Info<< nl << "9. Cell-centred scalar tangent query" << endl;
+
+    {
+        volScalarField queriedImpK
+        (
+            IOobject
+            (
+                "queriedImpK",
+                runTime.timeName(),
+                mesh,
+                IOobject::NO_READ,
+                IOobject::NO_WRITE
+            ),
+            mesh,
+            dimensionedScalar("0", dimPressure, 0.0)
+        );
+
+        manager.updateScalarTangent
+        (
+            gradD, gradD0, dt, queriedImpK, tangentRequest::scalar
+        );
+
+        reportError
+        (
+            "agrees with the tangent from the stress update",
+            relativeDifference
+            (
+                Foam::primitiveField(impK), Foam::primitiveField(queriedImpK)
+            ),
+            1e-15
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // 10. Misuse guards
+    // ---------------------------------------------------------------------
+
+    Info<< nl << "10. Misuse guards" << endl;
 
     {
         symmTensorField scratch(mesh.nCells(), symmTensor::zero);

--- a/src/solids4FoamModels/mechanicalConstitutiveLaw/DESIGN-tangents.md
+++ b/src/solids4FoamModels/mechanicalConstitutiveLaw/DESIGN-tangents.md
@@ -358,10 +358,23 @@ obtain a tangent today is to also perform a stress update, which would write to
         );
 ```
 
-The state copy is the price of the "a tangent query never mutates state"
-invariant. It is paid once at construction and then at most once every N outer
-iterations, so it is not on the hot path. `mechanicalConstitutiveLawState` is
-`Field`-based and copyable, so this is a handful of `Field` copies per law.
+**Correction, from PR-3.** The copy described above is both heavier than
+necessary and was not expressible: `mechanicalConstitutiveLawState` had copy
+construction and assignment `= delete`d. What is implemented instead is a
+*shadow*: a state that aliases the parent's old-time fields, which are
+read-only through it, and owns its own current-time fields.
+
+This works because a constitutive law is a pure function of the kinematics and
+the old-time state. `evaluate()` reads only `*0` fields and writes only
+current-time fields; the plastic law's `sigmaY` is an output, with the trial
+value coming from `yieldStress(epsilonPEq0[i])`. History is therefore read-only
+during evaluation, so copying it is waste. A shadow costs one set of
+current-time fields and no copy of history, and the invariant becomes
+structural: a shadow *cannot* write history because it does not own it, and
+says so with a `FatalError` if asked.
+
+The same mechanism serves the finite-difference tangent, which is the other
+consumer that must not disturb state. See §8.9.
 
 **Lifecycle, stated explicitly (this reproduces today's behaviour exactly):**
 
@@ -1498,7 +1511,7 @@ Supersedes the stage numbering in §5. Content is otherwise as described there.
 |---|---|
 | 1 | **Done.** Defect fixes D1, D4, D5 and the `(4/3)*mu` change of §8.2 including `linGeomTotalDispSolid.C:574`; the `petscSnesPressure` u-p regression case; `planeStress` injection (§8.1) and support in the three new laws; `supportsFourthOrderTangent()` + manager guard. D3 is left to PR-2, which deletes the line. plateHole, wobblyNewton and perforatedPlate all pass. |
 | 2 | **Done.** Flat-list `updateStressSmallStrain`/`updateStressFiniteStrain`/`updateTangentSmallStrain`/`updateTangentFiniteStrain` primitives, with the two `CompactListList` overloads and the internal-field half of the two `volTensorField` overloads re-expressed on them; `registerTopology()` and `topologyFor()` made public; `dualFaceIntegrationPointTopology`; defect D6. Plus `Test-mechanicalConstitutiveLaw`, run by the `layeredPipe` regression test. See §8.6. |
-| 3 | `solidModel::jacobianTangent(deflt)`; `approximateJacobian` deprecation shim; optional manager owned by `solidModel` behind `useMechanicalConstitutiveLawManager` (default `no`). |
+| 3 | **Done.** `solidModel::jacobianTangent(deflt)` and the `approximateJacobian` deprecation shim, used by both vertex-centred solvers; the shadow state of §3.1; a working `fourthOrderFiniteDifference` tangent. The optional manager on `solidModel` moves to PR-4. See §8.8. |
 | 4 | `vertexCentredLinGeomSolid` tangent-only adoption (§8.4). |
 | 5 | `vertexCentredNonLinGeomTotalLagSolid` tangent-only; then stress for both, removing `dualMechanicalModel` and requiring OQ-2 to be settled. |
 | 6 | `hofvm::divSigmaIntoPETScMatrix(mat66)` + uniform-tangent fast path; delete the `(impK_-K)*3/4` back-derivation from the three cell-centred solvers. |
@@ -1618,7 +1631,66 @@ framework *runs* correctly on foam-extend, only that it compiles — the
 and its `FOAMEXTEND` guard should be removed as soon as the framework builds
 there.
 
-### 8.8 Open questions still outstanding
+### 8.8 Notes from PR-3
+
+**The shadow state, and why not a copy.** §3.1 is corrected above. The one
+thing worth restating: the threat a tangent query poses is not to history, which
+`evaluate()` never writes, but to the **current-time** fields, which
+`endTimeStep()` reads and which `storeOldTime()` promotes to history at the next
+time step. A tangent query therefore needs somewhere to put a law's *outputs*,
+not a copy of its *inputs*.
+
+**A latent contract violation this exposed.** The plastic law reached its
+old-time fields through the non-const accessor, e.g.
+`state.symmTensorField0("epsilonP")`, because `state` is a non-const reference
+and overload resolution then picks the create-and-modify overload. The shadow's
+guard rejected it immediately. Fixed by reading history through
+`getSymmTensorField0()` / `getScalarField0()`, which say what is meant. The rule
+is now enforced rather than assumed: **inside `evaluate()`, read `*0` fields
+only through the `get*` accessors, and write only current-time fields.**
+
+**`fourthOrderFiniteDifference` did not work at all.** It contained a
+`FatalErrorInFunction` placeholder reading "In FD material tangent, make copy of
+state", and separately computed each finite-difference column but never wrote it
+into the `mat66`. This settles OQ-5: the mode was advertised in `README.md` but
+could not run. It is now implemented.
+
+**It is evaluated field-wise, not point-wise.** The original sketch looped six
+Voigt components inside a loop over integration points, i.e. `6*N` calls into
+the law with one-element views. It now perturbs every integration point at once
+and calls the law six times in total. Same arithmetic, one sixth of the calls,
+better vectorisation, and one shadow for the whole assembly instead of one per
+point.
+
+**The perturbation convention was wrong for shear.** `gradDPerturbed` added `h`
+to both off-diagonals of `gradD`, which moves `eps_xy` by `h` and therefore the
+engineering shear `gamma_xy = 2*eps_xy` by `2h`. Against an analytical `mat66`
+where `C(XY,XY)` is `mu`, the finite difference came out a factor of two high on
+every shear column. The perturbation is now defined on the Voigt strain vector:
+a shear component moves each off-diagonal by `h/2`. Verified by comparing the
+finite-difference and analytical tangents for `linearElastic`, which now agree
+to 4e-10.
+
+**The plastic law now supports a finite-difference tangent** and refuses an
+analytical `fourthOrder` one with a message pointing at the alternative.
+Previously it silently ignored a fourth-order request and left the caller's
+`List<mat66>` holding uninitialised memory.
+
+**A test that looked right and proved nothing.** The first version of the
+state-preservation check evaluated a stress, took tangent queries at wildly
+perturbed kinematics, evaluated the same stress again, and required the two to
+agree. They always do - with or without the shadow - precisely because a law
+recomputes current-time state from old-time state. Disabling the shadow did not
+fail it. The check now straddles a time step, so that `storeOldTime()` commits
+whatever the queries left behind; without the shadow it fails by 114%.
+
+**Deferred from PR-3.** §8.5 also listed an optional manager owned by
+`solidModel` behind `useMechanicalConstitutiveLawManager`. It is left to PR-4,
+which is where the first consumer appears: it is inert on its own, and the
+question of which dictionary object the manager is constructed from is better
+answered next to a caller than in the abstract.
+
+### 8.9 Open questions still outstanding
 
 OQ-1 (restart `impK` state-dependence), OQ-3 (configurable `impKf_` cadence),
 OQ-5 (`fourthOrderFiniteDifference` production status), OQ-6 (stabilisation term

--- a/src/solids4FoamModels/mechanicalConstitutiveLaw/README.md
+++ b/src/solids4FoamModels/mechanicalConstitutiveLaw/README.md
@@ -194,8 +194,22 @@ The flat-list form is the primitive: the `volField` and `CompactListList`
 overloads are implemented in terms of it, and it is the only form that works on
 storage belonging to a mesh other than the manager's own, such as a dual mesh.
 There are also tangent-only updates, `updateTangentSmallStrain` and
-`updateTangentFiniteStrain`, for solid models that take their Jacobian from the
-manager while their residual stress still comes from elsewhere.
+`updateTangentFiniteStrain`, plus `updateScalarTangent` for the cell-centred
+case, for solid models that take their Jacobian from the manager while their
+residual stress still comes from elsewhere.
+
+A tangent query never disturbs constitutive state. Each law is evaluated
+against a **shadow** of its state, which aliases the parent's old-time fields -
+read-only through it - and owns its own current-time fields. This works because
+a law is a pure function of the kinematics and the old-time state: it reads
+only `*0` fields, through the `get*` accessors, and writes only current-time
+fields. History is never copied, only aliased, so the cost is one set of
+current-time fields.
+
+The same mechanism makes the `fourthOrderFiniteDifference` tangent safe: it
+evaluates the law once per Voigt strain component at perturbed kinematics, and
+those perturbed results must not be left where `endTimeStep()` can read them or
+`storeOldTime()` can commit them.
 
 The manager is **discretisation-agnostic**.
 
@@ -302,10 +316,14 @@ closed-form linear elastic stress and tangent, agreement between the flat-list,
 dual-face topology addressing and its fourth-order tangent, and the misuse
 guards.
 
-It requires every material to be `linearElastic`, and is run by the
-`layeredPipe` tutorial's `regressionTest.sh`, that being the only tutorial with
-more than one material. No solid model uses this framework yet, so that is
-currently its only runtime coverage.
+The closed-form checks need every material to be `linearElastic`; the rest
+apply to any law. It is run by two tutorials' `regressionTest.sh`:
+`layeredPipe`, the only one with more than one material, and `perforatedPlate`,
+the only one whose material is history dependent and so the only place a
+tangent query has any history to disturb.
+
+No solid model sources its stress or tangent from this framework yet, so that
+is currently its only runtime coverage.
 
 ---
 

--- a/src/solids4FoamModels/mechanicalConstitutiveLaw/mechanicalConstitutiveLawManager.C
+++ b/src/solids4FoamModels/mechanicalConstitutiveLaw/mechanicalConstitutiveLawManager.C
@@ -877,7 +877,7 @@ void Foam::mechanicalConstitutiveLawManager::resetMaterialPropertyFields()
 }
 
 
-void Foam::mechanicalConstitutiveLawManager::updateStressSmallStrain
+void Foam::mechanicalConstitutiveLawManager::evaluateSmallStrain
 (
     const integrationPointTopology& topo,
     const UList<tensor>& gradD,
@@ -886,7 +886,8 @@ void Foam::mechanicalConstitutiveLawManager::updateStressSmallStrain
     UList<symmTensor>& stress,
     UList<scalar>* scalarTangentPtr,
     UList<mat66>* fourthOrderTangentPtr,
-    const tangentRequest tangentReq
+    const tangentRequest tangentReq,
+    const bool preserveState
 )
 {
     const word context = "updateStressSmallStrain (flat list)";
@@ -949,6 +950,25 @@ void Foam::mechanicalConstitutiveLawManager::updateStressSmallStrain
             continue;
         }
 
+        // A tangent query evaluates against a shadow of the law's state: the
+        // shadow aliases the old-time fields, so history is read but never
+        // written, and the law's outputs land where they are discarded
+        autoPtr<mechanicalConstitutiveLawState> shadowPtr;
+        if (preserveState)
+        {
+            shadowPtr.set
+            (
+                new mechanicalConstitutiveLawState
+                (
+                    tp.states_[lawI],
+                    mechanicalConstitutiveLawState::SHADOW
+                )
+            );
+        }
+
+        mechanicalConstitutiveLawState& lawState =
+            preserveState ? shadowPtr() : tp.states_[lawI];
+
         // Views into integration-point data (no copies)
         const UIndirectList<tensor> gradDView(gradD, ipIDs);
         const UIndirectList<tensor> gradD0View(gradD0, ipIDs);
@@ -970,7 +990,7 @@ void Foam::mechanicalConstitutiveLawManager::updateStressSmallStrain
                 stressView, tangentView, tangentReq
             );
 
-            laws_[lawI].evaluate(kin, tp.states_[lawI], response);
+            laws_[lawI].evaluate(kin, lawState, response);
         }
         else if (needsFourthOrderTangent(tangentReq))
         {
@@ -981,19 +1001,19 @@ void Foam::mechanicalConstitutiveLawManager::updateStressSmallStrain
                 stressView, tangentView, tangentReq
             );
 
-            laws_[lawI].evaluate(kin, tp.states_[lawI], response);
+            laws_[lawI].evaluate(kin, lawState, response);
         }
         else
         {
             mechanicalConstitutiveLawResponse response(stressView, tangentReq);
 
-            laws_[lawI].evaluate(kin, tp.states_[lawI], response);
+            laws_[lawI].evaluate(kin, lawState, response);
         }
     }
 }
 
 
-void Foam::mechanicalConstitutiveLawManager::updateStressFiniteStrain
+void Foam::mechanicalConstitutiveLawManager::evaluateFiniteStrain
 (
     const integrationPointTopology& topo,
     const UList<tensor>& F,
@@ -1006,7 +1026,8 @@ void Foam::mechanicalConstitutiveLawManager::updateStressFiniteStrain
     UList<symmTensor>& stress,
     UList<scalar>* scalarTangentPtr,
     UList<mat66>* fourthOrderTangentPtr,
-    const tangentRequest tangentReq
+    const tangentRequest tangentReq,
+    const bool preserveState
 )
 {
     const word context = "updateStressFiniteStrain (flat list)";
@@ -1071,6 +1092,25 @@ void Foam::mechanicalConstitutiveLawManager::updateStressFiniteStrain
             continue;
         }
 
+        // A tangent query evaluates against a shadow of the law's state: the
+        // shadow aliases the old-time fields, so history is read but never
+        // written, and the law's outputs land where they are discarded
+        autoPtr<mechanicalConstitutiveLawState> shadowPtr;
+        if (preserveState)
+        {
+            shadowPtr.set
+            (
+                new mechanicalConstitutiveLawState
+                (
+                    tp.states_[lawI],
+                    mechanicalConstitutiveLawState::SHADOW
+                )
+            );
+        }
+
+        mechanicalConstitutiveLawState& lawState =
+            preserveState ? shadowPtr() : tp.states_[lawI];
+
         // Views into integration-point data (no copies)
         const UIndirectList<tensor> FView(F, ipIDs);
         const UIndirectList<tensor> F0View(F0, ipIDs);
@@ -1102,7 +1142,7 @@ void Foam::mechanicalConstitutiveLawManager::updateStressFiniteStrain
                 stressView, tangentView, tangentReq
             );
 
-            laws_[lawI].evaluate(kin, tp.states_[lawI], response);
+            laws_[lawI].evaluate(kin, lawState, response);
         }
         else if (needsFourthOrderTangent(tangentReq))
         {
@@ -1113,15 +1153,77 @@ void Foam::mechanicalConstitutiveLawManager::updateStressFiniteStrain
                 stressView, tangentView, tangentReq
             );
 
-            laws_[lawI].evaluate(kin, tp.states_[lawI], response);
+            laws_[lawI].evaluate(kin, lawState, response);
         }
         else
         {
             mechanicalConstitutiveLawResponse response(stressView, tangentReq);
 
-            laws_[lawI].evaluate(kin, tp.states_[lawI], response);
+            laws_[lawI].evaluate(kin, lawState, response);
         }
     }
+}
+
+
+void Foam::mechanicalConstitutiveLawManager::updateStressSmallStrain
+(
+    const integrationPointTopology& topo,
+    const UList<tensor>& gradD,
+    const UList<tensor>& gradD0,
+    const scalar dt,
+    UList<symmTensor>& stress,
+    UList<scalar>* scalarTangentPtr,
+    UList<mat66>* fourthOrderTangentPtr,
+    const tangentRequest tangentReq
+)
+{
+    evaluateSmallStrain
+    (
+        topo,
+        gradD,
+        gradD0,
+        dt,
+        stress,
+        scalarTangentPtr,
+        fourthOrderTangentPtr,
+        tangentReq,
+        false           // commit the constitutive state
+    );
+}
+
+
+void Foam::mechanicalConstitutiveLawManager::updateStressFiniteStrain
+(
+    const integrationPointTopology& topo,
+    const UList<tensor>& F,
+    const UList<tensor>& F0,
+    const UList<tensor>& Finv,
+    const UList<tensor>& Finv0,
+    const UList<scalar>& J,
+    const UList<scalar>& J0,
+    const scalar dt,
+    UList<symmTensor>& stress,
+    UList<scalar>* scalarTangentPtr,
+    UList<mat66>* fourthOrderTangentPtr,
+    const tangentRequest tangentReq
+)
+{
+    evaluateFiniteStrain
+    (
+        topo,
+        F,
+        F0,
+        Finv,
+        Finv0,
+        J,
+        J0,
+        dt,
+        stress,
+        scalarTangentPtr,
+        fourthOrderTangentPtr,
+        tangentReq,
+        false           // commit the constitutive state
+    );
 }
 
 
@@ -1146,7 +1248,7 @@ void Foam::mechanicalConstitutiveLawManager::updateTangentSmallStrain
 
     // A constitutive law produces a stress alongside its tangent, so give it
     // somewhere to put one that is not the caller's storage
-    updateStressSmallStrain
+    evaluateSmallStrain
     (
         topo,
         gradD,
@@ -1155,7 +1257,8 @@ void Foam::mechanicalConstitutiveLawManager::updateTangentSmallStrain
         scratchStress(topo.nIntegrationPoints()),
         scalarTangentPtr,
         fourthOrderTangentPtr,
-        tangentReq
+        tangentReq,
+        true            // preserve the constitutive state
     );
 }
 
@@ -1185,7 +1288,7 @@ void Foam::mechanicalConstitutiveLawManager::updateTangentFiniteStrain
 
     // A constitutive law produces a stress alongside its tangent, so give it
     // somewhere to put one that is not the caller's storage
-    updateStressFiniteStrain
+    evaluateFiniteStrain
     (
         topo,
         F,
@@ -1198,8 +1301,54 @@ void Foam::mechanicalConstitutiveLawManager::updateTangentFiniteStrain
         scratchStress(topo.nIntegrationPoints()),
         scalarTangentPtr,
         fourthOrderTangentPtr,
+        tangentReq,
+        true            // preserve the constitutive state
+    );
+}
+
+
+void Foam::mechanicalConstitutiveLawManager::updateScalarTangent
+(
+    const volTensorField& gradD,
+    const volTensorField& gradD0,
+    const scalar dt,
+    volScalarField& scalarTangent,
+    const tangentRequest tangentReq
+)
+{
+    checkMeshConsistency(mesh_, gradD.mesh(), gradD.name());
+    checkMeshConsistency(mesh_, gradD0.mesh(), gradD0.name());
+    checkMeshConsistency(mesh_, scalarTangent.mesh(), scalarTangent.name());
+
+    if (!needsScalarTangent(tangentReq))
+    {
+        FatalErrorInFunction
+            << "updateScalarTangent was asked for a "
+            << tangentRequestName(tangentReq) << " tangent." << nl
+            << "This interface returns a scalar tangent at cell centres, so "
+            << "the request must be scalar or scalarDeviatoric."
+            << exit(FatalError);
+    }
+
+    const integrationPointTopology& topo =
+        topologyFor(cellCentredIntegrationPointTopology::typeName);
+
+    scalarField& tangent = Foam::primitiveFieldRef(scalarTangent);
+
+    updateTangentSmallStrain
+    (
+        topo,
+        Foam::primitiveField(gradD),
+        Foam::primitiveField(gradD0),
+        dt,
+        &tangent,
+        nullptr,
         tangentReq
     );
+
+#ifndef OPENFOAM_ORG
+    scalarTangent.correctBoundaryConditions();
+#endif
 }
 
 

--- a/src/solids4FoamModels/mechanicalConstitutiveLaw/mechanicalConstitutiveLawManager.H
+++ b/src/solids4FoamModels/mechanicalConstitutiveLaw/mechanicalConstitutiveLawManager.H
@@ -326,6 +326,41 @@ class mechanicalConstitutiveLawManager
              || req == tangentRequest::fourthOrderFiniteDifference;
         }
 
+        //- Flat-list small-strain evaluation.
+        //  Shared implementation of the public stress and tangent-only
+        //  updates. With preserveState, each law is evaluated against a
+        //  shadow of its state, so history is read but never written
+        void evaluateSmallStrain
+        (
+            const integrationPointTopology& topo,
+            const UList<tensor>& gradD,
+            const UList<tensor>& gradD0,
+            const scalar dt,
+            UList<symmTensor>& stress,
+            UList<scalar>* scalarTangentPtr,
+            UList<mat66>* fourthOrderTangentPtr,
+            const tangentRequest tangentReq,
+            const bool preserveState
+        );
+
+        //- Finite-strain counterpart of evaluateSmallStrain
+        void evaluateFiniteStrain
+        (
+            const integrationPointTopology& topo,
+            const UList<tensor>& F,
+            const UList<tensor>& F0,
+            const UList<tensor>& Finv,
+            const UList<tensor>& Finv0,
+            const UList<scalar>& J,
+            const UList<scalar>& J0,
+            const scalar dt,
+            UList<symmTensor>& stress,
+            UList<scalar>* scalarTangentPtr,
+            UList<mat66>* fourthOrderTangentPtr,
+            const tangentRequest tangentReq,
+            const bool preserveState
+        );
+
         //- Check that the requested tangent can be provided at the integration
         //  points of the given topology for the current set of laws
         void checkTangentRequest
@@ -488,18 +523,33 @@ public:
             const tangentRequest tangentReq = tangentRequest::none
         );
 
+        //- Evaluate only the requested scalar tangent at cell centres,
+        //  modifying nothing else.
+        //  Each law is evaluated against a shadow of its constitutive state,
+        //  so history is read but never written, and the stress goes to
+        //  manager-owned scratch storage. Neither the caller's fields nor any
+        //  history variable is disturbed.
+        //  Intended for solid models that need an implicit stiffness
+        //  coefficient at construction time, before any stress update has been
+        //  performed, or at a chosen refresh cadence between updates
+        void updateScalarTangent
+        (
+            const volTensorField& gradD,
+            const volTensorField& gradD0,
+            const scalar dt,
+            volScalarField& scalarTangent,
+            const tangentRequest tangentReq = tangentRequest::scalar
+        );
+
         //- Evaluate only the requested small-strain tangent at the integration
         //  points of the supplied topology, leaving the caller's stress
         //  storage untouched.
         //  This is for solid models that take their Jacobian from the manager
         //  while their residual stress still comes from elsewhere, which is the
         //  intended migration path.
-        //  Note that the constitutive state of this topology is advanced
-        //  exactly as the corresponding updateStress call would advance it: a
-        //  law computes its tangent and its stress together. For a history-
-        //  dependent law this is only harmless because the topology used for
-        //  the Jacobian carries its own state, separate from the topology used
-        //  for the residual
+        //  Each law is evaluated against a shadow of its constitutive state,
+        //  so a tangent query never disturbs history, whichever topology it is
+        //  made on
         void updateTangentSmallStrain
         (
             const integrationPointTopology& topo,

--- a/src/solids4FoamModels/mechanicalConstitutiveLaw/mechanicalConstitutiveLawState.C
+++ b/src/solids4FoamModels/mechanicalConstitutiveLaw/mechanicalConstitutiveLawState.C
@@ -181,10 +181,41 @@ const Field<Type>& mechanicalConstitutiveLawState::getField
 }
 
 
+void mechanicalConstitutiveLawState::checkNotShadow(const word& what) const
+{
+    if (isShadow())
+    {
+        FatalErrorInFunction
+            << "'" << what << "' would modify history through a shadow state."
+            << nl
+            << "A shadow aliases the old-time fields of its parent so that a "
+            << "tangent query can evaluate a law without disturbing them. "
+            << "Only current-time fields may be written through a shadow."
+            << exit(FatalError);
+    }
+}
+
+
+template<class Type>
+const HashTable<autoPtr<Field<Type>>>&
+mechanicalConstitutiveLawState::readableFields0() const
+{
+    // A shadow reads its parent's history, never its own
+    if (isShadow())
+    {
+        return shadowedPtr_->readableFields0<Type>();
+    }
+
+    return fields0<Type>();
+}
+
+
 // * * * * * * * * * * * * Public interface * * * * * * * * * * * * * * * //
 
 void mechanicalConstitutiveLawState::setSize(const label newSize)
 {
+    checkNotShadow("setSize");
+
     size_ = newSize;
 
     forAllIter(HashTable<autoPtr<Field<scalar>>>, scalarFields_, iter)
@@ -225,6 +256,8 @@ void mechanicalConstitutiveLawState::setSize(const label newSize)
 
 void mechanicalConstitutiveLawState::storeOldTime()
 {
+    checkNotShadow("storeOldTime");
+
     // Scalars
 #ifdef OPENFOAM_COM
     forAllConstIters(scalarFields0_, iter)
@@ -319,6 +352,8 @@ const Field<scalar>& mechanicalConstitutiveLawState::scalarField
 
 Field<scalar>& mechanicalConstitutiveLawState::scalarField0(const word& name)
 {
+    checkNotShadow("scalarField0");
+
     return accessField(fields0<scalar>(), name);
 }
 
@@ -327,7 +362,7 @@ const Field<scalar>& mechanicalConstitutiveLawState::scalarField0
     const word& name
 ) const
 {
-    return getField(fields0<scalar>(), name);
+    return getField(readableFields0<scalar>(), name);
 }
 
 const Field<scalar>& mechanicalConstitutiveLawState::getScalarField
@@ -343,7 +378,7 @@ const Field<scalar>& mechanicalConstitutiveLawState::getScalarField0
     const word& name
 ) const
 {
-    return getField(fields0<scalar>(), name);
+    return getField(readableFields0<scalar>(), name);
 }
 
 
@@ -364,6 +399,8 @@ const Field<vector>& mechanicalConstitutiveLawState::vectorField
 
 Field<vector>& mechanicalConstitutiveLawState::vectorField0(const word& name)
 {
+    checkNotShadow("vectorField0");
+
     return accessField(fields0<vector>(), name);
 }
 
@@ -372,7 +409,7 @@ const Field<vector>& mechanicalConstitutiveLawState::vectorField0
     const word& name
 ) const
 {
-    return getField(fields0<vector>(), name);
+    return getField(readableFields0<vector>(), name);
 }
 
 const Field<vector>& mechanicalConstitutiveLawState::getVectorField
@@ -388,7 +425,7 @@ const Field<vector>& mechanicalConstitutiveLawState::getVectorField0
     const word& name
 ) const
 {
-    return getField(fields0<vector>(), name);
+    return getField(readableFields0<vector>(), name);
 }
 
 
@@ -409,6 +446,8 @@ const Field<tensor>& mechanicalConstitutiveLawState::tensorField
 
 Field<tensor>& mechanicalConstitutiveLawState::tensorField0(const word& name)
 {
+    checkNotShadow("tensorField0");
+
     return accessField(fields0<tensor>(), name);
 }
 
@@ -417,7 +456,7 @@ const Field<tensor>& mechanicalConstitutiveLawState::tensorField0
     const word& name
 ) const
 {
-    return getField(fields0<tensor>(), name);
+    return getField(readableFields0<tensor>(), name);
 }
 
 const Field<tensor>& mechanicalConstitutiveLawState::getTensorField
@@ -433,7 +472,7 @@ const Field<tensor>& mechanicalConstitutiveLawState::getTensorField0
     const word& name
 ) const
 {
-    return getField(fields0<tensor>(), name);
+    return getField(readableFields0<tensor>(), name);
 }
 
 
@@ -460,6 +499,8 @@ Field<symmTensor>& mechanicalConstitutiveLawState::symmTensorField0
     const word& name
 )
 {
+    checkNotShadow("symmTensorField0");
+
     return accessField(fields0<symmTensor>(), name);
 }
 
@@ -468,7 +509,7 @@ const Field<symmTensor>& mechanicalConstitutiveLawState::symmTensorField0
     const word& name
 ) const
 {
-    return getField(fields0<symmTensor>(), name);
+    return getField(readableFields0<symmTensor>(), name);
 }
 
 const Field<symmTensor>& mechanicalConstitutiveLawState::getSymmTensorField
@@ -484,7 +525,7 @@ const Field<symmTensor>& mechanicalConstitutiveLawState::getSymmTensorField0
     const word& name
 ) const
 {
-    return getField(fields0<symmTensor>(), name);
+    return getField(readableFields0<symmTensor>(), name);
 }
 
 } // End namespace Foam

--- a/src/solids4FoamModels/mechanicalConstitutiveLaw/mechanicalConstitutiveLawState.H
+++ b/src/solids4FoamModels/mechanicalConstitutiveLaw/mechanicalConstitutiveLawState.H
@@ -82,6 +82,12 @@ class mechanicalConstitutiveLawState
 
         label size_;
 
+        //- Parent state shadowed by this one, or nullptr if this state owns
+        //  its history.
+        //  A shadow aliases the parent's old-time fields, which are read-only
+        //  through it, and owns its own current-time fields
+        const mechanicalConstitutiveLawState* shadowedPtr_;
+
 
     // Private helper interface
 
@@ -113,6 +119,15 @@ class mechanicalConstitutiveLawState
         ) const;
 
 
+        //- Fatal error if this state is a shadow, for operations that would
+        //  write history
+        void checkNotShadow(const word& what) const;
+
+        //- The old-time table to read from: the parent's when shadowing
+        template<class Type>
+        const HashTable<autoPtr<Field<Type>>>& readableFields0() const;
+
+
     // No copy
 
         mechanicalConstitutiveLawState
@@ -124,11 +139,48 @@ class mechanicalConstitutiveLawState
 
 public:
 
+    // Public Types
+
+        //- Tag selecting the shadow constructor.
+        //  Copy construction stays deleted: a shadow is not a copy, and the
+        //  distinction matters enough to be spelled out at the call site
+        enum shadowType
+        {
+            SHADOW
+        };
+
+
     // Constructors
 
         explicit mechanicalConstitutiveLawState(const label size = 0)
         :
-            size_(size)
+            size_(size),
+            shadowedPtr_(nullptr)
+        {}
+
+        //- Construct a shadow of another state.
+        //  The shadow aliases the parent's old-time fields, which are
+        //  read-only through it, and owns its own current-time fields.
+        //  A constitutive law is a function of the kinematics and the old-time
+        //  state: it reads only old-time fields and writes only current-time
+        //  fields. Evaluating a law into a shadow therefore produces the
+        //  correct answer while leaving every one of the parent's fields
+        //  untouched, which is exactly what a tangent query needs - including
+        //  a finite-difference tangent, which evaluates repeatedly at
+        //  perturbed kinematics and must not leave those perturbed values
+        //  where endTimeStep() can read them or storeOldTime() can commit them.
+        //  History is aliased rather than copied because it is only ever read,
+        //  so the cost is one set of current-time fields and no copy of the
+        //  parent's history.
+        //  The parent must outlive the shadow
+        mechanicalConstitutiveLawState
+        (
+            const mechanicalConstitutiveLawState& parent,
+            const shadowType
+        )
+        :
+            size_(parent.size()),
+            shadowedPtr_(&parent)
         {}
 
 
@@ -137,6 +189,12 @@ public:
         label size() const
         {
             return size_;
+        }
+
+        //- Is this state a shadow of another?
+        bool isShadow() const
+        {
+            return shadowedPtr_ != nullptr;
         }
 
 

--- a/src/solids4FoamModels/mechanicalConstitutiveLaw/mechanicalConstitutiveLawTangentRequest.H
+++ b/src/solids4FoamModels/mechanicalConstitutiveLaw/mechanicalConstitutiveLawTangentRequest.H
@@ -90,6 +90,42 @@ inline const word tangentRequestName
     return "unknown";
 }
 
+
+// Return the tangent request with the given name.
+// Written by hand rather than with NamedEnum or Enum, whose interfaces differ
+// between the supported forks
+inline tangentRequest tangentRequestNamed(const word& name)
+{
+    if (name == "none")
+    {
+        return tangentRequest::none;
+    }
+    else if (name == "scalar")
+    {
+        return tangentRequest::scalar;
+    }
+    else if (name == "scalarDeviatoric")
+    {
+        return tangentRequest::scalarDeviatoric;
+    }
+    else if (name == "fourthOrder")
+    {
+        return tangentRequest::fourthOrder;
+    }
+    else if (name == "fourthOrderFiniteDifference")
+    {
+        return tangentRequest::fourthOrderFiniteDifference;
+    }
+
+    FatalErrorInFunction
+        << "Unknown tangent request '" << name << "'." << nl
+        << "Valid options are: none, scalar, scalarDeviatoric, fourthOrder, "
+        << "fourthOrderFiniteDifference"
+        << exit(FatalError);
+
+    return tangentRequest::none;
+}
+
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
 } // End namespace Foam

--- a/src/solids4FoamModels/mechanicalConstitutiveLaw/mechanicalConstitutiveLaws/linearElasticMisesPlasticMechanicalConstitutiveLaw/linearElasticMisesPlasticMechanicalConstitutiveLaw.C
+++ b/src/solids4FoamModels/mechanicalConstitutiveLaw/mechanicalConstitutiveLaws/linearElasticMisesPlasticMechanicalConstitutiveLaw/linearElasticMisesPlasticMechanicalConstitutiveLaw.C
@@ -244,10 +244,12 @@ void Foam::linearElasticMisesPlasticMechanicalConstitutiveLaw::evaluate
 
     // State (current + old-time)
     Field<symmTensor>& epsilonP = state.symmTensorField("epsilonP");
-    const Field<symmTensor>& epsilonP0 = state.symmTensorField0("epsilonP");
+    const Field<symmTensor>& epsilonP0 =
+        state.getSymmTensorField0("epsilonP");
 
     Field<scalar>& epsilonPEq = state.scalarField("epsilonPEq");
-    const Field<scalar>& epsilonPEq0 = state.scalarField0("epsilonPEq");
+    const Field<scalar>& epsilonPEq0 =
+        state.getScalarField0("epsilonPEq");
 
     // Optional yield stress state (handy for debugging/post-proc)
     Field<scalar>& sigmaY = state.scalarField("sigmaY");
@@ -431,6 +433,24 @@ void Foam::linearElasticMisesPlasticMechanicalConstitutiveLaw::evaluate
             }
         }
     }
+
+    // Fourth-order tangent.
+    // There is no analytical consistent tangent for this law yet, but the
+    // finite-difference tangent of the base class is well defined for any law
+    // and is evaluated against a shadow state, so it neither disturbs the
+    // return mapping just performed nor the history it started from
+    if (response.tangentReq() == tangentRequest::fourthOrderFiniteDifference)
+    {
+        finiteDifferenceFourthOrder(kin, state, response);
+    }
+    else if (response.tangentReq() == tangentRequest::fourthOrder)
+    {
+        FatalErrorInFunction
+            << "An analytical fourth-order tangent is not implemented for "
+            << type() << "." << nl
+            << "Use 'fourthOrderFiniteDifference' to obtain one by finite "
+            << "differences." << exit(FatalError);
+    }
 }
 
 
@@ -442,7 +462,8 @@ void Foam::linearElasticMisesPlasticMechanicalConstitutiveLaw::endTimeStep
 ) const
 {
     const Field<scalar>& epsilonPEq = state.scalarField("epsilonPEq");
-    const Field<scalar>& epsilonPEq0 = state.scalarField0("epsilonPEq");
+    const Field<scalar>& epsilonPEq0 =
+        state.getScalarField0("epsilonPEq");
 
     label nYielding = 0;
     scalar curDEpsilonPEq = 0.0;

--- a/src/solids4FoamModels/mechanicalConstitutiveLaw/mechanicalConstitutiveLaws/mechanicalConstitutiveLaw/mechanicalConstitutiveLaw.C
+++ b/src/solids4FoamModels/mechanicalConstitutiveLaw/mechanicalConstitutiveLaws/mechanicalConstitutiveLaw/mechanicalConstitutiveLaw.C
@@ -60,62 +60,91 @@ void Foam::mechanicalConstitutiveLaw::finiteDifferenceFourthOrder
     const scalar hMin = 1e-8;
     const scalar hRel = 1e-6;
 
-    auto& stress = response.stress();
-    auto& Cfield = response.fourthOrderTangent();
+    UIndirectList<symmTensor>& stress = response.stress();
+    UIndirectList<mat66>& Cfield = response.fourthOrderTangent();
 
-    forAll(stress, ipI)
+    const label nIP = stress.size();
+
+    if (nIP == 0)
     {
-        // Scale the perturbation with the local displacement gradient
-        const scalar h = max(hMin, hRel*mag(kin.gradD()[ipI]));
+        return;
+    }
 
-        mat66& C = Cfield[ipI];
-        C.clear();   // mat66 is not zero-initialised
+    // The unperturbed stress, which the caller has already evaluated into the
+    // response. Taking a copy leaves the caller's storage untouched below
+    const Field<symmTensor> sigma0(stress);
 
-        // Copy of the base stress
-        symmTensor sigma0 = stress[ipI];
+    // Per-integration-point perturbation, scaled with the local gradient
+    Field<scalar> h(nIP);
+    forAll(h, ipI)
+    {
+        h[ipI] = max(hMin, hRel*mag(kin.gradD()[ipI]));
+    }
 
-        // Single-entry addressing
-        labelList addr(1, 0);
+    // Evaluate the perturbed states into a shadow of the caller's state. The
+    // shadow aliases the old-time fields, so each perturbed evaluation starts
+    // from the same history - which is what a consistent tangent means - and
+    // writes its outputs where they are discarded. Without this the last
+    // perturbed evaluation would be left in the current-time fields, to be
+    // read by endTimeStep() and committed by the next storeOldTime()
+    mechanicalConstitutiveLawState shadow
+    (
+        state, mechanicalConstitutiveLawState::SHADOW
+    );
 
-        // Loop over Voigt strain components
-        for (label j = 0; j < 6; ++j)
+    // Work storage. The perturbation is applied to every integration point at
+    // once and the law evaluated once per Voigt component, rather than six
+    // times per integration point: same arithmetic, one sixth of the calls
+    Field<tensor> gradDPert(nIP);
+    Field<symmTensor> sigmaPert(nIP, symmTensor::zero);
+
+    // Identity addressing, so the work fields can be presented as the
+    // UIndirectList views the kinematics and response wrappers expect
+    labelList addr(nIP);
+    forAll(addr, ipI)
+    {
+        addr[ipI] = ipI;
+    }
+
+    const UIndirectList<tensor> gradDPertView(gradDPert, addr);
+    UIndirectList<symmTensor> sigmaPertView(sigmaPert, addr);
+
+    forAll(Cfield, ipI)
+    {
+        // mat66 is not zero-initialised
+        Cfield[ipI].clear();
+    }
+
+    // Loop over the Voigt strain components
+    for (label j = 0; j < 6; ++j)
+    {
+        forAll(gradDPert, ipI)
         {
-            // Perturb gradD (copy)
-            tensor gPert = kin.gradDPerturbed(ipI, j, h);
+            gradDPert[ipI] = kin.gradDPerturbed(ipI, j, h[ipI]);
+        }
 
-            UList<tensor> gradDBuf(&gPert, 1);
-            UIndirectList<tensor> gradDView(gradDBuf, addr);
+        smallStrainMechanicalConstitutiveLawKinematics kinPert
+        (
+            gradDPertView, kin.gradD0(), kin.dt()
+        );
 
-            // Unperturbed gradD0
-            // The const_cast is safe as we do not modify g0
-            const tensor& g0 = kin.gradD0()[ipI];
-            UList<tensor> gradD0Buf(const_cast<tensor*>(&g0), 1);
-            UIndirectList<tensor> gradD0View(gradD0Buf, addr);
+        mechanicalConstitutiveLawResponse respPert
+        (
+            sigmaPertView, tangentRequest::none
+        );
 
-            // Output stress
-            symmTensor sigmaPert = symmTensor::zero;
-            UList<symmTensor> stressBuf(&sigmaPert, 1);
-            UIndirectList<symmTensor> stressView(stressBuf, addr);
+        evaluate(kinPert, shadow, respPert);
 
-            // Kinematics (standard constructor)
-            smallStrainMechanicalConstitutiveLawKinematics kinPert
-            (
-                gradDView, gradD0View, kin.dt()
-            );
+        // Column j of the tangent
+        forAll(Cfield, ipI)
+        {
+            mat66& C = Cfield[ipI];
+            const symmTensor ds((sigmaPert[ipI] - sigma0[ipI])/h[ipI]);
 
-            mechanicalConstitutiveLawResponse respPert
-            (
-                stressView, tangentRequest::none
-            );
-
-            // FIX!!! WE MUST MAKE A COPY OF THE STATE!
-            FatalErrorInFunction
-                << "In FD material tangent, make copy of state"
-                << exit(FatalError);
-            evaluate(kinPert, state, respPert);
-
-            // Finite difference column
-            const symmTensor ds((sigmaPert - sigma0)/h);
+            for (label i = 0; i < 6; ++i)
+            {
+                C(i, j) = ds[i];
+            }
         }
     }
 }

--- a/src/solids4FoamModels/mechanicalConstitutiveLaw/smallStrainMechanicalConstitutiveLawKinematics.H
+++ b/src/solids4FoamModels/mechanicalConstitutiveLaw/smallStrainMechanicalConstitutiveLawKinematics.H
@@ -163,6 +163,14 @@ public:
         //  h = perturbation magnitude
         //  This can be used for calculating material tangents with finite
         //  differences
+        //- Return gradD at integration point ipI with Voigt strain component
+        //  j perturbed by h.
+        //  The perturbation is defined on the Voigt strain vector, which uses
+        //  engineering shear: gamma_xy = 2*eps_xy. A shear component therefore
+        //  moves each off-diagonal of gradD by h/2, so that the corresponding
+        //  Voigt component moves by exactly h. This is what makes a
+        //  finite-difference tangent directly comparable with an analytical
+        //  one, where for isotropic elasticity C(XY,XY) is mu rather than 2*mu
         inline tensor gradDPerturbed
         (
             const label ipI, const label j, const scalar h
@@ -196,18 +204,18 @@ public:
                     break;
 
                 case symmTensor::YZ:
-                    g.yz() += h;
-                    g.zy() += h;
+                    g.yz() += 0.5*h;
+                    g.zy() += 0.5*h;
                     break;
 
                 case symmTensor::XZ:
-                    g.xz() += h;
-                    g.zx() += h;
+                    g.xz() += 0.5*h;
+                    g.zx() += 0.5*h;
                     break;
 
                 case symmTensor::XY:
-                    g.xy() += h;
-                    g.yx() += h;
+                    g.xy() += 0.5*h;
+                    g.yx() += 0.5*h;
                     break;
 
                 default:

--- a/src/solids4FoamModels/solidModels/solidModel/solidModel.C
+++ b/src/solids4FoamModels/solidModels/solidModel/solidModel.C
@@ -2179,4 +2179,46 @@ const Foam::dictionary& Foam::solidModel::solidModelDict() const
     return solidProperties_.subDict(type_ + "Coeffs");
 }
 
+
+Foam::tangentRequest Foam::solidModel::jacobianTangent
+(
+    const tangentRequest deflt
+) const
+{
+    const dictionary& dict = solidModelDict();
+
+    if (dict.found("approximateJacobian"))
+    {
+        if (dict.found("jacobianTangent"))
+        {
+            FatalIOErrorInFunction(dict)
+                << "Both 'approximateJacobian' and 'jacobianTangent' are set."
+                << nl
+                << "'approximateJacobian' is deprecated: use "
+                << "'jacobianTangent' only."
+                << exit(FatalIOError);
+        }
+
+        const Switch approximate(dict.lookup("approximateJacobian"));
+
+        const tangentRequest req =
+            approximate
+          ? tangentRequest::scalar
+          : tangentRequest::fourthOrder;
+
+        WarningInFunction
+            << "'approximateJacobian' is deprecated. Replace it with "
+            << "'jacobianTangent " << tangentRequestName(req) << ";'" << endl;
+
+        return req;
+    }
+
+    if (!dict.found("jacobianTangent"))
+    {
+        return deflt;
+    }
+
+    return tangentRequestNamed(word(dict.lookup("jacobianTangent")));
+}
+
 // ************************************************************************* //

--- a/src/solids4FoamModels/solidModels/solidModel/solidModel.H
+++ b/src/solids4FoamModels/solidModels/solidModel/solidModel.H
@@ -56,6 +56,7 @@ SourceFiles
 #include "compatibilityFunctions.H"
 #include "stabilisationModel.H"
 #include "CompactListList.H"
+#include "mechanicalConstitutiveLawTangentRequest.H"
 #ifdef OPENFOAM_COM
     #include "Enum.H"
     #include "fvOptions.H"
@@ -598,6 +599,22 @@ public:
                     solutionAlg() == solutionAlgorithm::PETSC_SNES
                  && highOrderJacobian_;
             }
+
+            //- Requested fidelity of the material tangent used to build the
+            //  Jacobian, from the 'jacobianTangent' entry of the solid model
+            //  coefficients dictionary.
+            //  Each solid model supplies its own default, because today's
+            //  defaults differ: the cell-centred models want a scalar tangent,
+            //  the vertex-centred ones a fourth-order one. Existing cases
+            //  therefore keep their behaviour without dictionary changes.
+            //  This entry is orthogonal to highOrderJacobian(), which selects
+            //  a different discrete operator rather than a tangent fidelity.
+            //  The deprecated 'approximateJacobian' switch is still read, and
+            //  maps yes to scalar and no to fourthOrder
+            tangentRequest jacobianTangent
+            (
+                const tangentRequest deflt
+            ) const;
 
             //- Is it a new time step? This function return true the first time
             //  it is called in a time step

--- a/src/solids4FoamModels/solidModels/vertexCentredLinGeomSolid/vertexCentredLinGeomSolid.C
+++ b/src/solids4FoamModels/solidModels/vertexCentredLinGeomSolid/vertexCentredLinGeomSolid.C
@@ -1309,7 +1309,13 @@ label vertexCentredLinGeomSolid::formJacobian
     // Calculate stress at dual faces
     dualMechanicalPtr_().correct(dualSigmaf_);
 
-    if (solidModelDict().lookupOrDefault<Switch>("approximateJacobian", false))
+    // Fidelity of the material tangent used to build the Jacobian. The
+    // default reproduces the previous behaviour, which was
+    // 'approximateJacobian' defaulting to false, i.e. a full material tangent
+    const tangentRequest jacTangent =
+        jacobianTangent(tangentRequest::fourthOrder);
+
+    if (jacTangent == tangentRequest::scalar)
     {
         // Add laplacian term as a compact approximate linearisation of
         // div(sigma)
@@ -1324,6 +1330,15 @@ label vertexCentredLinGeomSolid::formJacobian
             dualImpKf(),
             false           // flip sign
         );
+    }
+    else if (jacTangent != tangentRequest::fourthOrder)
+    {
+        FatalErrorInFunction
+            << "jacobianTangent " << tangentRequestName(jacTangent)
+            << " is not supported by " << type() << "." << nl
+            << "This solid model assembles its Jacobian either from a scalar "
+            << "tangent or from a full fourth-order material tangent."
+            << exit(FatalError);
     }
     else
     {

--- a/src/solids4FoamModels/solidModels/vertexCentredNonLinGeomTotalLagSolid/vertexCentredNonLinGeomTotalLagSolid.C
+++ b/src/solids4FoamModels/solidModels/vertexCentredNonLinGeomTotalLagSolid/vertexCentredNonLinGeomTotalLagSolid.C
@@ -1661,7 +1661,13 @@ label vertexCentredNonLinGeomTotalLagSolid::formJacobian
     // Calculate stress at dual faces
     dualMechanicalPtr_().correct(dualSigmaf_);
 
-    if (solidModelDict().lookupOrDefault<Switch>("approximateJacobian", false))
+    // Fidelity of the material tangent used to build the Jacobian. The
+    // default reproduces the previous behaviour, which was
+    // 'approximateJacobian' defaulting to false, i.e. a full material tangent
+    const tangentRequest jacTangent =
+        jacobianTangent(tangentRequest::fourthOrder);
+
+    if (jacTangent == tangentRequest::scalar)
     {
         // Add laplacian term as a compact approximate linearisation of
         // div(sigma)
@@ -1676,6 +1682,15 @@ label vertexCentredNonLinGeomTotalLagSolid::formJacobian
             dualImpKf(),
             false           // flip sign
         );
+    }
+    else if (jacTangent != tangentRequest::fourthOrder)
+    {
+        FatalErrorInFunction
+            << "jacobianTangent " << tangentRequestName(jacTangent)
+            << " is not supported by " << type() << "." << nl
+            << "This solid model assembles its Jacobian either from a scalar "
+            << "tangent or from a full fourth-order material tangent."
+            << exit(FatalError);
     }
     else
     {

--- a/tutorials/solids/elastoplasticity/perforatedPlate/regressionTest.sh
+++ b/tutorials/solids/elastoplasticity/perforatedPlate/regressionTest.sh
@@ -124,6 +124,45 @@ else
     failures=$((failures + 1))
 fi
 
+# Exercise the mechanicalConstitutiveLawManager on this case. It is the only
+# tutorial in the regression set whose material is history dependent, so it is
+# the only one where a tangent query has any history to disturb
+run_constitutive_test() {
+    if ! command -v Test-mechanicalConstitutiveLaw > /dev/null 2>&1; then
+        echo "SKIP: Test-mechanicalConstitutiveLaw not found in PATH"
+        return 0
+    fi
+
+    if [[ ! -d "${CASE_DIR}/constant/polyMesh" ]]; then
+        echo "SKIP: mechanicalConstitutiveLaw checks (case has no mesh)"
+        return 0
+    fi
+
+    if ( cd "${CASE_DIR}" && Test-mechanicalConstitutiveLaw \
+            > "log.Test-mechanicalConstitutiveLaw" 2>&1 )
+    then
+        local n_passed
+        n_passed=$(grep -c 'PASS:' \
+            "${CASE_DIR}/log.Test-mechanicalConstitutiveLaw" || true)
+
+        if (( n_passed == 0 )); then
+            echo "SKIP: mechanicalConstitutiveLaw checks (not built on this fork)"
+            return 0
+        fi
+
+        echo "PASS: mechanicalConstitutiveLaw checks (${n_passed} checks)"
+        return 0
+    fi
+
+    echo "FAIL: mechanicalConstitutiveLaw checks"
+    grep 'FAIL:' "${CASE_DIR}/log.Test-mechanicalConstitutiveLaw" || true
+    return 1
+}
+
+if ! run_constitutive_test; then
+    failures=$((failures + 1))
+fi
+
 # Clean case again
 ( cd "${CASE_DIR}" && ./Allclean > /dev/null 2>&1 ) || true
 


### PR DESCRIPTION
## What this adds 🚀

Stacked on #198 — **review that one first**; this PR targets its branch.

Three things, in the order they matter:

### 1. A constitutive law can be evaluated without disturbing its state

A tangent query has to evaluate a law; a finite-difference tangent has to
evaluate it six times at perturbed strains. Neither may leave a trace.

The design called for evaluating against a *copy* of the state. That turned out
to be both heavier than needed and not expressible — copy construction was
`= delete`d. What is implemented instead is a **shadow**: it aliases the
parent's old-time fields, read-only through it, and owns its own current-time
fields.

This is sound because a law is a pure function of the kinematics and the
old-time state — it reads only `*0` fields and writes only current-time fields.
History is read-only during evaluation, so copying it is waste. The invariant
also becomes structural rather than documentary: a shadow *cannot* write
history because it does not own it.

The threat is worth stating precisely, because it is not the obvious one: a
tangent query cannot corrupt history, which `evaluate()` never writes. It can
corrupt the **current-time** fields, which `endTimeStep()` reads and which
`storeOldTime()` promotes to history at the next time step.

### 2. `fourthOrderFiniteDifference` now works

It could not run. The implementation contained

```c++
// FIX!!! WE MUST MAKE A COPY OF THE STATE!
FatalErrorInFunction << "In FD material tangent, make copy of state"
```

and separately computed each finite-difference column but never wrote it into
the `mat66` — while being advertised as a tangent mode in the framework README.

It is now implemented, evaluated **field-wise**: the original sketch looped six
Voigt components inside a loop over integration points, i.e. `6*N` calls into
the law with one-element views. Perturbing every point at once costs the same
arithmetic in six calls total, vectorises better, and needs one shadow for the
whole assembly.

One convention bug fixed on the way: `gradDPerturbed` added `h` to both
off-diagonals of `gradD`, moving `eps_xy` by `h` and so the engineering shear
`gamma_xy = 2*eps_xy` by `2h`. Against an analytical `mat66`, where `C(XY,XY)`
is `mu` rather than `2*mu`, every shear column came out a factor of two high.
The perturbation is now defined on the Voigt strain vector. Finite-difference
and analytical tangents for `linearElastic` now agree to **4e-10**.

The plastic law gains a finite-difference tangent, and refuses an analytical
one with a message pointing at the alternative. Previously it silently ignored
a fourth-order request and left the caller's `List<mat66>` holding
uninitialised memory.

### 3. `jacobianTangent`, replacing `approximateJacobian`

A dictionary entry selecting tangent fidelity, with per-solid-model defaults so
no existing case changes behaviour. It subsumes `approximateJacobian`, which
was a Boolean spelling of the same scalar-versus-`mat66` axis; the old entry is
still read and mapped, with one warning, and setting both is an error. It stays
orthogonal to `highOrderJacobian`, which selects a different discrete operator.

Both vertex-centred solvers now go through it, so the mapping is exercised
rather than merely defined.

---

## Testing ✅

Regression suites, all passing with unchanged numbers: `layeredPipe`,
`perforatedPlate`, `plateHole` (4 approaches), `wobblyNewton`, `cantilever2d`.
That last one sets `approximateJacobian no` and now emits exactly one
deprecation warning while still selecting a fourth-order tangent.

`Test-mechanicalConstitutiveLaw` is generalised beyond `linearElastic` and now
also runs from `perforatedPlate` — the only material in the regression set with
history for a tangent query to disturb. The elastic-only case had been hiding
that gap entirely.

**One test needed a second attempt, and it is worth a reviewer's attention.**
The first state-preservation check evaluated a stress, took tangent queries at
wildly perturbed kinematics, evaluated the same stress again, and required
agreement. That always holds — with or without the shadow — because a law
recomputes current-time state from old-time state. Disabling the shadow did not
fail it. The check now straddles a time step, so `storeOldTime()` commits
whatever the queries left behind; with the shadow disabled it fails by 114%.

Builds clean on OpenFOAM-v2512 and foam-extend-4.1 (isolated worktree).

---

## Deferred

§8.5 also listed an optional manager owned by `solidModel` behind
`useMechanicalConstitutiveLawManager`. It moves to the next increment, where
the first consumer appears: it is inert on its own, and which dictionary object
the manager is constructed from is better settled next to a caller.

---

## Where to look 🔍

- `mechanicalConstitutiveLawState.H` — the shadow, and whether the law contract
  it depends on is one we are happy to enforce.
- `mechanicalConstitutiveLaw.C` — the finite-difference tangent.
- `smallStrainMechanicalConstitutiveLawKinematics.H` — the Voigt shear
  convention.
- §3.1 and §8.8 of `DESIGN-tangents.md`.
