### PR TITLE
Build the framework on foam-extend; disable the nonlinear vertex-centred model

### DIFF
--- a/src/solids4FoamModels/Make/files.foamextend
+++ b/src/solids4FoamModels/Make/files.foamextend
@@ -19,7 +19,14 @@ solidModels/unsLinGeomSolid/unsLinGeomSolid.C
 solidModels/unsNonLinGeomUpdatedLagSolid/unsNonLinGeomUpdatedLagSolid.C
 solidModels/unsNonLinGeomTotalLagSolid/unsNonLinGeomTotalLagSolid.C
 solidModels/vertexCentredLinGeomSolid/vertexCentredLinGeomSolid.C
+/* Not compiled: vertexCentredNonLinTotalLagGeometry does not currently run.
+   No tutorial selects it, so nothing exercised it; an attempt to give it one
+   failed inside the PETSc solve. Its dictionary entries useGeometricStiffness,
+   compactImplicitStencil and the material's tangentEps also have no defaults
+   and are set by no case. Fixing it is separate from the mechanical
+   constitutive law work; see the solver's README.md.
 solidModels/vertexCentredNonLinGeomTotalLagSolid/vertexCentredNonLinGeomTotalLagSolid.C
+*/
 solidModels/weakThermalLinGeomSolid/weakThermalLinGeomSolid.C
 solidModels/coupledPressureDisplacementSolid/coupledPressureDisplacementSolid.C
 

--- a/src/solids4FoamModels/Make/files.openfoam
+++ b/src/solids4FoamModels/Make/files.openfoam
@@ -19,7 +19,14 @@ solidModels/unsLinGeomSolid/unsLinGeomSolid.C
 solidModels/unsNonLinGeomUpdatedLagSolid/unsNonLinGeomUpdatedLagSolid.C
 solidModels/unsNonLinGeomTotalLagSolid/unsNonLinGeomTotalLagSolid.C
 solidModels/vertexCentredLinGeomSolid/vertexCentredLinGeomSolid.C
+/* Not compiled: vertexCentredNonLinTotalLagGeometry does not currently run.
+   No tutorial selects it, so nothing exercised it; an attempt to give it one
+   failed inside the PETSc solve. Its dictionary entries useGeometricStiffness,
+   compactImplicitStencil and the material's tangentEps also have no defaults
+   and are set by no case. Fixing it is separate from the mechanical
+   constitutive law work; see the solver's README.md.
 solidModels/vertexCentredNonLinGeomTotalLagSolid/vertexCentredNonLinGeomTotalLagSolid.C
+*/
 solidModels/weakThermalLinGeomSolid/weakThermalLinGeomSolid.C
 
 fluidModels/fluidModel/fluidModel.C

--- a/src/solids4FoamModels/mechanicalConstitutiveLaw/DESIGN-state-io.md
+++ b/src/solids4FoamModels/mechanicalConstitutiveLaw/DESIGN-state-io.md
@@ -64,70 +64,120 @@ works.** It only needs a different answer where the old one cannot reach.
 
 ---
 
-## 3. Why the new framework cannot simply do the same
+## 3. The general shape of an integration-point topology
 
-State in the new framework lives at the integration points of a *topology*, and
-only one topology is one-to-one with cells:
+State lives at the integration points of a *topology*, and the first draft
+treated those as either "cell-shaped" or "awkward". That is too coarse. Every
+topology in use or planned is of one form:
+
+> **n integration points attached to each entity of some mesh**, where the
+> entity is a cell, a face or a point.
+
+Writing it that way makes the IO question answerable uniformly, because
+OpenFOAM already has a mesh-aware, parallel-aware, decomposable container for
+each entity kind.
 
 <!-- markdownlint-disable MD013 -->
 
-| Topology | Integration points per cell | Cell-shaped? |
-|---|---|---|
-| `cellCentred` | 1 | yes |
-| `compactCell` (quadrature) | fixed n | no, but regular |
-| `faceCentred` | shared between cells | no, but `surfaceField` fits |
-| `pointCentred` | shared between cells | no, but `pointField` fits |
-| `dualFace` | variable, many | no |
+| Topology | Mesh | Entity | n per entity | Natural container |
+|---|---|---|---|---|
+| `cellCentred` | primary | cell | 1 | `volField` |
+| `faceCentred` | primary | face | 1 | `surfaceField` |
+| `pointCentred` | primary | point | 1 | `pointField` |
+| Gauss points in cells (`compactCell`) | primary | cell | fixed n | n `volField`s |
+| Gauss points on faces | primary | face | fixed n | n `surfaceField`s |
+| `dualFace` | **dual** | face | variable | none - see §7 |
 
 <!-- markdownlint-enable MD013 -->
 
-Two qualifications, both from review.
+So the classification that matters for IO is not "is it cells" but three
+independent properties:
 
-`faceCentred` and `pointCentred` are **not** short of a container: OpenFOAM has
-mesh-aware surface and point fields with proper parallel handling. What they are
-short of is *semantics* - an integration point shared between two cells can be
-reached from two materials, so a single value per face is not obviously the
-right model. That is a different problem from having nowhere to put the number.
+1. **Which mesh** the entities belong to. The primary mesh is decomposed,
+   reconstructed and written by the standard tools; a derived mesh such as the
+   dual is not.
+2. **Which entity kind**, which selects the container.
+3. **Whether n is fixed**. A fixed n becomes n containers with an index suffix;
+   a variable n has no entity-shaped representation at all.
 
-`setFields` sets the internal and boundary values of `volField`s, and finite-area
-fields. It does not set `surfaceField`s, `pointField`s or arbitrary `IOField`s.
-So "a per-cell `volField` is what `setFields` can write" is right; "and nothing
-else" was too strong.
+**A topology is standard-IO-capable when its mesh is the primary mesh and n is
+fixed.** Everything in the table except `dualFace` satisfies that, including
+both Gauss-point cases. This is worth stating as an interface:
+
+```c++
+        //- The mesh entity that integration points are attached to
+        enum class entityKind { cell, face, point };
+
+        //- Entity kind for this topology
+        virtual entityKind entity() const = 0;
+
+        //- Integration points per entity, or -1 where it varies
+        virtual label pointsPerEntity() const = 0;
+
+        //- True if the entities belong to the mesh the manager was built on,
+        //  rather than to a derived mesh such as a dual
+        virtual bool onPrimaryMesh() const = 0;
+```
+
+The manager then chooses the container generically, and a new topology gets IO
+for free by answering three questions rather than by having IO written for it.
+
+Two qualifications carried over from review.
+
+`setFields` sets the internal and boundary values of `volField`s, and
+finite-area fields. It does not set `surfaceField`s, `pointField`s or arbitrary
+`IOField`s. So the `setFields` route exists for cell-entity topologies and not
+for the others - which matters for prescribing inputs (§4), not for restart.
+
+A shared integration point - a face or point reachable from two cells - can be
+reached from two *materials*. That is a semantic problem, not a storage one,
+and it is what §4 has to deal with.
 
 ---
 
 ## 4. Decision
 
-**The user-facing form is always a `volField` on the primary mesh. The manager
-maps between that and integration points.**
+**Prescribed inputs are always specified as a `volField` on the primary mesh.
+Persistent state is stored in the container its topology's entity implies.**
 
-Materials are already defined per primary cell, `setFields` operates on
-volFields, and a per-cell initial condition is what a user actually wants to
-specify. The manager broadcasts a cell's value to every integration point of
+The two directions genuinely differ, which is why they get different answers.
+
+**Prescribed (R2, R3).** A user specifies an initial stress, an initial strain
+or a fibre direction per *region of material*, and materials are already
+defined per primary cell. A cell-shaped input is therefore the natural
+specification and not a loss of fidelity, and it is the one form `setFields`
+can write. The manager broadcasts a cell's value to every integration point of
 that cell.
 
-**This is exact only where an integration point belongs to exactly one cell**,
-i.e. where `requiresUniqueIntegrationPointsPerMaterial()` is false -
-`cellCentred`, `compactCell`, `dualFace`. For `faceCentred` and `pointCentred`
-an integration point is reachable from two cells that may carry different
-prescribed values, and the broadcast is then ambiguous. The first draft called
+This is exact where an integration point belongs to exactly one cell, i.e.
+where `requiresUniqueIntegrationPointsPerMaterial()` is false - `cellCentred`,
+`compactCell`, `dualFace`. For `faceCentred`, `pointCentred` and face Gauss
+points an integration point is reachable from two cells that may carry
+different values, and the broadcast is then ambiguous. The first draft called
 the cell-shaped form "not a compromise"; that is false for shared topologies.
-Those need a stated mapping policy - reject a discontinuity across the point,
-take the owner cell, or interpolate - and the policy has to be part of the
-declaration rather than an implicit choice.
+Those need a mapping policy stated in the declaration - reject a discontinuity
+across the point, take the owner cell, or interpolate - rather than an implicit
+choice.
 
-For R1 the direction reverses and the mapping has to be lossless, so it depends
-on the topology:
+**Persistent (R1).** The direction reverses and the mapping must be lossless,
+so the container follows the entity:
 
 <!-- markdownlint-disable MD013 -->
 
 | Topology | Restart representation | Standard tools? |
 |---|---|---|
-| `cellCentred` | one `volField`, `READ_IF_PRESENT` / `AUTO_WRITE`. Identical to legacy | yes, fully |
-| `compactCell`, fixed n per cell | n `volField`s, suffixed `_0` … `_n-1` | yes, fully |
-| `dualFace`, `faceCentred`, `pointCentred` | `IOField` under `<time>/mechanicalState/<topology>/<law>/<name>` | **no** — see §7 |
+| `cellCentred` | one `volField`, `READ_IF_PRESENT` / `AUTO_WRITE`. Identical to legacy | yes |
+| `faceCentred` | one `surfaceField` | yes |
+| `pointCentred` | one `pointField` | yes |
+| Gauss points in cells | n `volField`s, suffixed `_0` … `_n-1` | yes |
+| Gauss points on faces | n `surfaceField`s, suffixed likewise | yes |
+| `dualFace` | none available | **no** - see §7 |
 
 <!-- markdownlint-enable MD013 -->
+
+The suffix convention is deliberate: n separate fields of a standard type
+decompose, reconstruct and plot with no new tooling, where one field of n
+values per entity would need all three written from scratch.
 
 ---
 
@@ -251,9 +301,12 @@ draft.
 
 ## 7. The awkward case, and what to do about it
 
-For `dualFace` and the other shared-point topologies there is no cell-shaped
-lossless representation, because the number of integration points per cell
-varies. Three options:
+§4 leaves exactly one topology without a representation: `dualFace`, and any
+future topology on a derived mesh or with a variable count. `faceCentred`,
+`pointCentred` and both Gauss-point cases are now covered by standard
+containers, so the awkward set is smaller than the first draft assumed.
+
+For that remaining case there are three options:
 
 1. **A topology-aware persistent field per topology per law.** Not a bare
    `IOField`: that is an ordered `Field` plus IO and nothing more
@@ -272,9 +325,16 @@ varies. Three options:
 
 **Recommendation: 3 now, 1 next, never 2.** With one widening from review: the
 guard in 3 must cover *every* combination that lacks an exact defined mapping,
-not just the multi-point topologies. That includes boundary state, shared
-integration points with conflicting cell values, and any mesh that can change
-topology. Option 2 produces a run that
+not just topologies on a derived mesh. That includes boundary state, shared
+integration points with conflicting prescribed values, and any mesh that can
+change topology.
+
+Note how little this now blocks. The cell-centred solid models and their
+high-order Gauss-point variants - the ones in common use, and the priority for
+migration - are all standard-IO-capable by §4, so restart works for them
+through the same mechanism the legacy laws already use. Only the vertex-centred
+path is held back, and it currently runs `linearElastic`, which has no history
+to lose. Option 2 produces a run that
 restarts to a subtly different state with no indication that anything was lost,
 which is the worst property a restart can have. Option 3 costs one guard and is
 honest. Option 1 is the real answer and can be built when someone needs a
@@ -293,11 +353,11 @@ works today.
 | Step | Content | Unblocks |
 |---|---|---|
 | 1 | `declareState` and the spec object; manager allocates and applies defaults. No IO yet | the rest |
-| 2 | `prescribed` fields read from `volField`s and broadcast to integration points | R2, R3, fibre directions, `setFields` |
+| 2 | `prescribed` fields read from `volField`s in `constant/` and broadcast to integration points, with a declared mapping policy for shared points | R2, R3, fibre directions, `setFields` |
 | 3 | `initialStress` and `initialStrain` applied by the manager, small strain only | the specific request |
-| 4 | `persistent` fields written and read as `volField`s for cell-shaped topologies | R1 for cell-centred solid models |
-| 5 | Guard refusing history-dependent laws on non-cell-shaped topologies | honest failure instead of silent loss |
-| 6 | Topology-aware persistent state with integration-point identity, plus decompose/reconstruct/redistribute support | R1 everywhere |
+| 4 | `persistent` fields written and read in the container the topology's entity implies: `volField`, `surfaceField`, `pointField`, or n of them for a fixed Gauss-point count | R1 for the cell-centred solid models and their high-order variants |
+| 5 | Guard refusing history-dependent laws wherever the mapping is not exact: derived meshes, variable counts, unresolved shared points, changing topology | honest failure instead of silent loss |
+| 6 | Topology-aware persistent state with integration-point identity, plus decompose/reconstruct/redistribute support, for topologies on a derived mesh or with a variable count | R1 everywhere |
 | 7 | `mapPolyMesh` handling so history survives a topology change | `crackerFvMesh` with a history-dependent law |
 
 <!-- markdownlint-enable MD013 -->
@@ -345,7 +405,12 @@ implementing it as written. The substantive corrections, all incorporated above:
    was too strong (§3).
 2. `faceCentred` and `pointCentred` are not short of a container - mesh-aware
    surface and point fields exist. Their difficulty is shared integration
-   points, which is a semantic problem, not a storage one (§3).
+   points, which is a semantic problem, not a storage one (§3). Following this
+   through is what produced the general classification now in §3: the question
+   is not whether a topology is cell-shaped but which mesh and entity its
+   points attach to, and whether the count per entity is fixed. Gauss points in
+   cells and Gauss points on faces both come out standard-IO-capable, and only
+   a derived mesh or a variable count does not.
 3. The per-cell broadcast is exact only where an integration point belongs to
    one cell. Calling it "not a compromise" was wrong for shared topologies,
    which need a declared mapping policy (§4).

--- a/src/solids4FoamModels/mechanicalConstitutiveLaw/DESIGN-state-io.md
+++ b/src/solids4FoamModels/mechanicalConstitutiveLaw/DESIGN-state-io.md
@@ -1,0 +1,371 @@
+# Design: persistent and prescribed constitutive state
+
+Status: proposal, revised after review. Nothing here is implemented yet.
+
+The first draft was reviewed and came back "do not implement as written". The
+substantive objections are incorporated below and summarised in §10.
+
+Applies to the `mechanicalConstitutiveLaw` framework. Resolves OQ-2 and the
+wider requirement behind it.
+
+---
+
+## 1. This is three requirements, not one
+
+They are usually discussed together, and they pull in different directions.
+
+<!-- markdownlint-disable MD013 -->
+
+| # | Requirement | Direction | Lifetime | Loss tolerance |
+|---|---|---|---|---|
+| R1 | Restart: history survives stop/start | read **and** write | every write interval | **none** — must round-trip exactly |
+| R2 | Initial stress / initial strain, for any law | read only | once, at construction | none, but it is a per-cell specification by nature |
+| R3 | Material orientation: fibre directions and similar | read only | once, at construction | as R2 |
+
+<!-- markdownlint-enable MD013 -->
+
+R2 and R3 are the same mechanism: read a field the user prepared, never write
+it back. R1 is different: it is a machine-to-machine round trip.
+
+Conflating them is what makes the problem look hard. Separated, R2 and R3 are
+easy and R1 is easy for most topologies and awkward for one.
+
+---
+
+## 2. What the legacy laws already do
+
+This is not a new problem, and the existing answer is good:
+
+```c++
+// linearElasticMisesPlastic.C:341-353
+epsilonP_
+(
+    IOobject
+    (
+        "epsilonP",
+        mesh.time().timeName(),
+        mesh,
+        IOobject::READ_IF_PRESENT,
+        IOobject::AUTO_WRITE
+    ),
+    mesh,
+    dimensionedSymmTensor("zero", dimless, symmTensor::zero)
+),
+```
+
+A `volField` on the primary mesh with `READ_IF_PRESENT` and `AUTO_WRITE`. That
+one declaration satisfies R1 and R2 at once, is inspectable, decomposes and
+reconstructs with the standard tools, and is directly writable by `setFields`.
+`HolzapfelGasserOgdenElastic` reads its fibre fields the same way, as
+`MUST_READ` volFields, which is R3.
+
+**The new framework should not invent a different answer where the old one
+works.** It only needs a different answer where the old one cannot reach.
+
+---
+
+## 3. Why the new framework cannot simply do the same
+
+State in the new framework lives at the integration points of a *topology*, and
+only one topology is one-to-one with cells:
+
+<!-- markdownlint-disable MD013 -->
+
+| Topology | Integration points per cell | Cell-shaped? |
+|---|---|---|
+| `cellCentred` | 1 | yes |
+| `compactCell` (quadrature) | fixed n | no, but regular |
+| `faceCentred` | shared between cells | no, but `surfaceField` fits |
+| `pointCentred` | shared between cells | no, but `pointField` fits |
+| `dualFace` | variable, many | no |
+
+<!-- markdownlint-enable MD013 -->
+
+Two qualifications, both from review.
+
+`faceCentred` and `pointCentred` are **not** short of a container: OpenFOAM has
+mesh-aware surface and point fields with proper parallel handling. What they are
+short of is *semantics* - an integration point shared between two cells can be
+reached from two materials, so a single value per face is not obviously the
+right model. That is a different problem from having nowhere to put the number.
+
+`setFields` sets the internal and boundary values of `volField`s, and finite-area
+fields. It does not set `surfaceField`s, `pointField`s or arbitrary `IOField`s.
+So "a per-cell `volField` is what `setFields` can write" is right; "and nothing
+else" was too strong.
+
+---
+
+## 4. Decision
+
+**The user-facing form is always a `volField` on the primary mesh. The manager
+maps between that and integration points.**
+
+Materials are already defined per primary cell, `setFields` operates on
+volFields, and a per-cell initial condition is what a user actually wants to
+specify. The manager broadcasts a cell's value to every integration point of
+that cell.
+
+**This is exact only where an integration point belongs to exactly one cell**,
+i.e. where `requiresUniqueIntegrationPointsPerMaterial()` is false -
+`cellCentred`, `compactCell`, `dualFace`. For `faceCentred` and `pointCentred`
+an integration point is reachable from two cells that may carry different
+prescribed values, and the broadcast is then ambiguous. The first draft called
+the cell-shaped form "not a compromise"; that is false for shared topologies.
+Those need a stated mapping policy - reject a discontinuity across the point,
+take the owner cell, or interpolate - and the policy has to be part of the
+declaration rather than an implicit choice.
+
+For R1 the direction reverses and the mapping has to be lossless, so it depends
+on the topology:
+
+<!-- markdownlint-disable MD013 -->
+
+| Topology | Restart representation | Standard tools? |
+|---|---|---|
+| `cellCentred` | one `volField`, `READ_IF_PRESENT` / `AUTO_WRITE`. Identical to legacy | yes, fully |
+| `compactCell`, fixed n per cell | n `volField`s, suffixed `_0` … `_n-1` | yes, fully |
+| `dualFace`, `faceCentred`, `pointCentred` | `IOField` under `<time>/mechanicalState/<topology>/<law>/<name>` | **no** — see §7 |
+
+<!-- markdownlint-enable MD013 -->
+
+---
+
+## 5. Laws declare their state; the manager owns the IO
+
+Today each legacy law constructs its own `IOobject`s. That is exactly the
+coupling this framework exists to remove: a law is supposed to be a pure
+function with no knowledge of meshes, files or registries.
+
+So laws *declare* what they need and the manager does the rest:
+
+```c++
+        //- Declare the state fields this law uses.
+        //  Called once, before any evaluation. The manager allocates the
+        //  fields, applies the defaults, reads any prescribed values, and
+        //  arranges for the persistent ones to be written
+        virtual void declareState(mechanicalConstitutiveLawStateSpec& spec) const
+        {}
+```
+
+with
+
+```c++
+enum class stateRole
+{
+    //- History. Written every write interval, read back on restart (R1)
+    persistent,
+
+    //- Prescribed once from a field the user prepared, never written back
+    //  (R2, R3). Absent means the default is used
+    prescribed
+};
+```
+
+and a law declaring, for example:
+
+```c++
+void linearElasticMisesPlasticMechanicalConstitutiveLaw::declareState
+(
+    mechanicalConstitutiveLawStateSpec& spec
+) const
+{
+    spec.add<symmTensor>("epsilonP", stateRole::persistent, symmTensor::zero);
+    spec.add<scalar>("epsilonPEq", stateRole::persistent, 0.0);
+    spec.add<scalar>("sigmaY", stateRole::persistent, yieldStress(0.0));
+}
+```
+
+The manager then, per law and topology: allocates the `Field<Type>` at the
+right size, looks for a `volField` of that name on the primary mesh, broadcasts
+it to the law's integration points if found, and registers the persistent ones
+for writing.
+
+This keeps every law free of IO, and it makes the set of state variables
+introspectable, which is worth having on its own.
+
+---
+
+## 5a. Two things the first draft omitted entirely
+
+**Boundary integration points.** A `boundaryAware()` topology carries a
+*separate* `mechanicalConstitutiveLawState` per law per patch
+(`mechanicalConstitutiveLawManager.C:275-306`), and commits it alongside the
+internal one (`:381-390`). `cellCentred` is boundary-aware, so this is the
+common case, not an exotic one. A single `volField` covers it only if the
+mapping explicitly carries the internal field to the internal state and each
+patch's boundary values to that patch's state, in both directions. The
+declaration therefore has to name the boundary state as part of the same
+variable, not leave it implicit.
+
+**Mesh topology change.** `crackerFvMesh` calls `changeMesh()`
+(`crackerFvMesh.C:561-579`). Constitutive state is a raw `Field` whose
+`setSize()` zero-fills any growth (`mechanicalConstitutiveLawState.C:215-253`),
+and the manager caches topologies and their state for its whole lifetime
+(`mechanicalConstitutiveLawManager.H:142-191`). So a topology change today
+would silently zero the history of every new cell and misalign the rest.
+
+This is a blocker rather than a detail, and it affects *continuing* runs, not
+just restarts. The framework needs a `mapPolyMesh` path that rebuilds the
+topology and its addressing and maps **both current and old-time** state,
+including onto newly created crack faces and points. Until that exists, a
+history-dependent law on a changing mesh must be refused.
+
+---
+
+## 6. Initial stress and initial strain are manager-level, not per-law
+
+The requirement is that they work for **any** law, including `linearElastic`.
+Adding a `sigma0` term to every law would be repetitive, easy to get wrong, and
+would have to be repeated for every law written in future.
+
+Instead the manager applies them around the law:
+
+```text
+initial strain:   the law is evaluated at (gradD - gradD_initial)
+initial stress:   sigma += sigma_initial, after evaluation
+```
+
+Both are `prescribed` fields with the reserved names `initialStrain` and
+`initialStress`, allocated only if the corresponding `volField` is present.
+When absent there is no field, no branch in the inner loop, and no cost.
+
+Note the name: `gradD0` already means the *previous-time* displacement gradient
+(`smallStrainMechanicalConstitutiveLawKinematics.H:86-92`) and must not be
+reused for a prescribed initial value.
+
+**Limitations, stated rather than hidden.** Both were understated in the first
+draft.
+
+* The additive treatment of initial strain is a **small-strain, total-form**
+  construction. It is not automatically valid for a law written in incremental
+  or rate form, and finite strain needs a multiplicative split
+  `F = F_e * F_initial`. The reference convention has to be declared per
+  kinematic formulation rather than assumed, and anything outside the case it
+  is defined for must be refused rather than silently applied.
+* `initialStress` needs a stated stress measure and frame. Adding a prescribed
+  field to whatever a law returns is only meaningful once "Cauchy, current
+  configuration" - or whatever the convention is - is written down.
+
+---
+
+## 7. The awkward case, and what to do about it
+
+For `dualFace` and the other shared-point topologies there is no cell-shaped
+lossless representation, because the number of integration points per cell
+varies. Three options:
+
+1. **A topology-aware persistent field per topology per law.** Not a bare
+   `IOField`: that is an ordered `Field` plus IO and nothing more
+   (`IOField.H:53-57`), with no mesh addressing and no identity for an
+   integration point, so it is only safe on an unchanged mesh with an identical
+   processor layout and ordering. A real solution carries global or topological
+   identity for each integration point and supports decompose, reconstruct and
+   redistribute - which means a purpose-built `regIOobject`, not a file in a
+   subdirectory.
+2. **Reduce to one value per cell.** Standard tools work, everything is
+   inspectable, and restart is *approximate*: the loss is exactly the sub-cell
+   variation of history, i.e. a restarted run behaves as though history had
+   been homogenised within each cell.
+3. **Refuse.** Error if a history-dependent law is used on a non-cell-shaped
+   topology, until 1 is implemented.
+
+**Recommendation: 3 now, 1 next, never 2.** With one widening from review: the
+guard in 3 must cover *every* combination that lacks an exact defined mapping,
+not just the multi-point topologies. That includes boundary state, shared
+integration points with conflicting cell values, and any mesh that can change
+topology. Option 2 produces a run that
+restarts to a subtly different state with no indication that anything was lost,
+which is the worst property a restart can have. Option 3 costs one guard and is
+honest. Option 1 is the real answer and can be built when someone needs a
+parallel restart of a vertex-centred elastoplastic case.
+
+Note that the vertex-centred solvers currently in the tree only run
+`linearElastic`, which has no history at all, so option 3 blocks nothing that
+works today.
+
+---
+
+## 8. Staging
+
+<!-- markdownlint-disable MD013 -->
+
+| Step | Content | Unblocks |
+|---|---|---|
+| 1 | `declareState` and the spec object; manager allocates and applies defaults. No IO yet | the rest |
+| 2 | `prescribed` fields read from `volField`s and broadcast to integration points | R2, R3, fibre directions, `setFields` |
+| 3 | `initialStress` and `initialStrain` applied by the manager, small strain only | the specific request |
+| 4 | `persistent` fields written and read as `volField`s for cell-shaped topologies | R1 for cell-centred solid models |
+| 5 | Guard refusing history-dependent laws on non-cell-shaped topologies | honest failure instead of silent loss |
+| 6 | Topology-aware persistent state with integration-point identity, plus decompose/reconstruct/redistribute support | R1 everywhere |
+| 7 | `mapPolyMesh` handling so history survives a topology change | `crackerFvMesh` with a history-dependent law |
+
+<!-- markdownlint-enable MD013 -->
+
+Steps 1 to 3 are worth doing on their own: they deliver initial stress, initial
+strain and fibre directions, none of which exist in the new framework today,
+and none of which depend on the restart question being settled.
+
+---
+
+## 9. Open questions
+
+* **Q1. Answered, and it could not be deferred.** A `prescribed` field that is
+  never written would simply vanish on restart, because construction searches
+  the restart time directory and not `0/`. So prescribed inputs are read from
+  `constant/`, which is where time-independent material data belongs and where
+  the fibre-angle inputs of the legacy anisotropic law would also sit. That
+  keeps them present on restart without writing them every interval.
+* **Q2.** Should `persistent` fields be written every write interval, or only
+  on demand? Every interval matches the legacy `AUTO_WRITE` behaviour and makes
+  restart automatic, at the cost of larger output for laws with several state
+  variables. Whichever is chosen, only converged end-of-time-step state may be
+  written: an intermediate nonlinear-iteration value must never be persisted as
+  restart history. On load, current and old-time state must both be initialised
+  coherently before the first evaluation, since a law reads old-time state and
+  the manager only rolls current into old when the time index advances
+  (`mechanicalConstitutiveLawManager.C:354-395`).
+* **Q4.** What is the reference configuration and stress measure for
+  `initialStress`, and which kinematic formulations may `initialStrain` be
+  offered for? §6 needs these written down before it is implemented.
+
+* **Q3.** Where a law's state has a natural physical name that collides across
+  laws in a multi-material case (`epsilonP` for two different plastic laws),
+  does the on-disk name need a per-material qualifier? The legacy code sidesteps
+  this with sub-meshes, which this framework removes.
+
+---
+
+## 10. What the review changed
+
+The first draft was reviewed by an independent agent, which recommended against
+implementing it as written. The substantive corrections, all incorporated above:
+
+1. `setFields` writes volFields *and* finite-area fields; "and nothing else"
+   was too strong (§3).
+2. `faceCentred` and `pointCentred` are not short of a container - mesh-aware
+   surface and point fields exist. Their difficulty is shared integration
+   points, which is a semantic problem, not a storage one (§3).
+3. The per-cell broadcast is exact only where an integration point belongs to
+   one cell. Calling it "not a compromise" was wrong for shared topologies,
+   which need a declared mapping policy (§4).
+4. **Boundary state was omitted entirely.** `boundaryAware()` topologies keep a
+   separate state per law per patch, and `cellCentred` is boundary-aware, so
+   this is the common case (§5a).
+5. **Mesh topology change was omitted entirely.** `crackerFvMesh` changes the
+   mesh; state is a raw `Field` that zero-fills on growth, so history would be
+   silently corrupted on a continuing run, not merely on restart (§5a).
+6. A bare `IOField` is not a restart format: no addressing, no integration-point
+   identity, unsafe across decomposition. The lossless option needs a
+   purpose-built `regIOobject` (§7).
+7. Prescribed fields would vanish on restart, since construction reads the
+   restart time and not `0/`. They move to `constant/`, which answers Q1 (§9).
+8. §6 reused the name `gradD0`, which already means the previous-time gradient,
+   and over-claimed generality: the additive treatment is small-strain
+   total-form only, and initial stress needs a stated measure and frame (§6).
+
+The review endorsed keeping `declareState` rather than letting laws own their
+own IO, on the condition that the descriptor carries dimensions, persistence,
+scope, mapping policy and validation. It also suggested keeping immutable
+orientation inputs conceptually distinct from evolving state even where they
+share a loading service, which is worth doing.

--- a/src/solids4FoamModels/mechanicalConstitutiveLaw/DESIGN-tangents.md
+++ b/src/solids4FoamModels/mechanicalConstitutiveLaw/DESIGN-tangents.md
@@ -1753,7 +1753,51 @@ something the query computed - shadows never write current-time fields, so the
 committed values are the same whichever call triggers it - but the contract now
 says so instead of claiming the query modifies nothing at all.
 
-### 8.10 Open questions still outstanding
+### 8.10 Correction: boundary dual faces *are* read, by the residual
+
+§8.4 states that "no boundary dual face is ever read" and concludes that
+`dualFaceIntegrationPointTopology::nIntegrationPoints()` should be
+`dualMesh().nInternalFaces()`. **That is true of the Jacobian and false of the
+residual**, and the distinction was missed because only the Jacobian had moved.
+
+The three `vfvm` assembly routines do iterate `dualMesh.owner()`, i.e. internal
+dual faces only. But the residual path in
+`vertexCentredLinGeomSolid::updatePointDivSigma` does this:
+
+```c++
+surfaceVectorField dualTraction(dualN & dualSigmaf_);
+enforceTractionBoundaries(pointD, dualTraction, mesh(), ...);
+const vectorField dualDivSigma = fvc::div(dualTraction*dualMesh().magSf());
+```
+
+`fvc::div` of a surface field sums fluxes over every face of each cell,
+boundary faces included, so the **boundary field** of `dualSigmaf_` is read.
+`enforceTractionBoundaries` overwrites it only on patches whose `pointD`
+boundary condition is a `solidTractionPointPatchVectorField`; a
+fixed-displacement patch keeps `dualN & dualSigmaf_`. `cantilever2d` has a
+clamped end, so this is live in the one case that covers this solver.
+
+**Consequence.** The tangent-only slice of PR-4 is unaffected: it only ever
+needed internal faces. Moving *stress* onto the manager needs boundary dual
+faces as well, which the present topology deliberately excludes. The stress
+move is therefore blocked on a decision about how to represent them.
+
+**Recommended.** One topology covering all dual faces, indexed
+`[0, nInternalFaces)` for internal and `[nInternalFaces, nFaces)` for boundary,
+with the solid model gathering `dualGradDf_` and scattering `dualSigmaf_`
+across the internal field and the boundary patches. One topology means one set
+of constitutive state, which is the property that matters: a history-dependent
+law must not have its plastic strain split across two state objects. The
+Jacobian then reads the first `nInternalFaces` entries of the same arrays, and
+`vfvm::divSigma` is indifferent to a longer list.
+
+Rejected: a second, boundary-only topology, because it gives each dual face
+family its own `mechanicalConstitutiveLawState` and so splits history. Also
+rejected as an endpoint: leaving boundary stress with `dualMechanicalModel`,
+because then it can never be removed - though it would work as a stepping
+stone.
+
+### 8.11 Open questions still outstanding
 
 OQ-1 (restart `impK` state-dependence), OQ-3 (configurable `impKf_` cadence),
 OQ-5 (`fourthOrderFiniteDifference` production status), OQ-6 (stabilisation term

--- a/src/solids4FoamModels/mechanicalConstitutiveLaw/DESIGN-tangents.md
+++ b/src/solids4FoamModels/mechanicalConstitutiveLaw/DESIGN-tangents.md
@@ -1513,9 +1513,9 @@ Supersedes the stage numbering in §5. Content is otherwise as described there.
 | 2 | **Done.** Flat-list `updateStressSmallStrain`/`updateStressFiniteStrain`/`updateTangentSmallStrain`/`updateTangentFiniteStrain` primitives, with the two `CompactListList` overloads and the internal-field half of the two `volTensorField` overloads re-expressed on them; `registerTopology()` and `topologyFor()` made public; `dualFaceIntegrationPointTopology`; defect D6. Plus `Test-mechanicalConstitutiveLaw`, run by the `layeredPipe` regression test. See §8.6. |
 | 3 | **Done.** `solidModel::jacobianTangent(deflt)` and the `approximateJacobian` deprecation shim, used by both vertex-centred solvers; the shadow state of §3.1; a working `fourthOrderFiniteDifference` tangent. The optional manager on `solidModel` moves to PR-4. See §8.8. |
 | 4 | **Done.** `vertexCentredLinGeomSolid` tangent-only adoption (§8.4), plus the optional manager deferred from PR-3. See §8.9. |
-| 5 | `vertexCentredNonLinGeomTotalLagSolid` tangent-only; then stress for both, removing `dualMechanicalModel` and requiring OQ-2 to be settled. |
+| 5 | Stress for `vertexCentredLinGeomSolid`, removing its dependence on `dualMechanicalModel`. Its nonlinear sibling is disabled, see §8.11. |
 | 6 | `hofvm::divSigmaIntoPETScMatrix(mat66)` + uniform-tangent fast path; delete the `(impK_-K)*3/4` back-derivation from the three cell-centred solvers. |
-| 7…n | Cell-centred solvers, risk-ordered: `uns*` → `thermal`/`poro` → `nonLinGeom*` → `linGeomTotalDispSolid` → `coupledPressureDisplacementSolid`. |
+| 7…n | Cell-centred solvers and their high-order variants, the ones in common use and now the priority, risk-ordered: `uns*` → `thermal`/`poro` → `nonLinGeom*` → `linGeomTotalDispSolid` → `coupledPressureDisplacementSolid`. |
 | final | Retire the legacy tangent interface and migrate or bless the six `"impK"` registry consumers (OQ-8). |
 
 <!-- markdownlint-enable MD013 -->
@@ -1797,7 +1797,26 @@ rejected as an endpoint: leaving boundary stress with `dualMechanicalModel`,
 because then it can never be removed - though it would work as a stepping
 stone.
 
-### 8.11 Open questions still outstanding
+### 8.11 `vertexCentredNonLinTotalLagGeometry` is disabled
+
+Its compilation is commented out in `Make/files.openfoam` and
+`Make/files.foamextend`, and the reason is recorded in the solver's own
+`README.md`. No tutorial ever selected it, and an attempt to give it one failed:
+three of its dictionary entries have no defaults and are set by no case, and
+with those supplied the run dies in a floating point exception inside the PETSc
+solve on the first Newton step.
+
+That state pre-dates this work and is independent of it. Fixing it is separate
+from the constitutive law migration, so the migration skips it rather than
+carrying an untestable solver.
+
+**Consequence for the plan.** PR-5's original content - the nonlinear
+vertex-centred tangent, then stress for both vertex-centred models - reduces to
+stress for `vertexCentredLinGeomSolid` alone. The priority after that moves to
+the cell-centred solid models and their high-order variants, which are the ones
+in common use.
+
+### 8.12 Open questions still outstanding
 
 OQ-1 (restart `impK` state-dependence), OQ-3 (configurable `impKf_` cadence),
 OQ-5 (`fourthOrderFiniteDifference` production status), OQ-6 (stabilisation term

--- a/src/solids4FoamModels/solidModels/vertexCentredNonLinGeomTotalLagSolid/README.md
+++ b/src/solids4FoamModels/solidModels/vertexCentredNonLinGeomTotalLagSolid/README.md
@@ -1,239 +1,32 @@
----
-sort: 8
----
+# vertexCentredNonLinTotalLagGeometry
 
-# vertexCentredNonLinGeomTotalLagSolid
+**This solid model is currently disabled and does not compile into the
+library.** See the commented-out entry in `src/solids4FoamModels/Make/files.*`.
 
-This page documents the vertex-centred nonlinear total-Lagrangian solid model.
-The runtime type is:
+## Why
 
-```text
-vertexCentredNonLinTotalLagGeometry
-```
+No tutorial in the repository selects it, so nothing has ever exercised it. An
+attempt to give it a regression case, on a hyperelastic cantilever beam with a
+`neoHookeanElastic` material, did not succeed:
 
-The model assumes finite strains and rotations and solves for the total
-displacement at the mesh **points**, `pointD`, in the total-Lagrangian frame,
-so the mesh is not moved. As with
-[vertexCentredLinGeomSolid](https://www.solids4foam.com/documentation/solid-models/vertexCentredLinGeomSolid.html),
-the governing equations are integrated over a dual mesh built automatically by
-`meshDualiser`, and the implicit system is solved with PETSc SNES.
+- `useGeometricStiffness` and `compactImplicitStencil` are looked up with no
+  default, and no case sets either.
+- The material tangent path needs `tangentEps` in the material sub-dictionary,
+  which no tutorial in the repository sets. It is an absolute perturbation, and
+  so has the scale-dependence problem that the equivalent in the mechanical
+  constitutive law framework was fixed for.
+- The scalar Jacobian arm additionally needs an `interpolate(impK)` entry in
+  `system/dualMesh/fvSchemes`, which no case provides.
 
-```note
-This model works best on triangular and tetrahedral grids. It requires PETSc
-for the implicit path.
-```
+With all of those supplied, the run still fails with a floating point exception
+inside the PETSc solve, on the first Newton step.
 
----
+## What would re-enable it
 
-## User Guide
+A case that runs it, and whatever fix the floating point exception turns out to
+need. This is independent of the mechanical constitutive law framework: the
+model was already in this state before that work began, and the framework
+neither caused nor depends on it.
 
-### What this model solves
-
-`vertexCentredNonLinGeomTotalLagSolid`:
-
-- solves the momentum equation in total-Lagrangian form over the dual mesh,
-  with the primary unknown at the mesh points;
-- carries the kinematics at the **dual mesh faces** — `dualFf`, `dualFinvf`,
-  `dualJf` — alongside `dualGradDf` and `dualSigmaf`;
-- assembles the material tangent _and_, optionally, the geometric stiffness
-  into the Jacobian;
-- can add pressure as an extra unknown per point, for near-incompressible
-  materials;
-- enforces displacement boundary conditions as fixed degrees of freedom;
-- also offers an explicit central-difference path.
-
-### Supported solution algorithms
-
-The `solutionAlgorithm` entry selects the path:
-
-| Value | Meaning | Notes |
-| --- | --- | --- |
-| `PETScSNES` | Newton-Raphson via PETSc SNES | The intended path |
-| `explicit` | Explicit time integration | Time-step limited by stability |
-| `implicitSegregated` | Not implemented | Fatal error; use `PETScSNES` |
-| `implicitCoupled` | Not implemented | Fatal error; use `PETScSNES` |
-
-```warning
-The base-class default is `implicitSegregated`, which this model rejects with
-a fatal error. Every case **must** set `solutionAlgorithm` explicitly.
-```
-
-### Model options
-
-| Entry | Default | Description |
-| --- | --- | --- |
-| `useGeometricStiffness` | none | Geometric stiffness in the Jacobian |
-| `zeta` | `1.0` | Compact edge gradient fraction |
-| `zetaImplicit` | `zeta` | The `zeta` used to form the Jacobian |
-| `approximateJacobian` | `false` | Compact Laplacian instead of the tangent |
-| `compactImplicitStencil` | none | Compact stencil for that Jacobian |
-| `tangentEps` | `1e-10` | Geometric stiffness perturbation size |
-| `fixedDofScale` | see below | Scaling of the constraint equations |
-| `predictor` | `false` | Predict `pointD` at a new time step |
-| `predictorMethod` | `linear` | `linear` or `quadratic` predictor |
-| `optionsFile` | `petscOptions` | PETSc options file name |
-| `stopOnPetscError` | `true` | Stop if PETSc reports an error |
-
-`zeta` is the compact edge gradient fraction: `0` is more accurate but more
-prone to oscillations, `1` is less accurate but more robust. It is the entry
-most worth tuning, and the shipped tutorial uses `0.1`. `zetaImplicit`
-defaults to `zeta`, and lets the Jacobian use a different value from the
-residual.
-
-`compactImplicitStencil` has no default and is only read when
-`approximateJacobian` is enabled, in which case it must be present.
-
-`fixedDofScale` defaults to `average(impK)*sqrt(gAverage(magSf))`, so that the
-constraint equations are conditioned like the momentum equations.
-
-The `linear` predictor assumes constant velocity over the step; `quadratic`
-assumes constant acceleration.
-
-`useGeometricStiffness` is read with `lookup()`, so it has no default and the
-model fails at construction if it is missing. Including the geometric
-stiffness costs one Jacobian assembly pass but usually pays for itself in
-Newton iterations on strongly nonlinear problems.
-
-The relevant inherited `solidModel` entries are:
-
-| Entry | Default | Relevance |
-| --- | --- | --- |
-| `solutionAlgorithm` | `implicitSegregated` | Must be overridden, see above |
-| `solvePressure` | `false` | Adds pressure as an extra unknown per point |
-| `infoFrequency` | `100` | Frequency for solver progress output |
-
-The block size of the PETSc system is 2 in 2-D and 3 in 3-D, or 3 and 4
-respectively when `solvePressure` is enabled.
-
-### Recommended dictionary setup
-
-Minimal example for `constant/solidProperties`:
-
-```text
-solidModel     vertexCentredNonLinTotalLagGeometry;
-
-vertexCentredNonLinTotalLagGeometryCoeffs
-{
-    // Solution algorithm (PETScSNES, explicit)
-    solutionAlgorithm     PETScSNES;
-
-    // Include the geometric stiffness in the Jacobian
-    useGeometricStiffness yes;
-
-    // Use the exact Jacobian or a small-stencil approximation
-    approximateJacobian   no;
-
-    // Compact edge discretisation fraction
-    // 0 -> more accurate but oscillations more likely
-    // 1 -> less accurate but oscillations less likely
-    zeta                  0.1;
-}
-```
-
-A `petscOptions` file must be present in the case directory, unless the name is
-overridden with `optionsFile`.
-
-### Required fields and boundary conditions
-
-The boundary conditions are set on `pointD`, a `pointVectorField`, not on the
-cell-centred `D`. The available point patch types are the same as for the
-linear-geometry vertex-centred model:
-
-| Patch type | Purpose |
-| --- | --- |
-| `pointSolidTraction` | Prescribed traction and pressure |
-| `pointNormalDisplacement` | Prescribed normal displacement |
-| `pointFixedDisplacementZeroShear` | Normal displacement fixed, zero shear |
-| `pointFixedRotation` | Prescribed rotation about an axis |
-| `pointLinearSpatialDisplacement` | Displacement varying linearly in space |
-| `pointSolidForce` | Prescribed force |
-| `pointSolidContact` | Contact |
-| `componentMixed` | Mixed per-component condition |
-
-```warning
-`tractionBoundarySnGrad()` is `notImplemented` for this model, as is
-`solutionD()`; both are cell-centred concepts.
-```
-
-### Field glossary
-
-- `pointD`: total displacement at the mesh points; the primary unknown.
-- `pointP`: point pressure, when `solvePressure` is enabled.
-- `pointDD`, `pointU`, `pointA`, `pointRho`: point increment, velocity,
-  acceleration and density.
-- `pointVol`, `pointGlobalVol`: dual cell volume per point, local and with
-  processor-boundary contributions summed.
-- `pointDivSigma`: divergence of stress at each point; the momentum residual.
-- `dualGradDf`, `dualSigmaf`: displacement gradient and stress at the dual
-  faces.
-- `dualFf`, `dualFinvf`, `dualJf`: total deformation gradient, its inverse and
-  Jacobian at the dual faces.
-- `dualPf`, `volP`: pressure at the dual faces and at cell centres.
-- `D`, `sigma`: cell-centred fields, interpolated for post-processing.
-
-### Explicit path
-
-With `solutionAlgorithm explicit`, `setDeltaT()` computes the stable time step
-from the elastic wave speed and the dual mesh `deltaCoeffs`, scaled by `maxCo`
-from `controlDict` (default `0.1`).
-
----
-
-## Developer Notes
-
-### Class role
-
-`vertexCentredNonLinGeomTotalLagSolid` inherits from `solidModel` and, when
-PETSc is available, from `foamPetscSnesHelper`. It is the finite-strain
-counterpart of `vertexCentredLinGeomSolid` and shares its structure: dual
-mesh, `dualMechanicalModel`, fixed degrees of freedom, and a PETSc SNES
-driver.
-
-- `nonLinGeom()` returns `TOTAL_LAGRANGIAN`, so the mesh is never moved;
-- the unknowns live at points, so `solutionD()` is `notImplemented`;
-- the extra state relative to the linear model is the dual-face kinematics and
-  the optional pressure unknown.
-
-### PETSc SNES path
-
-`evolveSnes()` drives `foamPetscSnesHelper`, which calls back into:
-
-- `formResidual()`, which extracts `pointD` (and `pointP` when solving
-  pressure) from the solution vector, corrects the boundary conditions,
-  computes `dualGradDf` via `vfvc::fGrad` with `zeta`, forms `dualFf`,
-  `dualFinvf` and `dualJf`, evaluates `dualSigmaf`, and assembles
-  `pointDivSigma` on the deformed dual areas `J*Finv.T() & Sf0`;
-- `formJacobian()`, which adds either the exact linearisation of `div(sigma)`
-  through `vfvm::divSigma` using `materialTangentFaceField()`, or a compact
-  Laplacian through `vfvm::laplacian` when `approximateJacobian` is set, and
-  then — if `useGeometricStiffness` is enabled — the geometric stiffness.
-
-### Geometric stiffness
-
-`geometricStiffnessField()` builds the contribution to the tangent that comes
-from the deformed area vector `gamma = J*F^-T & Sf0` changing with the
-displacement. It is formed **numerically**: for each of the nine components of
-`gradD` in turn, the component is perturbed by `tangentEps`, `F`, `Finv`, `J`
-and the deformed `Sf` are recomputed, and the tangent column is the finite
-difference `(SfPerturb - SfRef)/eps`.
-
-Because it is a finite difference, `tangentEps` trades truncation error
-against round-off. The default `1e-10` suits displacement gradients of order
-one; on problems with very small or very large strains it may need adjusting.
-
-### Extension points
-
-- `formResidual()` and `formJacobian()` for a different discretisation;
-- `geometricStiffnessField()` if an analytical geometric tangent is derived,
-  which would remove the `tangentEps` sensitivity;
-- `setFixedDofs()` and `enforceTractionBoundaries()` for new point patch
-  types.
-
----
-
-## Tutorials
-
-No tutorial currently selects `vertexCentredNonLinTotalLagGeometry`. The
-finite-strain cases under `solids/hyperelasticity` are the natural place to
-try it, but note that they use cell-centred `D` boundary conditions, so the
-`0/pointD` field and its point patch types have to be set up first.
+Its linear-geometry sibling, `vertexCentredLinearGeometry`, is unaffected,
+compiles, and is covered by the `cantilever2d` tutorial.


### PR DESCRIPTION
## What this contains 📦

Stacked on #403 → #402 → #198. **Review those first.**

Three small, separable things that arose while preparing the vertex-centred
stress migration. The cross-fork build work that originally sat here has moved
down into #403, where it belongs: that is the PR which first makes a compiled
solid model reference the manager, and so the one that breaks the other forks.

### 1. `vertexCentredNonLinTotalLagGeometry` is disabled

It does not run. No tutorial selects it, so nothing ever exercised it, and an
attempt to give it a regression case failed: `useGeometricStiffness`,
`compactImplicitStencil` and the material's `tangentEps` are looked up with no
defaults and set by no case, and with those supplied the run dies in a floating
point exception inside the PETSc solve on the first Newton step.

That state pre-dates this work and is independent of it. Its source is
commented out of both fork file lists, with the details recorded in a README
beside it, so the migration can route around it rather than carry an untestable
solver through every increment. Its linear-geometry sibling is unaffected and
stays covered by `cantilever2d`.

### 2. A correction to the tangent design

§8.4 claimed that no boundary dual face is ever read. That is true of the
Jacobian and **false of the residual**: `fvc::div` sums over every face of a
dual cell, and `enforceTractionBoundaries` overwrites the traction only on
patches carrying a `solidTraction` point boundary condition, so a
fixed-displacement patch keeps the value derived from `dualSigmaf_`'s boundary
field. `cantilever2d` has a clamped end, so this is live in the one tutorial
covering that solver.

Nothing merged is affected — the tangent-only slice needs internal faces only —
but it changes how the *stress* migration must represent dual faces, so it is
recorded before that code is written.

### 3. A design for persistent and prescribed constitutive state

`DESIGN-state-io.md` proposes how constitutive state is persisted and
prescribed: restart of history, initial stress and initial strain usable by any
law including `linearElastic`, and orientation fields such as fibre directions,
initialisable with `setFields` where possible.

The central move is separating three requirements usually discussed as one.
Restart is an exact machine round-trip; initial stress, initial strain and
fibre directions are read-only inputs, and per-cell by nature. Laws *declare*
their state and the manager does the IO, which keeps laws the pure functions
this framework exists to make them.

It was reviewed by an independent agent, which recommended against implementing
the first draft. §10 lists what changed. Two omissions were substantive:
boundary integration points, where a `boundaryAware` topology keeps a separate
state per law per patch and `cellCentred` is boundary-aware; and mesh topology
change, where `crackerFvMesh` calls `changeMesh()` while state is a raw `Field`
that zero-fills on growth, so history would be corrupted on a *continuing* run
rather than only on restart.

**Nothing in it is implemented.** It is a proposal for review.

## Testing ✅

Full regression set passes. Builds clean on OpenFOAM-v2512 and foam-extend-4.1.
