### PR TITLE
Assemble the high-order Jacobian from a full material tangent

### DIFF
--- a/applications/test/mechanicalConstitutiveLaw/Test-mechanicalConstitutiveLaw.C
+++ b/applications/test/mechanicalConstitutiveLaw/Test-mechanicalConstitutiveLaw.C
@@ -53,8 +53,9 @@ Description
       9. updateScalarTangent agrees with the tangent from a stress update.
      10. The misuse guards fire: a fourth-order tangent on a topology that
          cannot carry one, a flat-list update on a topology whose integration
-         points are shared between cells, a tangent request with no storage,
-         and a duplicate registerTopology key.
+         points are shared between cells and where more than one material
+         could claim them, a tangent request with no storage, and a duplicate
+         registerTopology key.
 
 Author
     Philip Cardiff, UCD.
@@ -1052,7 +1053,29 @@ int main(int argc, char *argv[])
                 threw = true;
             }
 
-            report("a flat-list update on shared points is rejected", threw);
+            // The flat-list update performs no collapse, so a topology whose
+            // integration points are shared between cells is refused only
+            // when there is more than one law: with a single material no
+            // integration point can belong to two materials and there is
+            // nothing to collapse
+            if (lawEntries.size() > 1)
+            {
+                report
+                (
+                    "a flat-list update on shared points is rejected with "
+                    "several materials",
+                    threw
+                );
+            }
+            else
+            {
+                report
+                (
+                    "a flat-list update on shared points is allowed with one "
+                    "material",
+                    !threw
+                );
+            }
         }
 
         // A tangent request with no storage to put it in

--- a/src/solids4FoamModels/higherOrderHelpers/hofv/hofvm.C
+++ b/src/solids4FoamModels/higherOrderHelpers/hofv/hofvm.C
@@ -22,6 +22,7 @@ License
 #include <algorithm>
 
 #include "hofvm.H"
+#include "multiplyCoeff.H"
 #include "fvc.H"
 #include "fvmD2dt2.H"
 #include "compatibilityFunctions.H"
@@ -191,7 +192,7 @@ static label hofvmLaplacianPETSc
     const foamPetscSnesHelper& petscSnesHelper,
     const movingLeastSquares& mls,
     const volVectorField& D,
-    const volScalarField& diffusivity,
+    const volScalarField* diffusivityPtr,
     tensor (*calcCoeff)
     (
         const scalar& gamma,
@@ -199,6 +200,7 @@ static label hofvmLaplacianPETSc
         const vector& gradInterpCoeff,
         const vector& faceNormal
     ),
+    const List<mat66>* materialTangentPtr,
     const label rowOffset,
     const label colOffset
 )
@@ -214,8 +216,49 @@ static label hofvmLaplacianPETSc
     // Diffusion coefficient linearly interpolated to face centres.
     // If Gamma is not constant, next step is to interpolate diffusivity to
     // quad points using  hofvc::interpolate
-    const surfaceScalarField gamma(fvc::interpolate(diffusivity));
-    const scalarField& gammaI = gamma.internalField();
+    // Interpolated only on the scalar-coefficient path. With a full material
+    // tangent there is no scalar diffusivity to interpolate
+    autoPtr<surfaceScalarField> gammaPtr;
+    if (diffusivityPtr)
+    {
+        gammaPtr.set(new surfaceScalarField(fvc::interpolate(*diffusivityPtr)));
+    }
+
+    // Coefficient at one quadrature point.
+    // Either one of the three isotropic kernels scaled by a scalar
+    // diffusivity, or the full material tangent contracted with the face area
+    // vector and the gradient interpolation coefficient. The two agree
+    // identically for an isotropic tangent: summing the laplacian, transpose
+    // and trace kernels gives w*(mu*(n.g)*I + mu*g_i*n_j + lambda*n_i*g_j),
+    // which is Sf_m C_mikl g_k delta_lj with Sf = w*n
+    auto coeffAt =
+        [&]
+        (
+            const label faceID,
+            const scalar gammaFace,
+            const scalar quadPointW,
+            const vector& gradInterpCoeff,
+            const vector& faceNormal
+        ) -> tensor
+        {
+            if (materialTangentPtr)
+            {
+                tensor c(tensor::zero);
+                multiplyCoeff
+                (
+                    c,
+                    quadPointW*faceNormal,
+                    (*materialTangentPtr)[faceID],
+                    gradInterpCoeff
+                );
+                return c;
+            }
+
+            return calcCoeff
+            (
+                gammaFace, quadPointW, gradInterpCoeff, faceNormal
+            );
+        };
 
     // Face quadrature points weights, stencils and gradient interpolation
     // coefficients
@@ -236,7 +279,10 @@ static label hofvmLaplacianPETSc
     forAll(owner, faceI)
     {
         const vector& faceNormal = n[faceI];
-        const scalar gammaFace = gammaI[faceI];
+        const scalar gammaFace =
+            diffusivityPtr
+          ? Foam::primitiveField(gammaPtr())[faceI]
+          : 0.0;
         const label ownCellID = owner[faceI];
         const label neiCellID = neighbour[faceI];
         const PetscInt globalOwnRow =
@@ -253,8 +299,9 @@ static label hofvmLaplacianPETSc
             {
                 const PetscInt globalCellID = stencil[cI];
                 const tensor coeff =
-                    calcCoeff
+                    coeffAt
                     (
+                        faceI,
                         gammaFace,
                         quadPointW,
                         gradCoeffs[faceI][qpI][cI],
@@ -303,7 +350,12 @@ static label hofvmLaplacianPETSc
 
         if (isA<processorPolyPatch>(pp))
         {
-            const scalarField& pGamma = gamma.boundaryField()[patchI];
+            const scalarField pGamma
+            (
+                diffusivityPtr
+              ? scalarField(gammaPtr().boundaryField()[patchI])
+              : scalarField(pp.size(), 0.0)
+            );
             const vectorField patchNormal(mesh.boundary()[patchI].nf());
             const label start = pp.start();
 
@@ -325,8 +377,9 @@ static label hofvmLaplacianPETSc
                     {
                         const PetscInt globalCellID = stencil[cI];
                         const tensor coeff =
-                            calcCoeff
+                            coeffAt
                             (
+                                faceID,
                                 gammaFace,
                                 quadPointW,
                                 gradCoeffs[faceID][qpI][cI],
@@ -361,7 +414,12 @@ static label hofvmLaplacianPETSc
                 << abort(FatalError);
         }
 
-        const scalarField& pGamma = gamma.boundaryField()[patchI];
+        const scalarField pGamma
+        (
+            diffusivityPtr
+          ? scalarField(gammaPtr().boundaryField()[patchI])
+          : scalarField(pp.size(), 0.0)
+        );
         const vectorField patchNormal(mesh.boundary()[patchI].nf());
         const label start = pp.start();
 
@@ -397,8 +455,9 @@ static label hofvmLaplacianPETSc
                         const PetscInt globalCellID = stencil[cI];
 
                         const tensor coeff =
-                            calcCoeff
+                            coeffAt
                             (
+                                faceID,
                                 gammaFace,
                                 quadPointW,
                                 gradCoeffs[faceID][qpI][cI],
@@ -406,8 +465,9 @@ static label hofvmLaplacianPETSc
                             );
 
                         const tensor mirrorCoeff =
-                            calcCoeff
+                            coeffAt
                             (
+                                faceID,
                                 gammaFace,
                                 quadPointW,
                                 gradCoeffs[faceID][qpI][cI + stencilSize],
@@ -466,8 +526,9 @@ static label hofvmLaplacianPETSc
                     {
                         const PetscInt globalCellID = stencil[cI];
                         const tensor coeff =
-                            calcCoeff
+                            coeffAt
                             (
+                                faceID,
                                 gammaFace,
                                 quadPointW,
                                 gradCoeffs[faceID][qpI][cI],
@@ -720,8 +781,9 @@ void Foam::hofvm::laplacianIntoPETScMatrix
         petscSnesHelper,
         mls,
         D,
-        diffusivity,
+        &diffusivity,
         hofvm::laplacianCoeff,
+        nullptr,          // no material tangent on this path
         rowOffset,
         colOffset
     );
@@ -745,8 +807,9 @@ void Foam::hofvm::laplacianTransposeIntoPETScMatrix
         petscSnesHelper,
         mls,
         D,
-        diffusivity,
+        &diffusivity,
         hofvm::laplacianTransposeCoeff,
+        nullptr,          // no material tangent on this path
         rowOffset,
         colOffset
     );
@@ -770,8 +833,44 @@ void Foam::hofvm::laplacianTraceIntoPETScMatrix
         petscSnesHelper,
         mls,
         D,
-        diffusivity,
+        &diffusivity,
         hofvm::laplacianTraceCoeff,
+        nullptr,          // no material tangent on this path
+        rowOffset,
+        colOffset
+    );
+}
+
+
+void Foam::hofvm::divSigmaIntoPETScMatrix
+(
+    Mat jac,
+    const foamPetscSnesHelper& petscSnesHelper,
+    const movingLeastSquares& mls,
+    const volVectorField& D,
+    const List<mat66>& materialTangent,
+    const label rowOffset,
+    const label colOffset
+)
+{
+    if (materialTangent.size() != D.mesh().nFaces())
+    {
+        FatalErrorInFunction
+            << "The material tangent must be indexed by mesh face and sized "
+            << D.mesh().nFaces() << ", but it has "
+            << materialTangent.size() << " entries."
+            << exit(FatalError);
+    }
+
+    hofvm::hofvmLaplacianPETSc
+    (
+        jac,
+        petscSnesHelper,
+        mls,
+        D,
+        nullptr,          // no scalar diffusivity on this path
+        nullptr,          // and so no scalar coefficient kernel
+        &materialTangent,
         rowOffset,
         colOffset
     );

--- a/src/solids4FoamModels/higherOrderHelpers/hofv/hofvm.H
+++ b/src/solids4FoamModels/higherOrderHelpers/hofv/hofvm.H
@@ -38,6 +38,7 @@ Author
 #include "fvMatrices.H"
 #include "volFields.H"
 #include "movingLeastSquares.H"
+#include "mat66.H"
 #include "foamPetscSnesHelper.H"
 
 namespace Foam
@@ -115,6 +116,26 @@ namespace hofvm
     );
 
     // Add coefficients to the matrix for the Laplacian trace
+    //- Add the linearisation of div(sigma) to the PETSc matrix using a full
+    //  fourth-order material tangent, rather than the three isotropic kernels
+    //  driven by a back-derived mu and lambda.
+    //  materialTangent must be indexed by mesh face index and sized
+    //  mesh.nFaces(): internal faces first, then boundary faces in patch
+    //  order, which is the standard OpenFOAM face numbering.
+    //  For an isotropic tangent this is identical to summing
+    //  laplacianIntoPETScMatrix, laplacianTransposeIntoPETScMatrix and
+    //  laplacianTraceIntoPETScMatrix with the corresponding mu and lambda
+    void divSigmaIntoPETScMatrix
+    (
+        Mat jac,
+        const foamPetscSnesHelper& petscSnesHelper,
+        const movingLeastSquares& mls,
+        const volVectorField& D,
+        const List<mat66>& materialTangent,
+        const label rowOffset = 0,
+        const label colOffset = 0
+    );
+
     void laplacianTraceIntoPETScMatrix
     (
         Mat jac,

--- a/src/solids4FoamModels/mechanicalConstitutiveLaw/DESIGN-tangents.md
+++ b/src/solids4FoamModels/mechanicalConstitutiveLaw/DESIGN-tangents.md
@@ -1514,7 +1514,7 @@ Supersedes the stage numbering in §5. Content is otherwise as described there.
 | 3 | **Done.** `solidModel::jacobianTangent(deflt)` and the `approximateJacobian` deprecation shim, used by both vertex-centred solvers; the shadow state of §3.1; a working `fourthOrderFiniteDifference` tangent. The optional manager on `solidModel` moves to PR-4. See §8.8. |
 | 4 | **Done.** `vertexCentredLinGeomSolid` tangent-only adoption (§8.4), plus the optional manager deferred from PR-3. See §8.9. |
 | 5 | Stress for `vertexCentredLinGeomSolid`, removing its dependence on `dualMechanicalModel`. Its nonlinear sibling is disabled, see §8.11. |
-| 6 | `hofvm::divSigmaIntoPETScMatrix(mat66)` + uniform-tangent fast path; delete the `(impK_-K)*3/4` back-derivation from the three cell-centred solvers. |
+| 6 | **Done for `linGeomTotalDispSolid`.** `hofvm::divSigmaIntoPETScMatrix(mat66)`; the back-derivation is retained as the default rather than deleted, so existing cases are unchanged. The two `nonLinGeom*` solvers still carry it. See §8.13. |
 | 7…n | Cell-centred solvers and their high-order variants, the ones in common use and now the priority, risk-ordered: `uns*` → `thermal`/`poro` → `nonLinGeom*` → `linGeomTotalDispSolid` → `coupledPressureDisplacementSolid`. |
 | final | Retire the legacy tangent interface and migrate or bless the six `"impK"` registry consumers (OQ-8). |
 
@@ -1848,7 +1848,40 @@ non-coupled patch from its patch-internal value, which is exact for a scalar
 tangent because a boundary face belongs to its owner cell's material, then
 syncs the coupled patches. Any cell-centred caller would have hit this.
 
-### 8.13 Open questions still outstanding
+### 8.13 Notes from the high-order Jacobian
+
+`hofvm::divSigmaIntoPETScMatrix` assembles the high-order Jacobian from a full
+`mat66` per mesh face, and `linGeomTotalDispSolid` uses it when
+`jacobianTangent fourthOrder` is set. The `(impK_ - K)*3/4` back-derivation
+stays as the default, so existing cases are untouched, but it is no longer the
+only option and the comment beside it now says exactly when it is wrong.
+
+**No new mathematics was needed, as §3.5 predicted.** The three isotropic
+kernels sum to `w*(mu*(n.g)*I + mu*g_i*n_j + lambda*n_i*g_j)`, which is
+`Sf_m C_mikl g_k delta_lj` with `Sf = w*n` - already implemented as
+`multiplyCoeff` and already used by the vertex-centred solver. The assembler
+was generalised to take either a scalar diffusivity with one of the kernels or
+a material tangent, rather than being duplicated, so the internal, processor,
+symmetry and generic patch handling stays in one place.
+
+**Verified byte-identical**, with the same Newton iteration count and the same
+convergence reason, on `plateHole` with a linear elastic material - which is
+precisely the case where the back-derivation is valid, and therefore the only
+case where the two *should* agree. `plateHole` gains a `highOrderFourthOrder`
+approach so this stays covered.
+
+**A guard was relaxed to make this possible.** The flat-list update refused any
+topology whose integration points are shared between cells. The reason for that
+rule is stress collapse at a material interface, which cannot arise with a
+single law, so it now refuses only when there is more than one. The face-centred
+topology is shared by construction, so without this the material tangent could
+not be obtained per face at all.
+
+The test application asserted the old blanket rule and duly failed on
+`perforatedPlate`, which has one material. It now asserts the real contract:
+rejected with several materials, allowed with one.
+
+### 8.14 Open questions still outstanding
 
 OQ-1 (restart `impK` state-dependence), OQ-3 (configurable `impKf_` cadence),
 OQ-5 (`fourthOrderFiniteDifference` production status), OQ-6 (stabilisation term

--- a/src/solids4FoamModels/mechanicalConstitutiveLaw/DESIGN-tangents.md
+++ b/src/solids4FoamModels/mechanicalConstitutiveLaw/DESIGN-tangents.md
@@ -622,13 +622,39 @@ tmp<volScalarField> tMu = (impK_ - K)*(3.0/4.0);
 tmp<volScalarField> tLambda = impK_ - 2.0*mu;
 ```
 
-This inverts `impK = 2*mu + lambda` and `K = lambda + (2/3)*mu` and is valid
-**only** if the law's `impK()` is exactly `2*mu + lambda` and its `bulkModulus()`
-is exactly `lambda + (2/3)*mu`. That holds for `linearElastic` and, coincidentally,
-for `linearElasticMisesPlastic` at an elastic point. It is silently wrong for
-`linearElasticMisesPlastic` at a plastic point (`impK` carries the `theta`
-scaling, so the back-derived `mu` is not the shear modulus), for
-`orthotropicLinearElastic`, and for every hyperelastic law.
+This inverts `impK = (4/3)*mu_eff + K` to recover the isotropic tangent pair
+that `impK` and `bulkModulus()` encode between them.
+
+**Correction, from a later reading.** An earlier version of this section said the
+inversion is wrong for `linearElasticMisesPlastic` once a point yields. It is
+not. That law returns `impK = scaleFactor*(4/3)*mu_ + K_` and
+`bulkModulus() = K_`, so the back-derivation gives
+`mu_back = scaleFactor*mu_`, exactly the softened shear modulus, and
+`lambda_back = K_ - (2/3)*scaleFactor*mu_`, exactly the matching lambda for
+deviatoric softening at unchanged bulk modulus - which is the right structure
+for J2 plasticity. `linearElastic` and `neoHookeanElastic` define `impK` in the
+same form, so all three are inverted exactly.
+
+The real objection is structural rather than numerical. The solid model assumes
+every law's `impK()` has that algebraic form and that `bulkModulus()` is the
+matching `K`. `impK` is explicitly the "whatever converges best" coefficient, so
+a law is entitled to return something else, and nothing declares, checks or
+documents the assumption. A law that exercises that freedom gets a wrong pair
+with no diagnostic.
+
+Where an isotropic pair cannot represent the tangent at all - the orthotropic
+and anisotropic hyperelastic laws - no way of obtaining `mu` and `lambda` helps.
+`orthotropicLinearElastic` is protected only by an accident: it implements
+`impK` but not `bulkModulus`, which is `notImplemented` in the base class, so
+the back-derivation fatal-errors there rather than computing nonsense.
+
+**Note also that the obvious repair is a trap.** `shearModulus()` exists, but
+`linearElasticMisesPlastic::shearModulus()` returns the elastic `mu_` with no
+`scaleFactor`, so substituting it would discard the softening the
+back-derivation captures. It is also `notImplemented` in the base class and
+overridden by only seven of about twenty-five laws. Adding a
+`tangentShearModulus()` would re-encode the same implicit contract under a new
+name and still could not express an anisotropic tangent.
 
 **Decision: replace the three separate `hofvm` calls with one `mat66`-driven
 call. No new mathematics is required — the kernel already exists.**
@@ -1853,8 +1879,15 @@ syncs the coupled patches. Any cell-centred caller would have hit this.
 `hofvm::divSigmaIntoPETScMatrix` assembles the high-order Jacobian from a full
 `mat66` per mesh face, and `linGeomTotalDispSolid` uses it when
 `jacobianTangent fourthOrder` is set. The `(impK_ - K)*3/4` back-derivation
-stays as the default, so existing cases are untouched, but it is no longer the
-only option and the comment beside it now says exactly when it is wrong.
+stays as the default, so existing cases are untouched.
+
+**The case against the back-derivation is structural, not numerical.** See the
+correction in §3.5: it inverts exactly for every law currently defining `impK`
+in the standard form, plastic points included. What is wrong with it is that it
+depends on an undocumented contract about the form of `impK()`, and that no
+isotropic pair can represent an anisotropic tangent however it is obtained. A
+solid model does not need material constants; it needs a Jacobian operator, and
+the material tangent is the general way to supply one.
 
 **No new mathematics was needed, as §3.5 predicted.** The three isotropic
 kernels sum to `w*(mu*(n.g)*I + mu*g_i*n_j + lambda*n_i*g_j)`, which is

--- a/src/solids4FoamModels/mechanicalConstitutiveLaw/DESIGN-tangents.md
+++ b/src/solids4FoamModels/mechanicalConstitutiveLaw/DESIGN-tangents.md
@@ -1914,7 +1914,37 @@ The test application asserted the old blanket rule and duly failed on
 `perforatedPlate`, which has one material. It now asserts the real contract:
 rejected with several materials, allowed with one.
 
-### 8.14 Open questions still outstanding
+### 8.14 Boundary integration points in the flat-list update
+
+`faceCentredIntegrationPointTopology::nIntegrationPoints()` returns
+`mesh.nFaces()`, but its cell-to-integration-point map covers **internal faces
+only**, and says so. Laws are matched to integration points through that map,
+so a flat-list update left every boundary entry of the caller's storage exactly
+as it was found. `linGeomTotalDispSolid::faceMaterialTangent()` sizes its
+`List<mat66>` to `nFaces` and hands it to an assembler that does iterate the
+boundary patches, so it was reading unwritten memory.
+
+**Fixed** by giving the topology a `boundaryIntegrationPointIDs(patchI)` query
+and having both flat-list primitives evaluate the boundary points of a
+`boundaryAware` topology, using the per-law, per-patch boundary state the
+manager already keeps. This is the general fix: any topology that declares
+itself boundary-aware now has its boundary points covered, rather than the
+caller working around the gap.
+
+**Why this went unnoticed, which is the part worth remembering.** The
+`highOrderFourthOrder` variant was byte-identical to `highOrder`, with the same
+Newton iteration count, and that was reported as strong verification. It is
+not. This is a *Jacobian*: a wrong one changes the path to the solution, not the
+solution, and PETSc SNES converges to its tolerance either way. **A
+byte-identical converged result is exactly what a wrong Jacobian looks like
+when the residual is right.** No end-to-end solver comparison can validate a
+Jacobian; only a direct comparison of the tangent itself can.
+
+It was found by the finite-strain tangent test, which sized its comparison to
+`nIntegrationPoints()` and got a relative error of exactly 1 on the unwritten
+entries - a number too clean to be anything but "never assigned".
+
+### 8.15 Open questions still outstanding
 
 OQ-1 (restart `impK` state-dependence), OQ-3 (configurable `impKf_` cadence),
 OQ-5 (`fourthOrderFiniteDifference` production status), OQ-6 (stabilisation term

--- a/src/solids4FoamModels/mechanicalConstitutiveLaw/integrationPointTopology/faceCentredIntegrationPointTopology.H
+++ b/src/solids4FoamModels/mechanicalConstitutiveLaw/integrationPointTopology/faceCentredIntegrationPointTopology.H
@@ -104,6 +104,25 @@ public:
         return true;
     }
 
+    //- Global face indices for a boundary patch.
+    //  A patch occupies a contiguous block of the global face numbering
+    //  starting at its own start index
+    virtual labelList boundaryIntegrationPointIDs
+    (
+        const label patchI
+    ) const override
+    {
+        const polyPatch& pp = mesh_.boundaryMesh()[patchI];
+
+        labelList ids(pp.size());
+        forAll(ids, faceI)
+        {
+            ids[faceI] = pp.start() + faceI;
+        }
+
+        return ids;
+    }
+
     //- Faces are shared between cells → uniqueness required
     virtual bool requiresUniqueIntegrationPointsPerMaterial() const override
     {

--- a/src/solids4FoamModels/mechanicalConstitutiveLaw/integrationPointTopology/integrationPointTopology.H
+++ b/src/solids4FoamModels/mechanicalConstitutiveLaw/integrationPointTopology/integrationPointTopology.H
@@ -119,6 +119,30 @@ public:
     //- Does this topology store boundary integration points per patch
     virtual bool boundaryAware() const = 0;
 
+    //- Integration-point indices for the faces of a boundary patch, in patch
+    //  face order, or an empty list where the topology has none.
+    //
+    //  This is a separate question from boundaryAware(), and the two must not
+    //  be confused. boundaryAware() asks whether the topology keeps a
+    //  constitutive state per patch, which a cell-centred topology does, for
+    //  the GeometricField updates that evaluate a law on patch faces. This
+    //  asks whether the topology's *flat index space* contains slots for
+    //  boundary faces, which a cell-centred topology's does not: it has one
+    //  integration point per cell and nothing else.
+    //
+    //  Returning empty therefore means "no boundary slots to fill", and is the
+    //  right answer for every topology whose integration points are interior
+    //  quantities. A face-centred topology overrides it, because its index
+    //  space is the mesh faces, boundary faces included.
+    //
+    //  Returned by value: a view onto storage owned by the topology would be
+    //  invalidated by the next call, which is a trap for any caller holding
+    //  two patches at once
+    virtual labelList boundaryIntegrationPointIDs(const label patchI) const
+    {
+        return labelList();
+    }
+
     //- Can this topology carry a fourth-order (mat66) material tangent?
     //  This is true only where the integration points are the locations at
     //  which a Jacobian operator evaluates fluxes, i.e. face-like rather than

--- a/src/solids4FoamModels/mechanicalConstitutiveLaw/mechanicalConstitutiveLawManager.C
+++ b/src/solids4FoamModels/mechanicalConstitutiveLaw/mechanicalConstitutiveLawManager.C
@@ -1049,6 +1049,115 @@ void Foam::mechanicalConstitutiveLawManager::evaluateSmallStrain
             laws_[lawI].evaluate(kin, lawState, response);
         }
     }
+
+    // Boundary integration points.
+    // The topology's cell-to-integration-point map covers internal points
+    // only, so without this every boundary entry of the caller's storage is
+    // left exactly as it was found - which, for a caller that sized its list
+    // to nIntegrationPoints(), means unwritten memory.
+    // A topology with no boundary slots in its flat index space returns an
+    // empty list per patch below and nothing happens, which is the right
+    // outcome for a cell-centred topology: it is boundaryAware because it
+    // keeps a state per patch, not because its index space extends past the
+    // cells
+    if (tp.boundaryAware_)
+    {
+        forAll(laws_, lawI)
+        {
+            forAll(mesh_.boundary(), patchI)
+            {
+                const labelList& faces = lawBoundaryFaces_[lawI][patchI];
+
+                if
+                (
+                    faces.empty()
+                 || isA<emptyFvPatch>(mesh_.boundary()[patchI])
+                )
+                {
+                    continue;
+                }
+
+                const labelList patchIPs
+                (
+                    topo.boundaryIntegrationPointIDs(patchI)
+                );
+
+                if (patchIPs.empty())
+                {
+                    continue;
+                }
+
+                // This law's faces on this patch, as integration-point indices
+                labelList ipIDs(faces.size());
+                forAll(faces, i)
+                {
+                    ipIDs[i] = patchIPs[faces[i]];
+                }
+
+                autoPtr<mechanicalConstitutiveLawState> bShadowPtr;
+                if (preserveState)
+                {
+                    bShadowPtr.set
+                    (
+                        new mechanicalConstitutiveLawState
+                        (
+                            tp.boundaryStates_[lawI][patchI],
+                            mechanicalConstitutiveLawState::SHADOW
+                        )
+                    );
+                }
+
+                mechanicalConstitutiveLawState& bState =
+                    preserveState
+                  ? bShadowPtr()
+                  : tp.boundaryStates_[lawI][patchI];
+
+                const UIndirectList<tensor> gradDView(gradD, ipIDs);
+                const UIndirectList<tensor> gradD0View(gradD0, ipIDs);
+                UIndirectList<symmTensor> stressView(stress, ipIDs);
+
+                smallStrainMechanicalConstitutiveLawKinematics kin
+                (
+                    gradDView, gradD0View, dt
+                );
+
+                if (needsScalarTangent(tangentReq))
+                {
+                    UIndirectList<scalar> tanView(*scalarTangentPtr, ipIDs);
+
+                    mechanicalConstitutiveLawResponse response
+                    (
+                        stressView, tanView, tangentReq
+                    );
+
+                    laws_[lawI].evaluate(kin, bState, response);
+                }
+                else if (needsFourthOrderTangent(tangentReq))
+                {
+                    UIndirectList<mat66> tanView
+                    (
+                        *fourthOrderTangentPtr, ipIDs
+                    );
+
+                    mechanicalConstitutiveLawResponse response
+                    (
+                        stressView, tanView, tangentReq
+                    );
+
+                    laws_[lawI].evaluate(kin, bState, response);
+                }
+                else
+                {
+                    mechanicalConstitutiveLawResponse response
+                    (
+                        stressView, tangentReq
+                    );
+
+                    laws_[lawI].evaluate(kin, bState, response);
+                }
+            }
+        }
+    }
 }
 
 
@@ -1200,6 +1309,119 @@ void Foam::mechanicalConstitutiveLawManager::evaluateFiniteStrain
             mechanicalConstitutiveLawResponse response(stressView, tangentReq);
 
             laws_[lawI].evaluate(kin, lawState, response);
+        }
+    }
+
+    // Boundary integration points.
+    // The topology's cell-to-integration-point map covers internal points
+    // only, so without this every boundary entry of the caller's storage is
+    // left exactly as it was found - which, for a caller that sized its list
+    // to nIntegrationPoints(), means unwritten memory.
+    // A topology with no boundary slots in its flat index space returns an
+    // empty list per patch below and nothing happens, which is the right
+    // outcome for a cell-centred topology: it is boundaryAware because it
+    // keeps a state per patch, not because its index space extends past the
+    // cells
+    if (tp.boundaryAware_)
+    {
+        forAll(laws_, lawI)
+        {
+            forAll(mesh_.boundary(), patchI)
+            {
+                const labelList& faces = lawBoundaryFaces_[lawI][patchI];
+
+                if
+                (
+                    faces.empty()
+                 || isA<emptyFvPatch>(mesh_.boundary()[patchI])
+                )
+                {
+                    continue;
+                }
+
+                const labelList patchIPs
+                (
+                    topo.boundaryIntegrationPointIDs(patchI)
+                );
+
+                if (patchIPs.empty())
+                {
+                    continue;
+                }
+
+                // This law's faces on this patch, as integration-point indices
+                labelList ipIDs(faces.size());
+                forAll(faces, i)
+                {
+                    ipIDs[i] = patchIPs[faces[i]];
+                }
+
+                autoPtr<mechanicalConstitutiveLawState> bShadowPtr;
+                if (preserveState)
+                {
+                    bShadowPtr.set
+                    (
+                        new mechanicalConstitutiveLawState
+                        (
+                            tp.boundaryStates_[lawI][patchI],
+                            mechanicalConstitutiveLawState::SHADOW
+                        )
+                    );
+                }
+
+                mechanicalConstitutiveLawState& bState =
+                    preserveState
+                  ? bShadowPtr()
+                  : tp.boundaryStates_[lawI][patchI];
+
+                const UIndirectList<tensor> FView(F, ipIDs);
+                const UIndirectList<tensor> F0View(F0, ipIDs);
+                const UIndirectList<tensor> FinvView(Finv, ipIDs);
+                const UIndirectList<tensor> Finv0View(Finv0, ipIDs);
+                const UIndirectList<scalar> JView(J, ipIDs);
+                const UIndirectList<scalar> J0View(J0, ipIDs);
+                UIndirectList<symmTensor> stressView(stress, ipIDs);
+
+                finiteStrainMechanicalConstitutiveLawKinematics kin
+                (
+                    FView, F0View, JView, J0View, FinvView, Finv0View, dt
+                );
+
+                if (needsScalarTangent(tangentReq))
+                {
+                    UIndirectList<scalar> tanView(*scalarTangentPtr, ipIDs);
+
+                    mechanicalConstitutiveLawResponse response
+                    (
+                        stressView, tanView, tangentReq
+                    );
+
+                    laws_[lawI].evaluate(kin, bState, response);
+                }
+                else if (needsFourthOrderTangent(tangentReq))
+                {
+                    UIndirectList<mat66> tanView
+                    (
+                        *fourthOrderTangentPtr, ipIDs
+                    );
+
+                    mechanicalConstitutiveLawResponse response
+                    (
+                        stressView, tanView, tangentReq
+                    );
+
+                    laws_[lawI].evaluate(kin, bState, response);
+                }
+                else
+                {
+                    mechanicalConstitutiveLawResponse response
+                    (
+                        stressView, tangentReq
+                    );
+
+                    laws_[lawI].evaluate(kin, bState, response);
+                }
+            }
         }
     }
 }

--- a/src/solids4FoamModels/mechanicalConstitutiveLaw/mechanicalConstitutiveLawManager.C
+++ b/src/solids4FoamModels/mechanicalConstitutiveLaw/mechanicalConstitutiveLawManager.C
@@ -961,13 +961,14 @@ void Foam::mechanicalConstitutiveLawManager::evaluateSmallStrain
         );
     }
 
-    if (topo.requiresUniqueIntegrationPointsPerMaterial())
+    if (topo.requiresUniqueIntegrationPointsPerMaterial() && laws_.size() > 1)
     {
         FatalErrorInFunction
             << "The flat-list update does not perform stress collapse, but "
             << "topology " << topo.type() << " shares integration points "
-            << "between cells, so an integration point on a material interface "
-            << "would be written more than once." << nl
+            << "between cells, and there are " << laws_.size()
+            << " mechanical constitutive laws, so an integration point on a "
+            << "material interface would be written more than once." << nl
             << "Use the surfaceField or pointField overload, which takes a "
             << "stressCollapseRule."
             << exit(FatalError);
@@ -1105,13 +1106,14 @@ void Foam::mechanicalConstitutiveLawManager::evaluateFiniteStrain
         );
     }
 
-    if (topo.requiresUniqueIntegrationPointsPerMaterial())
+    if (topo.requiresUniqueIntegrationPointsPerMaterial() && laws_.size() > 1)
     {
         FatalErrorInFunction
             << "The flat-list update does not perform stress collapse, but "
             << "topology " << topo.type() << " shares integration points "
-            << "between cells, so an integration point on a material interface "
-            << "would be written more than once."
+            << "between cells, and there are " << laws_.size()
+            << " mechanical constitutive laws, so an integration point on a "
+            << "material interface would be written more than once."
             << exit(FatalError);
     }
 

--- a/src/solids4FoamModels/mechanicalConstitutiveLaw/mechanicalConstitutiveLawManager.H
+++ b/src/solids4FoamModels/mechanicalConstitutiveLaw/mechanicalConstitutiveLawManager.H
@@ -475,8 +475,11 @@ public:
         //  which is what allows evaluation on a dual or otherwise derived mesh.
         //  Only internal integration points are visited: boundary states are
         //  the business of the GeometricField overloads.
-        //  No stress or tangent collapse is performed, so the topology must
-        //  return requiresUniqueIntegrationPointsPerMaterial() == false.
+        //  No stress or tangent collapse is performed. A topology whose
+        //  integration points are shared between cells is therefore allowed
+        //  only with a single mechanical constitutive law, where no
+        //  integration point can belong to two materials and there is nothing
+        //  to collapse.
         //  A fourth-order tangent request additionally requires
         //  topo.supportsFourthOrderTangent().
         //  Unlike the GeometricField overloads, a tangent request that is not

--- a/src/solids4FoamModels/solidModels/linGeomTotalDispSolid/linGeomTotalDispSolid.C
+++ b/src/solids4FoamModels/solidModels/linGeomTotalDispSolid/linGeomTotalDispSolid.C
@@ -629,6 +629,75 @@ Foam::solidModels::linGeomTotalDispSolid::makeImpK() const
 }
 
 
+const Foam::List<Foam::mat66>&
+Foam::solidModels::linGeomTotalDispSolid::faceMaterialTangent() const
+{
+    if (!useMechanicalConstitutiveLawManager_)
+    {
+        FatalErrorInFunction
+            << "'jacobianTangent fourthOrder' needs the material tangent from "
+            << "the mechanical constitutive law framework, but "
+            << "'useMechanicalConstitutiveLawManager' is not set." << nl
+            << "The legacy mechanicalModel cannot supply one on the primary "
+            << "mesh."
+            << exit(FatalError);
+    }
+
+    const fvMesh& m = mesh();
+
+    // Indexed by mesh face, which is what hofvm::divSigmaIntoPETScMatrix
+    // expects and what the face-centred topology provides
+    faceMaterialTangent_.setSize(m.nFaces());
+
+    const integrationPointTopology& faceTopo =
+        mechanicalManager().topologyFor
+        (
+            faceCentredIntegrationPointTopology::typeName
+        );
+
+    // The topology spans internal faces then boundary faces in patch order,
+    // so gather the face gradients into one flat field in the same order
+    const surfaceTensorField gradDf(fvc::interpolate(gradD()));
+    const surfaceTensorField gradDf0(fvc::interpolate(gradD().oldTime()));
+
+    Field<tensor> gradDFlat(m.nFaces(), tensor::zero);
+    Field<tensor> gradD0Flat(m.nFaces(), tensor::zero);
+
+    const label nInt = m.nInternalFaces();
+    for (label faceI = 0; faceI < nInt; ++faceI)
+    {
+        gradDFlat[faceI] = Foam::primitiveField(gradDf)[faceI];
+        gradD0Flat[faceI] = Foam::primitiveField(gradDf0)[faceI];
+    }
+
+    forAll(m.boundary(), patchI)
+    {
+        const label start = m.boundaryMesh()[patchI].start();
+        const fvsPatchTensorField& pGradD = gradDf.boundaryField()[patchI];
+        const fvsPatchTensorField& pGradD0 = gradDf0.boundaryField()[patchI];
+
+        forAll(pGradD, faceI)
+        {
+            gradDFlat[start + faceI] = pGradD[faceI];
+            gradD0Flat[start + faceI] = pGradD0[faceI];
+        }
+    }
+
+    mechanicalManager().updateTangentSmallStrain
+    (
+        faceTopo,
+        gradDFlat,
+        gradD0Flat,
+        mesh().time().deltaTValue(),
+        nullptr,
+        &faceMaterialTangent_,
+        tangentRequest::fourthOrder
+    );
+
+    return faceMaterialTangent_;
+}
+
+
 Foam::tmp<Foam::volScalarField>
 Foam::solidModels::linGeomTotalDispSolid::makeRKappa() const
 {
@@ -1273,43 +1342,50 @@ label linGeomTotalDispSolid::formJacobian
         // not currently apply matrix under-relaxation to the high-order
         // Jacobian assembled directly into PETSc. If this becomes important
         // for robustness, an equivalent relaxation step may need to be added.
-        tmp<volScalarField> tK = mechanical().bulkModulus();
-        const volScalarField& K = tK();
-
-        tmp<volScalarField> tMu = (impK_ - K)*(3.0/4.0);
-        const volScalarField& mu = tMu();
-
-        tmp<volScalarField> tLambda = impK_ - 2.0*mu;
-        const volScalarField& lambda = tLambda();
-
         const movingLeastSquares& mls = displacementMLS();
 
-        hofvm::laplacianIntoPETScMatrix
-        (
-            jac,
-            *this,
-            mls,
-            D,
-            mu
-        );
+        if (jacobianTangent(tangentRequest::scalar) == tangentRequest::fourthOrder)
+        {
+            // Assemble from the full material tangent
+            hofvm::divSigmaIntoPETScMatrix
+            (
+                jac,
+                *this,
+                mls,
+                D,
+                faceMaterialTangent()
+            );
+        }
+        else
+        {
+            // Back-derive mu and lambda from impK and the bulk modulus.
+            //
+            // This inverts impK = 2*mu + lambda and K = lambda + (2/3)*mu, so
+            // it is correct only where the law's impK() is exactly 2*mu +
+            // lambda and its bulkModulus() exactly lambda + (2/3)*mu. That
+            // holds for linearElastic, and for linearElasticMisesPlastic only
+            // while a point is elastic: once it yields, impK carries the
+            // scaling factor and the back-derived mu is not the shear modulus.
+            // It is wrong for the orthotropic and hyperelastic laws.
+            //
+            // Retained as the default so that existing cases are unchanged.
+            // Set 'jacobianTangent fourthOrder' to assemble from the material
+            // tangent instead, which is correct for any law
+            tmp<volScalarField> tK = mechanical().bulkModulus();
+            const volScalarField& K = tK();
 
-        hofvm::laplacianTransposeIntoPETScMatrix
-        (
-            jac,
-            *this,
-            mls,
-            D,
-            mu
-        );
+            tmp<volScalarField> tMu = (impK_ - K)*(3.0/4.0);
+            const volScalarField& mu = tMu();
 
-        hofvm::laplacianTraceIntoPETScMatrix
-        (
-            jac,
-            *this,
-            mls,
-            D,
-            lambda
-        );
+            tmp<volScalarField> tLambda = impK_ - 2.0*mu;
+            const volScalarField& lambda = tLambda();
+
+            hofvm::laplacianIntoPETScMatrix(jac, *this, mls, D, mu);
+
+            hofvm::laplacianTransposeIntoPETScMatrix(jac, *this, mls, D, mu);
+
+            hofvm::laplacianTraceIntoPETScMatrix(jac, *this, mls, D, lambda);
+        }
 
         fvVectorMatrix transientJ
         (

--- a/src/solids4FoamModels/solidModels/linGeomTotalDispSolid/linGeomTotalDispSolid.C
+++ b/src/solids4FoamModels/solidModels/linGeomTotalDispSolid/linGeomTotalDispSolid.C
@@ -1358,19 +1358,28 @@ label linGeomTotalDispSolid::formJacobian
         }
         else
         {
-            // Back-derive mu and lambda from impK and the bulk modulus.
+            // Back-derive an isotropic tangent pair from impK and the bulk
+            // modulus, inverting impK = (4/3)*mu_eff + K.
             //
-            // This inverts impK = 2*mu + lambda and K = lambda + (2/3)*mu, so
-            // it is correct only where the law's impK() is exactly 2*mu +
-            // lambda and its bulkModulus() exactly lambda + (2/3)*mu. That
-            // holds for linearElastic, and for linearElasticMisesPlastic only
-            // while a point is elastic: once it yields, impK carries the
-            // scaling factor and the back-derived mu is not the shear modulus.
-            // It is wrong for the orthotropic and hyperelastic laws.
+            // This is exact for every law that currently defines impK in that
+            // form, plastic points included: linearElasticMisesPlastic returns
+            // scaleFactor*(4/3)*mu + K, so mu_eff comes back as scaleFactor*mu
+            // and lambda as K - (2/3)*scaleFactor*mu, which is deviatoric
+            // softening at unchanged bulk modulus.
             //
-            // Retained as the default so that existing cases are unchanged.
-            // Set 'jacobianTangent fourthOrder' to assemble from the material
-            // tangent instead, which is correct for any law
+            // What is wrong with it is structural. It assumes an algebraic
+            // form for impK() that nothing declares or checks, and impK is
+            // deliberately the "whatever converges best" coefficient, so a law
+            // is free to return something else. And no isotropic pair can
+            // represent an anisotropic tangent however it is obtained; the
+            // orthotropic law escapes only because it leaves bulkModulus()
+            // unimplemented, so this branch fatal-errors rather than
+            // computing nonsense.
+            //
+            // Retained as the default so existing cases are unchanged. Set
+            // 'jacobianTangent fourthOrder' to assemble from the material
+            // tangent instead, which needs no assumption about impK and works
+            // for an anisotropic law
             tmp<volScalarField> tK = mechanical().bulkModulus();
             const volScalarField& K = tK();
 

--- a/src/solids4FoamModels/solidModels/linGeomTotalDispSolid/linGeomTotalDispSolid.H
+++ b/src/solids4FoamModels/solidModels/linGeomTotalDispSolid/linGeomTotalDispSolid.H
@@ -38,6 +38,7 @@ SourceFiles
 
 #include "solidModel.H"
 #include "mechanicalConstitutiveLawManager.H"
+#include "integrationPointTopologies.H"
 #include "volFields.H"
 #include "surfaceFields.H"
 #include "pointFields.H"
@@ -79,6 +80,10 @@ class linGeomTotalDispSolid
 
         //- Mechanical constitutive law manager, when the above is set
         mutable autoPtr<mechanicalConstitutiveLawManager> mechanicalManagerPtr_;
+
+        //- Material tangent at mesh faces, for the high-order Jacobian.
+        //  Held here so it is allocated once rather than per assembly
+        mutable List<mat66> faceMaterialTangent_;
 
         //- Implicit stiffness; coefficient of the Laplacian term
         //  The value of this term only affects convergence and not the answer
@@ -123,6 +128,10 @@ class linGeomTotalDispSolid
 
         //- Return the reciprocal of the bulk modulus, from the same source
         tmp<volScalarField> makeRKappa() const;
+
+        //- Return the material tangent at mesh faces, indexed by face, for
+        //  the high-order Jacobian
+        const List<mat66>& faceMaterialTangent() const;
 
         //- Predict the fields for the next time-step based on the
         //  previous time-steps

--- a/tutorials/solids/linearElasticity/plateHole/Allrun
+++ b/tutorials/solids/linearElasticity/plateHole/Allrun
@@ -206,6 +206,7 @@ select_approach() {
             ;;
         highOrderFourthOrder)
             echo "Using the highOrder approach with a full material tangent"
+            solids4Foam::caseDoesNotRunWithFoamExtend
             link_files_for_suffix "highOrder"
             rm -f constant/solidProperties
             ln -s solidProperties.highOrderFourthOrder constant/solidProperties

--- a/tutorials/solids/linearElasticity/plateHole/Allrun
+++ b/tutorials/solids/linearElasticity/plateHole/Allrun
@@ -6,7 +6,7 @@ IFS=$'\n\t'
 # solids4Foam Allrun script
 # Allows selection of solution approach:
 #   segregated (default), segregatedManager, petscSnes,
-#   petscSnesPressure, highOrder
+#   petscSnesPressure, highOrder, highOrderFourthOrder
 #   pressureDisplacementCompressible [coarse|medium]
 #   pressureDisplacementIncompressible [coarse|medium]
 # -------------------------------------------------------------------------
@@ -21,6 +21,7 @@ Where [approach] is one of:
   petscSnes
   petscSnesPressure
   segregatedManager
+  highOrderFourthOrder
   highOrder
   pressureDisplacementCompressible
   pressureDisplacementIncompressible
@@ -42,6 +43,7 @@ Examples:
   ./Allrun petscSnes parallel
   ./Allrun petscSnesPressure
   ./Allrun segregatedManager
+  ./Allrun highOrderFourthOrder
   ./Allrun highOrder
   ./Allrun pressureDisplacementCompressible medium
   ./Allrun pressureDisplacementIncompressible medium
@@ -76,7 +78,7 @@ if [[ "${APPROACH}" == "parallel" ]]; then
 fi
 
 case "${APPROACH}" in
-    segregated|segregatedManager|petscSnes|petscSnesPressure|highOrder)
+    segregated|segregatedManager|petscSnes|petscSnesPressure|highOrder|highOrderFourthOrder)
         RUN_MODE="${ARG2:-serial}"
         case "${RUN_MODE}" in
             serial|parallel) ;;
@@ -138,7 +140,7 @@ link_files_for_suffix() {
 
 require_petsc_or_exit_silently() {
     case "${APPROACH}" in
-        petscSnes|petscSnesPressure|highOrder)
+        petscSnes|petscSnesPressure|highOrder|highOrderFourthOrder)
             solids4Foam::requirePetscOrExitSilently
             ;;
     esac
@@ -202,6 +204,13 @@ select_approach() {
             echo "Using the petscSnes approach"
             link_files_for_suffix "petscSnes"
             ;;
+        highOrderFourthOrder)
+            echo "Using the highOrder approach with a full material tangent"
+            link_files_for_suffix "highOrder"
+            rm -f constant/solidProperties
+            ln -s solidProperties.highOrderFourthOrder constant/solidProperties
+            ;;
+
         segregatedManager)
             echo "Using the segregated approach with the constitutive law manager"
             link_files_for_suffix "segregated"
@@ -247,7 +256,7 @@ echo
 solids4Foam::runApplication blockMesh
 
 case "${APPROACH}" in
-    segregated|segregatedManager|petscSnes|petscSnesPressure|highOrder)
+    segregated|segregatedManager|petscSnes|petscSnesPressure|highOrder|highOrderFourthOrder)
         if [[ "${RUN_MODE}" == "parallel" ]]; then
             solids4Foam::runApplication decomposePar
             solids4Foam::runParallel solids4Foam

--- a/tutorials/solids/linearElasticity/plateHole/constant/solidProperties.highOrderFourthOrder
+++ b/tutorials/solids/linearElasticity/plateHole/constant/solidProperties.highOrderFourthOrder
@@ -1,0 +1,67 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| solids4foam: solid mechanics and fluid-solid interaction simulations        |
+| Version:     v2.4                                                           |
+| Web:         https://solids4foam.github.io                                  |
+| Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
+|              producer and distributor of the OpenFOAM software via          |
+|              www.openfoam.com, and owner of the OPENFOAM® and OpenCFD®      |
+|              trade marks.                                                   |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "constant";
+    object      solidProperties;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+solidModel     linearGeometryTotalDisplacement;
+
+linearGeometryTotalDisplacementCoeffs
+{
+    // Assemble the high-order Jacobian from the full material tangent rather
+    // than from a mu and lambda back-derived out of impK and the bulk
+    // modulus. For a linear elastic material the two are identical; they
+    // differ for any law where impK is not exactly 2*mu + lambda
+    useMechanicalConstitutiveLawManager yes;
+    jacobianTangent fourthOrder;
+
+    // Solution algorithm
+    solutionAlgorithm    PETScSNES;
+
+    highOrderCoeffs
+    {
+        highOrderJacobian false;
+        highOrderResidual true;
+
+        displacement
+        {
+            // Polynomial order of displacement field
+            polynomialOrder 2;
+
+            // Extra cells in minimum size stencil
+            faceStencilExtraCells 15;
+
+            // Weight function for least square systems
+            weightFunctionCoeffs
+            {
+                type radiallySymmetricExponential;
+                k 6;
+            }
+            calcConditionNumber false;
+        }
+    }
+
+    stabilisation
+    {
+        momentum
+        {
+            type        alpha;
+            scaleFactor 0.1;
+        }
+    }
+}
+
+// ************************************************************************* //

--- a/tutorials/solids/linearElasticity/plateHole/regressionTest.sh
+++ b/tutorials/solids/linearElasticity/plateHole/regressionTest.sh
@@ -46,6 +46,7 @@ APPROACHES=(
     petscSnes
     petscSnesPressure
     highOrder
+    highOrderFourthOrder
 )
 
 PRESSURE_DISPLACEMENT_CASES=(


### PR DESCRIPTION
## What this changes 🔧

> **Corrected after review.** An earlier version of this description said the
> back-derivation is silently wrong for `linearElasticMisesPlastic` once a
> point yields. **That is not true**, and the algebra is short enough that it
> should have been checked before the claim was made. See below.

The high-order Jacobian back-derives an isotropic tangent pair from `impK` and
the bulk modulus:

```c++
tmp<volScalarField> tMu = (impK_ - K)*(3.0/4.0);
tmp<volScalarField> tLambda = impK_ - 2.0*mu;
```

inverting `impK = (4/3)*mu_eff + K`. **This is exact for every law that
currently defines `impK` in that form, plastic points included.**
`linearElasticMisesPlastic` returns `scaleFactor*(4/3)*mu_ + K_`, so the
inversion recovers `mu_eff = scaleFactor*mu_` and
`lambda = K_ - (2/3)*scaleFactor*mu_` — deviatoric softening at unchanged bulk
modulus, which is the right structure for J2 plasticity.

**The objection is structural, not numerical.** The solid model assumes an
algebraic form for `impK()` that nothing declares or checks — and `impK` is
deliberately the "whatever converges best" coefficient, which a law is entitled
to choose freely. And where an isotropic pair cannot represent the tangent at
all (orthotropic, anisotropic hyperelastic), no way of obtaining `mu` and
`lambda` helps. `orthotropicLinearElastic` escapes only by accident: it leaves
`bulkModulus()` unimplemented, so the branch fatal-errors rather than computing
nonsense.

The obvious repair is a trap. `shearModulus()` exists, but the plastic law's
returns the *elastic* `mu_` with no `scaleFactor`, so substituting it would
discard the softening the back-derivation captures. It is also
`notImplemented` in the base class, overridden by only 7 of ~25 laws.

A solid model does not need material constants. It needs a **Jacobian
operator** — which the material tangent supplies with no assumption about
`impK`, and which works for an anisotropic law.

## The fix

`hofvm::divSigmaIntoPETScMatrix` assembles from a full `mat66` per mesh face.
`linGeomTotalDispSolid` uses it when `jacobianTangent fourthOrder` is set. The
back-derivation **stays as the default**, so no existing case changes, but it
is no longer the only option and the comment beside it now states exactly when
it is wrong.

**No new mathematics was needed.** The three isotropic kernels sum to

```text
w*( mu*(n.g)*delta_ij + mu*g_i*n_j + lambda*n_i*g_j )
```

which is `Sf_m C_mikl g_k delta_lj` with `Sf = w*n` — already implemented as
`multiplyCoeff`, and already used by the vertex-centred solver. I verified the
index algebra rather than assuming it.

The assembler was **generalised rather than duplicated**: it now takes either a
scalar diffusivity with one of the kernels, or a material tangent. The internal,
processor, symmetry and generic patch handling stays in one place.

## Verification ✅

Byte-identical on `plateHole` with a linear elastic material, **same Newton
iteration count, same convergence reason**. That is the case where the
back-derivation is valid, and therefore the only case where the two paths
*should* agree — which is what makes it a meaningful check of the substitution
rather than of the physics.

`plateHole` gains a `highOrderFourthOrder` approach so this stays covered. It
matches `highOrder` to the last digit.

Full regression set passes. Builds clean on OpenFOAM-v2512 and foam-extend-4.1.

## A guard relaxed, and a test that caught it

The flat-list update refused *any* topology whose integration points are shared
between cells. The reason for that rule is stress collapse at a material
interface, which cannot arise with a single law — so it now refuses only when
there is more than one. Without this the material tangent could not be obtained
per face at all, since the face-centred topology is shared by construction.

The test application asserted the old blanket rule and duly failed on
`perforatedPlate`, which has one material. It now asserts the real contract:
rejected with several materials, allowed with one. Worth noting as a case of
the tests doing their job on a deliberate behaviour change.

## Not done here

The two `nonLinGeom*` solvers still carry the same back-derivation. They need
the same treatment, and the finite-strain tangent path to go with it.


## Added since first review: boundary integration points, and a correction

`faceCentredIntegrationPointTopology` reports `nFaces` integration points but
its cell map covers **internal faces only**, so the flat-list update never
wrote the boundary entries. `faceMaterialTangent()` sizes its `List<mat66>` to
`nFaces` and hands it to an assembler that *does* iterate the boundary patches,
so it was reading unwritten memory. Fixed by adding
`boundaryIntegrationPointIDs(patchI)` to the topology and evaluating the
boundary points in both flat-list primitives, reusing the per-law, per-patch
boundary state the manager already keeps.

**This corrects a claim in the Verification section above.** The
byte-identical `highOrderFourthOrder` result was offered there as strong
evidence. It is not, and the defect above is the proof: this is a *Jacobian*.
A wrong Jacobian changes the path to the solution, not the solution, and PETSc
SNES converges to tolerance either way. A byte-identical converged result is
exactly what a wrong Jacobian looks like when the residual is right. No
end-to-end solver comparison can validate a Jacobian; only a direct comparison
of the tangent itself can. The defect was found by the finite-strain tangent
test in #407, not by any tutorial.

Two review points from a second pass were also addressed:

- `boundaryIntegrationPointIDs` returns by value. Returning a view onto storage
  owned by the topology would be invalidated by the next call.
- `boundaryAware()` and "has boundary slots in the flat index space" are
  documented as the separate questions they are. A cell-centred topology is
  boundary-aware because it keeps a state per patch, not because its index
  space extends past the cells, and it correctly returns no boundary slots.

Regression set passes; builds clean on v2512 and foam-extend-4.1.
