### PR TITLE
Finite-strain finite-difference material tangent

### DIFF
--- a/applications/test/mechanicalConstitutiveLaw/Test-mechanicalConstitutiveLaw.C
+++ b/applications/test/mechanicalConstitutiveLaw/Test-mechanicalConstitutiveLaw.C
@@ -401,7 +401,21 @@ int main(int argc, char *argv[])
             J[ipI] = det(F[ipI]);
         }
 
+        // Poisoned, so that an integration point the manager fails to
+        // reach fails the comparison deterministically. mat66 is a POD, so
+        // left alone its contents would be whatever memory held, which is a
+        // test that passes or fails by luck
         List<mat66> fdC(n);
+        forAll(fdC, ipI)
+        {
+            for (label i = 0; i < 6; ++i)
+            {
+                for (label j = 0; j < 6; ++j)
+                {
+                    fdC[ipI](i, j) = GREAT;
+                }
+            }
+        }
 
         manager.updateTangentFiniteStrain
         (
@@ -414,33 +428,58 @@ int main(int argc, char *argv[])
         const label ZZ = symmTensor::ZZ;
         const label XY = symmTensor::XY;
 
-        // Internal faces only. The face-centred topology reports nFaces
-        // integration points but assigns only the internal ones to cells, and
-        // therefore to laws, so the boundary entries are never written
+        // Every integration point of the topology, boundary faces included.
+        // The deformation is uniform, so the tangent is the same everywhere
+        // and the boundary points are held to exactly the same standard as
+        // the internal ones.
+        //
+        // This is deliberate, and is the regression guard for the defect of
+        // section 8.14: the face-centred topology reports nFaces integration
+        // points, and until the manager evaluated the boundary ones, every
+        // entry from nInternalFaces upwards was left unwritten. Restricting
+        // this loop to internal faces would hide a repeat of that defect
         const label nInternal = mesh.nInternalFaces();
 
         // Single material here, so the constants are uniform
-        scalar maxRelError = 0.0;
-        for (label ipI = 0; ipI < nInternal; ++ipI)
+        const scalar mu = refMu[0];
+        const scalar lambda = refLambda[0];
+        const scalar scale = lambda + 2.0*mu;
+
+        scalar maxRelErrorInternal = 0.0;
+        scalar maxRelErrorBoundary = 0.0;
+
+        for (label ipI = 0; ipI < n; ++ipI)
         {
-            const scalar mu = refMu[0];
-            const scalar lambda = refLambda[0];
-            const scalar scale = lambda + 2.0*mu;
             const mat66& C = fdC[ipI];
 
-            maxRelError =
-                max(maxRelError, mag(C(XX, XX) - (lambda + 2.0*mu))/scale);
-            maxRelError =
-                max(maxRelError, mag(C(ZZ, ZZ) - (lambda + 2.0*mu))/scale);
-            maxRelError = max(maxRelError, mag(C(XX, YY) - lambda)/scale);
-            maxRelError = max(maxRelError, mag(C(XY, XY) - mu)/scale);
-            maxRelError = max(maxRelError, mag(C(XX, XY))/scale);
+            scalar e = 0.0;
+            e = max(e, mag(C(XX, XX) - (lambda + 2.0*mu))/scale);
+            e = max(e, mag(C(ZZ, ZZ) - (lambda + 2.0*mu))/scale);
+            e = max(e, mag(C(XX, YY) - lambda)/scale);
+            e = max(e, mag(C(XY, XY) - mu)/scale);
+            e = max(e, mag(C(XX, XY))/scale);
+
+            if (ipI < nInternal)
+            {
+                maxRelErrorInternal = max(maxRelErrorInternal, e);
+            }
+            else
+            {
+                maxRelErrorBoundary = max(maxRelErrorBoundary, e);
+            }
         }
 
         reportError
         (
             "reproduces the small-strain isotropic tangent near F = I",
-            maxRelError,
+            maxRelErrorInternal,
+            1e-3
+        );
+
+        reportError
+        (
+            "reproduces that tangent on boundary faces too",
+            maxRelErrorBoundary,
             1e-3
         );
 

--- a/applications/test/mechanicalConstitutiveLaw/Test-mechanicalConstitutiveLaw.C
+++ b/applications/test/mechanicalConstitutiveLaw/Test-mechanicalConstitutiveLaw.C
@@ -51,6 +51,8 @@ Description
          evaluated before and after intervening queries at wildly different
          kinematics is identical.
       9. updateScalarTangent agrees with the tangent from a stress update.
+     9a. The finite-strain finite-difference tangent of a hyperelastic law
+         reproduces the analytical small-strain isotropic tangent near F = I.
      10. The misuse guards fire: a fourth-order tangent on a topology that
          cannot carry one, a flat-list update on a topology whose integration
          points are shared between cells and where more than one material
@@ -208,11 +210,19 @@ int main(int argc, char *argv[])
     // topologies and the guards - applies to any law, and a history-dependent
     // law is the only thing that exercises the shadow state properly
     bool allLinearElastic = true;
+    bool allNeoHookean = true;
     forAll(lawEntries, lawI)
     {
-        if (word(lawEntries[lawI].dict().lookup("type")) != "linearElastic")
+        const word type(lawEntries[lawI].dict().lookup("type"));
+
+        if (type != "linearElastic")
         {
             allLinearElastic = false;
+        }
+
+        if (type != "neoHookeanElastic")
+        {
+            allNeoHookean = false;
         }
     }
 
@@ -220,13 +230,29 @@ int main(int argc, char *argv[])
     {
         const dictionary& lawDict = lawEntries[lawI].dict();
 
-        if (!allLinearElastic)
+        if (!allLinearElastic && !allNeoHookean)
         {
             continue;
         }
 
-        const scalar E = dimensionedScalar(lawDict.lookup("E")).value();
-        const scalar nu = dimensionedScalar(lawDict.lookup("nu")).value();
+        // A law may be given as E and nu or as mu and K, so accept either
+        // here too rather than assuming the first form
+        scalar E = 0.0;
+        scalar nu = 0.0;
+
+        if (lawDict.found("mu") && lawDict.found("K"))
+        {
+            const scalar muIn = dimensionedScalar(lawDict.lookup("mu")).value();
+            const scalar KIn = dimensionedScalar(lawDict.lookup("K")).value();
+
+            E = 9.0*KIn*muIn/(3.0*KIn + muIn);
+            nu = (3.0*KIn - 2.0*muIn)/(2.0*(3.0*KIn + muIn));
+        }
+        else
+        {
+            E = dimensionedScalar(lawDict.lookup("E")).value();
+            nu = dimensionedScalar(lawDict.lookup("nu")).value();
+        }
 
         const scalar mu = E/(2.0*(1.0 + nu));
 
@@ -322,6 +348,120 @@ int main(int argc, char *argv[])
     );
 
     const scalar dt = runTime.deltaTValue();
+
+    // ---------------------------------------------------------------------
+    // Finite-strain finite-difference tangent
+    //
+    // Run first, and on its own, because a finite-strain law such as
+    // neoHookeanElastic implements no small-strain evaluation: every check
+    // below would fatal on it
+    // ---------------------------------------------------------------------
+
+    if (allNeoHookean)
+    {
+        Info<< nl << "Finite-strain finite-difference tangent" << endl;
+
+        // A hyperelastic law linearises to isotropic elasticity as F
+        // approaches the identity, so at a small deformation its
+        // finite-difference spatial tangent must reproduce the analytical
+        // small-strain tangent built from the same constants. That checks the
+        // perturbation, the recomputed inverse and determinant, and the Voigt
+        // convention at once
+        // Face-centred: a cell-centred topology deliberately cannot carry a
+        // fourth-order tangent, since the operators that consume one are
+        // assembled from face fluxes
+        const integrationPointTopology& topo =
+            manager.topologyFor
+            (
+                faceCentredIntegrationPointTopology::typeName
+            );
+
+        const label n = topo.nIntegrationPoints();
+
+        tensorField F(n, tensor::zero);
+        tensorField Finv(n, tensor::zero);
+        scalarField J(n, 0.0);
+        const tensorField F0(n, I);
+        const tensorField Finv0(n, I);
+        const scalarField J0(n, 1.0);
+
+        // A uniform small deformation is enough: the check is on the tangent,
+        // not on any particular strain state
+        const tensor gradDSmall
+        (
+            1e-4,  0.5e-4, 0.0,
+            0.5e-4, -0.7e-4, 0.0,
+            0.0,    0.0,   0.3e-4
+        );
+
+        forAll(F, ipI)
+        {
+            F[ipI] = I + gradDSmall;
+            Finv[ipI] = inv(F[ipI]);
+            J[ipI] = det(F[ipI]);
+        }
+
+        List<mat66> fdC(n);
+
+        manager.updateTangentFiniteStrain
+        (
+            topo, F, F0, Finv, Finv0, J, J0, dt,
+            nullptr, &fdC, tangentRequest::fourthOrderFiniteDifference
+        );
+
+        const label XX = symmTensor::XX;
+        const label YY = symmTensor::YY;
+        const label ZZ = symmTensor::ZZ;
+        const label XY = symmTensor::XY;
+
+        // Internal faces only. The face-centred topology reports nFaces
+        // integration points but assigns only the internal ones to cells, and
+        // therefore to laws, so the boundary entries are never written
+        const label nInternal = mesh.nInternalFaces();
+
+        // Single material here, so the constants are uniform
+        scalar maxRelError = 0.0;
+        for (label ipI = 0; ipI < nInternal; ++ipI)
+        {
+            const scalar mu = refMu[0];
+            const scalar lambda = refLambda[0];
+            const scalar scale = lambda + 2.0*mu;
+            const mat66& C = fdC[ipI];
+
+            maxRelError =
+                max(maxRelError, mag(C(XX, XX) - (lambda + 2.0*mu))/scale);
+            maxRelError =
+                max(maxRelError, mag(C(ZZ, ZZ) - (lambda + 2.0*mu))/scale);
+            maxRelError = max(maxRelError, mag(C(XX, YY) - lambda)/scale);
+            maxRelError = max(maxRelError, mag(C(XY, XY) - mu)/scale);
+            maxRelError = max(maxRelError, mag(C(XX, XY))/scale);
+        }
+
+        reportError
+        (
+            "reproduces the small-strain isotropic tangent near F = I",
+            maxRelError,
+            1e-3
+        );
+
+        Info<< nl
+            << "============================================================"
+            << nl;
+
+        if (nFailed_ == 0)
+        {
+            Info<< "All mechanicalConstitutiveLaw checks passed" << nl
+                << "============================================================"
+                << nl << nl << "End" << nl << endl;
+            return 0;
+        }
+
+        Info<< nFailed_ << " mechanicalConstitutiveLaw check(s) FAILED" << nl
+            << "============================================================"
+            << nl << endl;
+
+        return 1;
+    }
 
     // ---------------------------------------------------------------------
     // 1. Closed-form stress and scalar tangent through the volField overload

--- a/src/solids4FoamModels/mechanicalConstitutiveLaw/DESIGN-tangents.md
+++ b/src/solids4FoamModels/mechanicalConstitutiveLaw/DESIGN-tangents.md
@@ -1944,6 +1944,42 @@ It was found by the finite-strain tangent test, which sized its comparison to
 `nIntegrationPoints()` and got a relative error of exactly 1 on the unwritten
 entries - a number too clean to be anything but "never assigned".
 
+### 8.15 The boundary check earns its place, and how that was established
+
+The finite-strain tangent test now compares **every** integration point of the
+face-centred topology, splitting the report into an internal and a boundary
+check rather than stopping at `nInternalFaces`. That restriction existed only
+as a workaround for the defect of section 8.14, so removing it is what turns
+the test into the regression guard for the fix.
+
+Two things make the boundary check trustworthy rather than decorative:
+
+1. The comparison buffer is **poisoned** with `GREAT` before the call. `mat66`
+   is a POD, so an unpoisoned `List<mat66>` holds whatever memory held, and an
+   integration point the manager never reaches would be compared against
+   arbitrary values - a test that passes or fails by luck.
+
+2. It was **mutation tested**. With `boundaryIntegrationPointIDs` reverted to
+   returning an empty list, i.e. exactly the pre-fix behaviour, the internal
+   check still passes and the boundary check fails with a relative error of
+   1.7e12: the poison, untouched. With the fix in place both pass at 2.2e-4.
+   The check fails when, and only when, the defect is present.
+
+Coverage is on `blockPunch`, whose law is `neoHookeanElastic` and which
+therefore has no small-strain evaluation at all. It is the only runtime
+coverage of the finite-strain kinematics, the finite-difference fourth-order
+tangent, and the boundary integration points. Its material is given as `mu` and
+`K`, which is why the law was extended to accept that form alongside `E` and
+`nu`.
+
+**A build lesson that cost time twice.** The first mutation run reported a
+pass. The mutation was genuinely in the library, but the test application had
+not been relinked, because the library and the applications were built in
+separate steps and only the library step was repeated. The library and the
+applications must be rebuilt **together** before any result from the test
+application means anything - the same trap as the vtable mismatch in section
+8.14. A test result from a half-rebuilt tree is not evidence.
+
 ### 8.15 Open questions still outstanding
 
 OQ-1 (restart `impK` state-dependence), OQ-3 (configurable `impKf_` cadence),

--- a/src/solids4FoamModels/mechanicalConstitutiveLaw/finiteStrainMechanicalConstitutiveLawKinematics.H
+++ b/src/solids4FoamModels/mechanicalConstitutiveLaw/finiteStrainMechanicalConstitutiveLawKinematics.H
@@ -209,6 +209,60 @@ public:
         {
             return F_[i] & inv(F0_[i]);
         }
+
+        //- Return F at integration point ipI with Voigt component j of the
+        //  displacement gradient perturbed by h.
+        //  F = I + gradD, so perturbing F is perturbing the displacement
+        //  gradient. The perturbation is defined on the Voigt strain vector,
+        //  which uses engineering shear, so a shear component moves each
+        //  off-diagonal by h/2 and the corresponding Voigt component by
+        //  exactly h. This matches gradDPerturbed in the small-strain
+        //  kinematics, so a finite-difference tangent taken here is directly
+        //  comparable with a small-strain one
+        inline tensor FPerturbed
+        (
+            const label ipI, const label j, const scalar h
+        ) const
+        {
+            tensor F = F_[ipI];
+
+            switch (j)
+            {
+                case symmTensor::XX:
+                    F.xx() += h;
+                    break;
+
+                case symmTensor::YY:
+                    F.yy() += h;
+                    break;
+
+                case symmTensor::ZZ:
+                    F.zz() += h;
+                    break;
+
+                case symmTensor::YZ:
+                    F.yz() += 0.5*h;
+                    F.zy() += 0.5*h;
+                    break;
+
+                case symmTensor::XZ:
+                    F.xz() += 0.5*h;
+                    F.zx() += 0.5*h;
+                    break;
+
+                case symmTensor::XY:
+                    F.xy() += 0.5*h;
+                    F.yx() += 0.5*h;
+                    break;
+
+                default:
+                    FatalErrorInFunction
+                        << "Invalid Voigt component index j = " << j
+                        << exit(FatalError);
+            }
+
+            return F;
+        }
 };
 
 

--- a/src/solids4FoamModels/mechanicalConstitutiveLaw/mechanicalConstitutiveLaws/mechanicalConstitutiveLaw/mechanicalConstitutiveLaw.C
+++ b/src/solids4FoamModels/mechanicalConstitutiveLaw/mechanicalConstitutiveLaws/mechanicalConstitutiveLaw/mechanicalConstitutiveLaw.C
@@ -152,6 +152,124 @@ void Foam::mechanicalConstitutiveLaw::finiteDifferenceFourthOrder
     }
 }
 
+
+void Foam::mechanicalConstitutiveLaw::finiteDifferenceFourthOrder
+(
+    const finiteStrainMechanicalConstitutiveLawKinematics& kin,
+    mechanicalConstitutiveLawState& state,
+    mechanicalConstitutiveLawResponse& response
+) const
+{
+    if (!response.hasFourthOrderTangent())
+    {
+        FatalErrorInFunction
+            << "Finite difference tangent requested but response has no storage"
+            << exit(FatalError);
+    }
+
+    // Relative perturbation floor, as for the small-strain form. The scale
+    // here is the displacement gradient F - I rather than F itself, since it
+    // is the deformation that sets the useful step, not the identity
+    const scalar hMin = 1e-8;
+    const scalar hRel = 1e-6;
+
+    UIndirectList<symmTensor>& stress = response.stress();
+    UIndirectList<mat66>& Cfield = response.fourthOrderTangent();
+
+    const label nIP = stress.size();
+
+    if (nIP == 0)
+    {
+        return;
+    }
+
+    // The unperturbed stress, which the caller has already evaluated into the
+    // response. Copied element-wise because Field has no constructor from a
+    // UIndirectList on every supported fork
+    Field<symmTensor> sigma0(nIP);
+
+    Field<scalar> h(nIP);
+    forAll(h, ipI)
+    {
+        sigma0[ipI] = stress[ipI];
+        h[ipI] = max(hMin, hRel*mag(kin.F()[ipI] - I));
+    }
+
+    // Evaluate the perturbed states against a shadow, so each column starts
+    // from the same history and the perturbed results are discarded
+    mechanicalConstitutiveLawState shadow
+    (
+        state, mechanicalConstitutiveLawState::SHADOW
+    );
+
+    // Work storage. Every integration point is perturbed at once and the law
+    // evaluated once per Voigt component, as in the small-strain form
+    Field<tensor> FPert(nIP);
+    Field<tensor> FinvPert(nIP);
+    Field<scalar> JPert(nIP);
+    Field<symmTensor> sigmaPert(nIP, symmTensor::zero);
+
+    labelList addr(nIP);
+    forAll(addr, ipI)
+    {
+        addr[ipI] = ipI;
+    }
+
+    const UIndirectList<tensor> FPertView(FPert, addr);
+    const UIndirectList<tensor> FinvPertView(FinvPert, addr);
+    const UIndirectList<scalar> JPertView(JPert, addr);
+    UIndirectList<symmTensor> sigmaPertView(sigmaPert, addr);
+
+    forAll(Cfield, ipI)
+    {
+        // mat66 is not zero-initialised
+        Cfield[ipI].clear();
+    }
+
+    for (label j = 0; j < 6; ++j)
+    {
+        forAll(FPert, ipI)
+        {
+            FPert[ipI] = kin.FPerturbed(ipI, j, h[ipI]);
+
+            // The inverse and determinant must follow the perturbation, or the
+            // kinematics handed to the law would be inconsistent
+            FinvPert[ipI] = inv(FPert[ipI]);
+            JPert[ipI] = det(FPert[ipI]);
+        }
+
+        finiteStrainMechanicalConstitutiveLawKinematics kinPert
+        (
+            FPertView,
+            kin.F0(),
+            JPertView,
+            kin.J0(),
+            FinvPertView,
+            kin.Finv0(),
+            kin.dt()
+        );
+
+        mechanicalConstitutiveLawResponse respPert
+        (
+            sigmaPertView, tangentRequest::none
+        );
+
+        evaluate(kinPert, shadow, respPert);
+
+        forAll(Cfield, ipI)
+        {
+            mat66& C = Cfield[ipI];
+            const symmTensor ds((sigmaPert[ipI] - sigma0[ipI])/h[ipI]);
+
+            for (label i = 0; i < 6; ++i)
+            {
+                C(i, j) = ds[i];
+            }
+        }
+    }
+}
+
+
 // * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
 
 Foam::mechanicalConstitutiveLaw::mechanicalConstitutiveLaw

--- a/src/solids4FoamModels/mechanicalConstitutiveLaw/mechanicalConstitutiveLaws/mechanicalConstitutiveLaw/mechanicalConstitutiveLaw.H
+++ b/src/solids4FoamModels/mechanicalConstitutiveLaw/mechanicalConstitutiveLaws/mechanicalConstitutiveLaw/mechanicalConstitutiveLaw.H
@@ -102,6 +102,21 @@ protected:
         mechanicalConstitutiveLawResponse& response
     ) const;
 
+        //- Finite-strain counterpart of the above.
+        //  Perturbs the deformation gradient rather than the displacement
+        //  gradient, recomputing its inverse and determinant for each
+        //  perturbed state, and differences the resulting Cauchy stress.
+        //  The perturbation is defined on the same Voigt strain vector, so a
+        //  tangent taken here is directly comparable with a small-strain one:
+        //  at F close to the identity a hyperelastic law should return its
+        //  linearised isotropic tangent
+        void finiteDifferenceFourthOrder
+        (
+            const finiteStrainMechanicalConstitutiveLawKinematics& kin,
+            mechanicalConstitutiveLawState& state,
+            mechanicalConstitutiveLawResponse& response
+        ) const;
+
 
 public:
 

--- a/src/solids4FoamModels/mechanicalConstitutiveLaw/mechanicalConstitutiveLaws/neoHookeanElasticMechanicalConstitutiveLaw/neoHookeanElasticMechanicalConstitutiveLaw.C
+++ b/src/solids4FoamModels/mechanicalConstitutiveLaw/mechanicalConstitutiveLaws/neoHookeanElasticMechanicalConstitutiveLaw/neoHookeanElasticMechanicalConstitutiveLaw.C
@@ -45,12 +45,49 @@ neoHookeanElasticMechanicalConstitutiveLaw
 :
     mechanicalConstitutiveLaw(dict),
     rho_(dict.lookup("rho")),
-    E_(dict.lookup("E")),
-    nu_(dict.lookup("nu")),
-    lambda_("lambda", E_.dimensions(), 0.0),
-    mu_("mu", E_.dimensions(), 0.0),
-    kappa_("kappa", E_.dimensions(), 0.0)
+    E_("E", dimPressure, 0.0),
+    nu_("nu", dimless, 0.0),
+    lambda_("lambda", dimPressure, 0.0),
+    mu_("mu", dimPressure, 0.0),
+    kappa_("kappa", dimPressure, 0.0)
 {
+    // The material may be given either as E and nu or as mu and K, matching
+    // the legacy neoHookeanElastic law, so that an existing case dictionary
+    // needs no change. Exactly one of the two pairs must be present
+    const bool haveENu = dict.found("E") && dict.found("nu");
+    const bool haveMuK = dict.found("mu") && dict.found("K");
+
+    if (haveENu == haveMuK)
+    {
+        FatalIOErrorInFunction(dict)
+            << "Specify the elastic properties either as 'E' and 'nu' or as "
+            << "'mu' and 'K', and not as both."
+            << exit(FatalIOError);
+    }
+
+    if (haveMuK)
+    {
+        const dimensionedScalar mu(dict.lookup("mu"));
+        const dimensionedScalar K(dict.lookup("K"));
+
+        if (mu.dimensions() != dimPressure || K.dimensions() != dimPressure)
+        {
+            FatalIOErrorInFunction(dict)
+                << "The shear modulus mu and bulk modulus K must both have "
+                << "dimensions " << dimPressure
+                << exit(FatalIOError);
+        }
+
+        // Invert mu = E/(2*(1 + nu)) and K = E/(3*(1 - 2*nu))
+        E_ = 9.0*K*mu/(3.0*K + mu);
+        nu_ = (3.0*K - 2.0*mu)/(2.0*(3.0*K + mu));
+    }
+    else
+    {
+        E_ = dimensionedScalar(dict.lookup("E"));
+        nu_ = dimensionedScalar(dict.lookup("nu"));
+    }
+
     if (E_.dimensions() != dimPressure)
     {
         FatalIOErrorInFunction(dict)
@@ -111,7 +148,7 @@ neoHookeanElasticMechanicalConstitutiveLaw
 void Foam::neoHookeanElasticMechanicalConstitutiveLaw::evaluate
 (
     const finiteStrainMechanicalConstitutiveLawKinematics& kin,
-    mechanicalConstitutiveLawState& /*state*/,
+    mechanicalConstitutiveLawState& state,
     mechanicalConstitutiveLawResponse& response
 ) const
 {
@@ -172,6 +209,24 @@ void Foam::neoHookeanElasticMechanicalConstitutiveLaw::evaluate
         {
             K[i] = Keff;
         }
+    }
+
+    // Fourth-order tangent.
+    // There is no analytical spatial tangent for this law yet, but the
+    // finite-difference tangent of the base class is well defined for any
+    // finite-strain law and is evaluated against a shadow state, so it leaves
+    // neither the stress just computed nor the history it started from
+    if (response.tangentReq() == tangentRequest::fourthOrderFiniteDifference)
+    {
+        finiteDifferenceFourthOrder(kin, state, response);
+    }
+    else if (response.tangentReq() == tangentRequest::fourthOrder)
+    {
+        FatalErrorInFunction
+            << "An analytical fourth-order tangent is not implemented for "
+            << type() << "." << nl
+            << "Use 'fourthOrderFiniteDifference' to obtain one by finite "
+            << "differences." << exit(FatalError);
     }
 }
 

--- a/src/solids4FoamModels/mechanicalConstitutiveLaw/mechanicalConstitutiveLaws/neoHookeanElasticMechanicalConstitutiveLaw/neoHookeanElasticMechanicalConstitutiveLaw.H
+++ b/src/solids4FoamModels/mechanicalConstitutiveLaw/mechanicalConstitutiveLaws/neoHookeanElasticMechanicalConstitutiveLaw/neoHookeanElasticMechanicalConstitutiveLaw.H
@@ -73,10 +73,10 @@ class neoHookeanElasticMechanicalConstitutiveLaw
         const dimensionedScalar rho_;
 
         //- Young's modulus
-        const dimensionedScalar E_;
+        dimensionedScalar E_;
 
         //- Poisson's ration
-        const dimensionedScalar nu_;
+        dimensionedScalar nu_;
 
         //- First Lamé parameter
         dimensionedScalar lambda_;

--- a/tutorials/solids/hyperelasticity/blockPunch/regressionTest.sh
+++ b/tutorials/solids/hyperelasticity/blockPunch/regressionTest.sh
@@ -23,6 +23,7 @@ DISP_Z_MAX=-0.163
 
 ALLRUN_LOGFILE="log.Allrun"
 SOLVER_LOGFILE="log.solids4Foam"
+CONSTITUTIVE_LOGFILE="log.Test-mechanicalConstitutiveLaw"
 DISP_FILE="postProcessing/0/solidPointDisplacement_pointDisp.dat"
 
 APPROACHES=(
@@ -36,6 +37,7 @@ echo "blockPunch regression test"
 echo "Time steps: ${EXPECTED_TIME_STEPS}"
 echo "Final time: ${REGRESSION_END_TIME}"
 echo "Point-A disp_z between ${DISP_Z_MAX} and ${DISP_Z_MIN}"
+echo "Plus the finite-strain mechanicalConstitutiveLaw framework checks"
 echo "============================================================"
 echo
 
@@ -128,6 +130,44 @@ check_displacement() {
     fi
 }
 
+# Exercise the finite-strain paths of the mechanicalConstitutiveLawManager on
+# this case. This tutorial is used because its law is neoHookeanElastic, which
+# implements no small-strain evaluation, so it is the only runtime coverage of
+# the finite-strain kinematics, the finite-difference fourth-order tangent, and
+# the boundary integration points of a face-centred topology
+run_constitutive_test() {
+    local case_dir="$1"
+
+    if ! command -v Test-mechanicalConstitutiveLaw > /dev/null 2>&1; then
+        echo "SKIP: Test-mechanicalConstitutiveLaw not found in PATH"
+        return 0
+    fi
+
+    if [[ ! -d "${case_dir}/constant/polyMesh" ]]; then
+        echo "SKIP: mechanicalConstitutiveLaw checks (case has no mesh)"
+        return 0
+    fi
+
+    if ( cd "${case_dir}" && Test-mechanicalConstitutiveLaw \
+            > "${CONSTITUTIVE_LOGFILE}" 2>&1 )
+    then
+        local n_passed
+        n_passed=$(grep -c 'PASS:' "${case_dir}/${CONSTITUTIVE_LOGFILE}" || true)
+
+        if (( n_passed == 0 )); then
+            echo "SKIP: mechanicalConstitutiveLaw checks (no checks reported)"
+            return 0
+        fi
+
+        echo "PASS: mechanicalConstitutiveLaw checks (${n_passed} checks)"
+        return 0
+    fi
+
+    echo "FAIL: mechanicalConstitutiveLaw checks"
+    grep 'FAIL:' "${case_dir}/${CONSTITUTIVE_LOGFILE}" || true
+    return 1
+}
+
 CHECK_ONLY=false
 
 for arg in "$@"; do
@@ -148,6 +188,10 @@ if [ "$CHECK_ONLY" = false ]; then
 fi
 
 failures=0
+
+# The framework checks depend only on the mesh and the material, so they are
+# run once rather than once per approach
+constitutive_tested=false
 
 for approach in "${APPROACHES[@]}"; do
     CASE_DIR="${REGRESSION_ROOT}/${approach}"
@@ -182,6 +226,15 @@ for approach in "${APPROACHES[@]}"; do
 
     if ! check_displacement "${CASE_DIR}" "${approach}"; then
         failures=$((failures + 1))
+    fi
+
+    # Before the Allclean below, which removes the mesh
+    if [ "${constitutive_tested}" = false ]; then
+        constitutive_tested=true
+
+        if ! run_constitutive_test "${CASE_DIR}"; then
+            failures=$((failures + 1))
+        fi
     fi
 
     if [ "$CHECK_ONLY" = false ]; then


### PR DESCRIPTION
## What this adds 🚀

Stacked on #405 → #404 → #406 → #403 → #402 → #198.

The finite-difference tangent existed only for small strain, so a finite-strain
law had **no way to supply a fourth-order tangent at all** — `neoHookeanElastic`
implemented `scalar` and `scalarDeviatoric` and silently ignored a fourth-order
request. That blocks the two `nonLinGeom*` solid models from dropping their
back-derivation.

This perturbs the deformation gradient rather than the displacement gradient,
recomputing the inverse and determinant for each perturbed state so the
kinematics stay consistent, and differences the Cauchy stress. Same Voigt
convention as the small-strain form, evaluated against a shadow state and
field-wise.

## Verification ✅

A hyperelastic law linearises to isotropic elasticity as `F` approaches the
identity. On `blockPunch`, the finite-difference tangent reproduces the
analytical small-strain tangent from the same constants to **2.2e-4**, with the
full diagonal coming back as

```
(lambda+2mu,  mu,  mu,  lambda+2mu,  mu,  lambda+2mu)
```

which checks the perturbation, the recomputed inverse and determinant, and the
Voigt convention together.

## Two things fixed to get there

**The new `neoHookeanElastic` could not read its own tutorials.** It required
`E` and `nu`, while the legacy law accepts *either* `E`/`nu` or `mu`/`K`, and
the hyperelasticity tutorials all use the latter. It now accepts either, so an
existing case dictionary needs no change — which was a stated constraint.

**The test application fatal-ed on finite-strain-only laws**, since it ran its
small-strain checks unconditionally. The finite-strain check now runs first and
on its own for such a law.

## ⚠️ A defect this exposed in #405

`faceCentredIntegrationPointTopology` reports `nIntegrationPoints() == nFaces`
but assigns **only internal faces** to cells, and therefore to laws. So a
flat-list update over it leaves every boundary entry unwritten —
and `linGeomTotalDispSolid::faceMaterialTangent()` in #405 sizes its
`List<mat66>` to `nFaces` and hands it to an assembler that *does* iterate the
boundary patches.

**Why #405's verification missed it, and this is the instructive part:** the
`highOrderFourthOrder` variant is byte-identical to `highOrder` with the same
Newton count. That is not a contradiction — it is a *Jacobian*. A wrong Jacobian
changes the path to the solution, not the solution, and SNES converges to its
tolerance either way. A byte-identical converged result is exactly what a wrong
Jacobian looks like when the residual is right. The check could not have
detected the defect it was meant to cover.

It surfaced here only because this test sized its comparison to
`nIntegrationPoints()` and got a relative error of exactly 1 on the unwritten
entries.

Note that **no path in the framework currently produces a fourth-order tangent
on a boundary face** — the `surfaceField` overload requires its `List<mat66>` to
be `nInternalFaces` long too. Recorded as §8.14 of the design document with two
candidate fixes. **#405 should not be merged before this is resolved.**

## Testing

`plateHole`, `perforatedPlate` and `layeredPipe` all pass. Builds clean on
OpenFOAM-v2512.

## Added since first push: the boundary check, with teeth

The test compared only `nInternalFaces`, which was a workaround for the
boundary integration points never being evaluated. That defect is fixed in
#405, so the comparison now covers **every** integration point of the
face-centred topology and reports internal and boundary faces as separate
checks. Removing the workaround is what makes this the regression guard for
that fix.

Two things make the boundary check trustworthy rather than decorative:

- The comparison buffer is **poisoned** with `GREAT` first. `mat66` is a POD,
  so an unpoisoned `List<mat66>` holds whatever memory held, and a point the
  manager never reaches would be compared against arbitrary values — a test
  that passes or fails by luck.
- It is **mutation tested**. With `boundaryIntegrationPointIDs` reverted to
  returning an empty list — exactly the pre-fix behaviour — the internal check
  still passes and the boundary check fails with a relative error of 1.7e12:
  the poison, untouched. With the fix, both pass at 2.2e-4.

Runtime coverage is wired into the `blockPunch` regression test. Its law is
`neoHookeanElastic`, which implements no small-strain evaluation, so it is the
only coverage of the finite-strain kinematics, the finite-difference
fourth-order tangent, and the boundary integration points. Its material is
given as `mu`/`K`, which is why the law was extended to accept that form
alongside `E`/`nu`.

Full regression set passes; builds clean on v2512 and foam-extend-4.1.
