### PR TITLE
Source the implicit stiffness from the framework in linGeomTotalDispSolid

### DIFF
--- a/src/solids4FoamModels/mechanicalConstitutiveLaw/DESIGN-tangents.md
+++ b/src/solids4FoamModels/mechanicalConstitutiveLaw/DESIGN-tangents.md
@@ -1816,7 +1816,39 @@ stress for `vertexCentredLinGeomSolid` alone. The priority after that moves to
 the cell-centred solid models and their high-order variants, which are the ones
 in common use.
 
-### 8.12 Open questions still outstanding
+### 8.12 Notes from the first cell-centred adoption
+
+`linGeomTotalDispSolid` now sources `impK` - and `rKappa` - from the framework
+behind `useMechanicalConstitutiveLawManager`, default `no`. `impKf_` and
+`rImpK_` stay derived from `impK_` exactly as before, `impK_` is still
+registered under `"impK"` for the contact and cohesive-zone models that look it
+up by name, and the stress still comes from `mechanicalModel`.
+
+**Byte-identical with the switch on**, on `plateHole` (linear elastic) and on
+`perforatedPlate` (elastoplastic, twenty time steps), including the yielding
+diagnostics. The switch was confirmed to engage rather than the agreement being
+vacuous: the framework constructs a law only in the manager runs.
+
+The elastoplastic case agreeing exactly is worth understanding rather than just
+noting. `impK_` is frozen at construction, and on a cold start the constitutive
+state is zero, so the legacy state-dependent `impK()` and the framework's
+tangent query are evaluated at the same state. That is OQ-1 restated: the
+agreement is exact from a cold start and would not be from a restart, for
+either implementation, because both freeze a state-dependent quantity at
+construction.
+
+`plateHole` gains a `segregatedManager` approach so the path has continuous
+coverage rather than a one-off manual check.
+
+**A gap this found in `updateScalarTangent`.** The flat-list primitive fills
+internal integration points only, so the returned `volScalarField` had a
+zero boundary field, and the first thing this caller does is form `1/impK_` -
+a floating point exception in the constructor. The manager now fills each
+non-coupled patch from its patch-internal value, which is exact for a scalar
+tangent because a boundary face belongs to its owner cell's material, then
+syncs the coupled patches. Any cell-centred caller would have hit this.
+
+### 8.13 Open questions still outstanding
 
 OQ-1 (restart `impK` state-dependence), OQ-3 (configurable `impKf_` cadence),
 OQ-5 (`fourthOrderFiniteDifference` production status), OQ-6 (stabilisation term

--- a/src/solids4FoamModels/mechanicalConstitutiveLaw/mechanicalConstitutiveLawManager.C
+++ b/src/solids4FoamModels/mechanicalConstitutiveLaw/mechanicalConstitutiveLawManager.C
@@ -1384,7 +1384,23 @@ void Foam::mechanicalConstitutiveLawManager::updateScalarTangent
         tangentReq
     );
 
+    // The flat-list primitive fills internal integration points only, so give
+    // the boundary usable values. A scalar tangent is a per-cell material
+    // property, and a boundary face belongs to the material of its owner cell,
+    // so taking the patch-internal value is exact rather than an
+    // approximation. Without this the boundary stays at whatever the field was
+    // constructed with, which a caller forming 1/tangent then divides by
+    forAll(scalarTangent.boundaryField(), patchI)
+    {
+        if (!scalarTangent.boundaryField()[patchI].coupled())
+        {
+            Foam::boundaryFieldRef(scalarTangent)[patchI] =
+                scalarTangent.boundaryField()[patchI].patchInternalField();
+        }
+    }
+
 #ifndef OPENFOAM_ORG
+    // Sync the coupled patches
     scalarTangent.correctBoundaryConditions();
 #endif
 }

--- a/src/solids4FoamModels/solidModels/linGeomTotalDispSolid/linGeomTotalDispSolid.C
+++ b/src/solids4FoamModels/solidModels/linGeomTotalDispSolid/linGeomTotalDispSolid.C
@@ -544,6 +544,109 @@ bool linGeomTotalDispSolid::evolveExplicit()
 }
 
 
+Foam::mechanicalConstitutiveLawManager&
+Foam::solidModels::linGeomTotalDispSolid::mechanicalManager() const
+{
+    if (mechanicalManagerPtr_.empty())
+    {
+        // mechanicalModel is itself the mechanicalProperties IOdictionary, so
+        // both frameworks are built from exactly the same entries
+        mechanicalManagerPtr_.set
+        (
+            new mechanicalConstitutiveLawManager(mesh(), mechanical())
+        );
+    }
+
+    return mechanicalManagerPtr_();
+}
+
+
+Foam::tmp<Foam::volScalarField>
+Foam::solidModels::linGeomTotalDispSolid::makeImpK() const
+{
+    // For the mixed displacement-pressure formulation the implicit stiffness
+    // is the scalar Laplacian surrogate for div(dev(sigma)), which is
+    // mu*lap(D) + (1/3)*mu*grad(div(D)), i.e. (4/3)*mu
+    const tangentRequest req =
+        solvePressure()
+      ? tangentRequest::scalarDeviatoric
+      : tangentRequest::scalar;
+
+    if (!useMechanicalConstitutiveLawManager_)
+    {
+        if (solvePressure())
+        {
+            return tmp<volScalarField>
+            (
+                new volScalarField((4.0/3.0)*mechanical().shearModulus())
+            );
+        }
+
+        return mechanical().impK();
+    }
+
+    // Match the legacy field exactly in name, dimensions and boundary types:
+    // it is registered under "impK" and looked up by that name by the contact
+    // and cohesive zone models
+    tmp<volScalarField> tImpK
+    (
+        new volScalarField
+        (
+            IOobject
+            (
+                "impK",
+                mesh().time().timeName(),
+                mesh(),
+                IOobject::NO_READ,
+                IOobject::NO_WRITE
+            ),
+            mesh(),
+            dimensionedScalar("zero", dimForce/dimArea, 0),
+            calculatedFvPatchScalarField::typeName
+        )
+    );
+
+#ifdef OPENFOAM_NOT_EXTEND
+    volScalarField& impK = tImpK.ref();
+#else
+    volScalarField& impK = tImpK();
+#endif
+
+    // A tangent query, so it neither writes a stress nor disturbs history.
+    // Evaluated at the current gradient, which is zero on a cold start and the
+    // restart value otherwise - the same state dependence the legacy impK()
+    // has, since it is likewise frozen at construction
+    mechanicalManager().updateScalarTangent
+    (
+        gradD(),
+        gradD().oldTime(),
+        mesh().time().deltaTValue(),
+        impK,
+        req
+    );
+
+    return tImpK;
+}
+
+
+Foam::tmp<Foam::volScalarField>
+Foam::solidModels::linGeomTotalDispSolid::makeRKappa() const
+{
+    if (!useMechanicalConstitutiveLawManager_)
+    {
+        return tmp<volScalarField>
+        (
+            new volScalarField(1.0/mechanical().bulkModulus())
+        );
+    }
+
+    return tmp<volScalarField>
+    (
+        new volScalarField(1.0/mechanicalManager().kappa())
+    );
+}
+
+
 // * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
 
 linGeomTotalDispSolid::linGeomTotalDispSolid
@@ -568,20 +671,18 @@ linGeomTotalDispSolid::linGeomTotalDispSolid
         solidModelDict().lookupOrDefault<Switch>("stopOnPetscError", true),
         bool(solutionAlg() == solutionAlgorithm::PETSC_SNES)
     ),
-    impK_
+    useMechanicalConstitutiveLawManager_
     (
-        // Note: for the mixed displacement-pressure formulation, the implicit
-        // stiffness is the scalar Laplacian surrogate for div(dev(sigma)),
-        // which is mu*lap(D) + (1/3)*mu*grad(div(D)), i.e. (4/3)*mu.
-        // This matches tangentRequest::scalarDeviatoric in the
-        // mechanicalConstitutiveLaw framework
-        solvePressure()
-      ? (4.0/3.0)*mechanical().shearModulus()
-      : mechanical().impK()
+        solidModelDict().lookupOrDefault<Switch>
+        (
+            "useMechanicalConstitutiveLawManager", false
+        )
     ),
+    mechanicalManagerPtr_(),
+    impK_(makeImpK()),
     impKf_(fvc::interpolate(impK_)),
     rImpK_(1.0/impK_),
-    rKappa_(1.0/mechanical().bulkModulus()),
+    rKappa_(makeRKappa()),
     A_
     (
         IOobject

--- a/src/solids4FoamModels/solidModels/linGeomTotalDispSolid/linGeomTotalDispSolid.H
+++ b/src/solids4FoamModels/solidModels/linGeomTotalDispSolid/linGeomTotalDispSolid.H
@@ -37,6 +37,7 @@ SourceFiles
 #define linGeomTotalDispSolid_H
 
 #include "solidModel.H"
+#include "mechanicalConstitutiveLawManager.H"
 #include "volFields.H"
 #include "surfaceFields.H"
 #include "pointFields.H"
@@ -65,6 +66,19 @@ class linGeomTotalDispSolid
     public foamPetscSnesHelper
 {
     // Private data
+
+        //- Take the implicit stiffness from the mechanical constitutive law
+        //  framework rather than from the legacy mechanicalModel.
+        //  Opt-in, and declared before impK_ so that it is set when impK_ is
+        //  constructed.
+        //  impK is a Jacobian and a stabilisation coefficient, not a material
+        //  response, so this changes the convergence path and the size of a
+        //  stabilisation term that vanishes under mesh refinement. The stress
+        //  still comes from mechanicalModel either way
+        const Switch useMechanicalConstitutiveLawManager_;
+
+        //- Mechanical constitutive law manager, when the above is set
+        mutable autoPtr<mechanicalConstitutiveLawManager> mechanicalManagerPtr_;
 
         //- Implicit stiffness; coefficient of the Laplacian term
         //  The value of this term only affects convergence and not the answer
@@ -97,6 +111,18 @@ class linGeomTotalDispSolid
         volScalarField ds_;
 
     // Private Member Functions
+
+        //- Return the mechanical constitutive law manager, constructing it on
+        //  first use
+        mechanicalConstitutiveLawManager& mechanicalManager() const;
+
+        //- Return the implicit stiffness, from the constitutive law framework
+        //  when useMechanicalConstitutiveLawManager_ is set and from the
+        //  legacy mechanicalModel otherwise
+        tmp<volScalarField> makeImpK() const;
+
+        //- Return the reciprocal of the bulk modulus, from the same source
+        tmp<volScalarField> makeRKappa() const;
 
         //- Predict the fields for the next time-step based on the
         //  previous time-steps

--- a/tutorials/solids/linearElasticity/plateHole/Allrun
+++ b/tutorials/solids/linearElasticity/plateHole/Allrun
@@ -5,7 +5,8 @@ IFS=$'\n\t'
 # -------------------------------------------------------------------------
 # solids4Foam Allrun script
 # Allows selection of solution approach:
-#   segregated (default), petscSnes, petscSnesPressure, highOrder
+#   segregated (default), segregatedManager, petscSnes,
+#   petscSnesPressure, highOrder
 #   pressureDisplacementCompressible [coarse|medium]
 #   pressureDisplacementIncompressible [coarse|medium]
 # -------------------------------------------------------------------------
@@ -19,11 +20,13 @@ Where [approach] is one of:
   segregated                           (default)
   petscSnes
   petscSnesPressure
+  segregatedManager
   highOrder
   pressureDisplacementCompressible
   pressureDisplacementIncompressible
 
-For segregated|petscSnes|petscSnesPressure|highOrder, the second argument is
+For segregated|segregatedManager|petscSnes|petscSnesPressure|highOrder, the
+second argument is
 the run mode:
   serial                               (default)
   parallel
@@ -38,6 +41,7 @@ Examples:
   ./Allrun segregated
   ./Allrun petscSnes parallel
   ./Allrun petscSnesPressure
+  ./Allrun segregatedManager
   ./Allrun highOrder
   ./Allrun pressureDisplacementCompressible medium
   ./Allrun pressureDisplacementIncompressible medium
@@ -72,7 +76,7 @@ if [[ "${APPROACH}" == "parallel" ]]; then
 fi
 
 case "${APPROACH}" in
-    segregated|petscSnes|petscSnesPressure|highOrder)
+    segregated|segregatedManager|petscSnes|petscSnesPressure|highOrder)
         RUN_MODE="${ARG2:-serial}"
         case "${RUN_MODE}" in
             serial|parallel) ;;
@@ -198,6 +202,13 @@ select_approach() {
             echo "Using the petscSnes approach"
             link_files_for_suffix "petscSnes"
             ;;
+        segregatedManager)
+            echo "Using the segregated approach with the constitutive law manager"
+            link_files_for_suffix "segregated"
+            rm -f constant/solidProperties
+            ln -s solidProperties.segregatedManager constant/solidProperties
+            ;;
+
         petscSnesPressure)
             echo "Using the petscSnes approach with the mixed"\
                  "displacement-pressure formulation"
@@ -236,7 +247,7 @@ echo
 solids4Foam::runApplication blockMesh
 
 case "${APPROACH}" in
-    segregated|petscSnes|petscSnesPressure|highOrder)
+    segregated|segregatedManager|petscSnes|petscSnesPressure|highOrder)
         if [[ "${RUN_MODE}" == "parallel" ]]; then
             solids4Foam::runApplication decomposePar
             solids4Foam::runParallel solids4Foam

--- a/tutorials/solids/linearElasticity/plateHole/constant/solidProperties.segregatedManager
+++ b/tutorials/solids/linearElasticity/plateHole/constant/solidProperties.segregatedManager
@@ -1,0 +1,48 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| solids4foam: solid mechanics and fluid-solid interaction simulations        |
+| Version:     v2.4                                                           |
+| Web:         https://solids4foam.github.io                                  |
+| Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
+|              producer and distributor of the OpenFOAM software via          |
+|              www.openfoam.com, and owner of the OPENFOAM® and OpenCFD®      |
+|              trade marks.                                                   |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "constant";
+    object      solidProperties;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+// linearGeometry: assumes small strains and rotations
+solidModel     linearGeometryTotalDisplacement;
+//solidModel     unsLinearGeometry;
+
+"linearGeometryTotalDisplacementCoeffs|linearGeometryTotalDisplacementCoeffs|unsLinearGeometryCoeffs"
+{
+    // Take the implicit stiffness from the mechanical constitutive law
+    // framework instead of the legacy mechanicalModel. impK is a Jacobian and
+    // a stabilisation coefficient, so this is expected to leave the answer
+    // alone; for a linear elastic material it is bit-for-bit identical
+    useMechanicalConstitutiveLawManager yes;
+
+    // Maximum number of momentum correctors
+    nCorrectors     1000;
+
+    // Solution tolerance for displacement
+    solutionTolerance 1e-06;
+
+    // Alternative solution tolerance for displacement
+    alternativeTolerance 1e-07;
+
+    // Material law solution tolerance
+    materialTolerance 1e-05;
+
+    // Write frequency for the residuals
+    infoFrequency   100;
+}
+
+// ************************************************************************* //

--- a/tutorials/solids/linearElasticity/plateHole/regressionTest.sh
+++ b/tutorials/solids/linearElasticity/plateHole/regressionTest.sh
@@ -42,6 +42,7 @@ ALLRUN_LOGFILE="log.Allrun"
 
 APPROACHES=(
     segregated
+    segregatedManager
     petscSnes
     petscSnesPressure
     highOrder


### PR DESCRIPTION
## What this adds 🚀

Stacked on #403 → #402 → #198. **Review those first.**

The first **cell-centred** solid model to take anything from the mechanical
constitutive law framework, which is the priority now that the vertex-centred
nonlinear path is set aside. `linGeomTotalDispSolid` sources `impK` and
`rKappa` from the manager behind `useMechanicalConstitutiveLawManager`,
default `no`.

What stays exactly as it was: `impKf_` and `rImpK_` are still derived from
`impK_`; `impK_` keeps its registered name `"impK"`, which the contact and
cohesive-zone models look up by string; and the stress still comes from
`mechanicalModel`. `impK` is a Jacobian and a stabilisation coefficient, not a
material response, so the expectation was that this moves the convergence path
at most.

**It does not move even that.** Byte-identical with the switch on:

| Case | Material | Result |
|---|---|---|
| `plateHole` | linear elastic | all output fields identical |
| `perforatedPlate` | elastoplastic, 20 steps | all output fields identical, yielding diagnostics included |

I checked the obvious way that could be a false pass — the switch never
engaging. It isn't: the framework constructs a law only in the manager runs.

The elastoplastic case agreeing *exactly* is worth understanding rather than
just noting. `impK_` is frozen at construction and the constitutive state is
zero on a cold start, so the legacy state-dependent `impK()` and the
framework's tangent query are evaluated at the same state. That is OQ-1
restated, and it belongs to the legacy path just as much: both freeze a
state-dependent quantity at construction, so neither reproduces itself across a
restart.

`plateHole` gains a `segregatedManager` approach, so this has continuous
coverage instead of a one-off manual check. It reproduces `segregated` to the
last digit on all three metrics.

## A gap this exposed 🐛

`updateScalarTangent` returned a `volScalarField` with a **zero boundary
field**, because the flat-list primitive fills internal integration points
only. The first thing this caller does is form `1/impK_` — a floating point
exception in the constructor.

The manager now fills each non-coupled patch from its patch-internal value,
which is exact for a scalar tangent since a boundary face belongs to its owner
cell's material, then syncs the coupled patches. Any cell-centred caller would
have hit this, so it is fixed in the manager rather than worked around here.

## Testing ✅

Full regression set passes unchanged: `plateHole` (5 approaches now),
`layeredPipe`, `perforatedPlate`, `wobblyNewton`, `cantilever2d`. Builds clean
on OpenFOAM-v2512 and foam-extend-4.1.
