### PR TITLE
electroMechanicalLaw: divide the face active stress by J

### DIFF
--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/electroMechanicalLaw/electroMechanicalLaw.C
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/electroMechanicalLaw/electroMechanicalLaw.C
@@ -221,7 +221,7 @@ void Foam::electroMechanicalLaw::correct(surfaceSymmTensorField& sigma)
         const surfaceScalarField Taf(fvc::interpolate(Ta));
 
         // Add active stress: convert 2nd Piola-Kirchhoff to Cauchy
-        sigma += J*symm(F & (Taf*f0f0f_) & F.T());
+        sigma += symm(F & (Taf*f0f0f_) & F.T())/J;
     }
     else
     {
@@ -232,7 +232,7 @@ void Foam::electroMechanicalLaw::correct(surfaceSymmTensorField& sigma)
             currentTa = (mesh().time().value()/rampTime_)*Ta_;
         }
 
-        sigma += J*symm(F & (currentTa*f0f0f_) & F.T());
+        sigma += symm(F & (currentTa*f0f0f_) & F.T())/J;
     }
 }
 


### PR DESCRIPTION
Fixes #337.

## The problem

The cell and face active-stress updates scaled the push-forward by `J` in opposite directions. Both are documented as converting an active second Piola-Kirchhoff stress to a Cauchy stress:

```
sigma = (1/J)*F & S & F.T()
```

so the cell overloads were correct and the face overloads applied `J` rather than `1/J` — a relative error of `J^2` between the two paths.

## The change

Two lines. Both face overloads now divide by `J`, matching their cell counterparts:

```cpp
// before
sigma += J*symm(F & (Taf*f0f0f_) & F.T());
sigma += J*symm(F & (currentTa*f0f0f_) & F.T());

// after
sigma += symm(F & (Taf*f0f0f_) & F.T())/J;
sigma += symm(F & (currentTa*f0f0f_) & F.T())/J;
```

All four active-stress lines in the file are now consistent:

```
167:  sigma += symm(F & (Ta*f0f0_) & F.T())/J;
178:  sigma += symm(F & (currentTa*f0f0_) & F.T())/J;
224:  sigma += symm(F & (Taf*f0f0f_) & F.T())/J;
235:  sigma += symm(F & (currentTa*f0f0f_) & F.T())/J;
```

Both the field-based and constant active-tension branches are corrected, so neither path is left inconsistent with its cell counterpart.

## Impact

Any solid model taking the face-based (`uns`) path with an active stress disagreed with the cell-based path by a factor that grows with volumetric deformation. At `J = 1` the two agree, so nearly incompressible cases mask the problem.

## Scope

Deliberately limited to the Jacobian factor. No dictionary or API change, and no electromechanics refactor — this stands alone and does not carry any part of the closed #282.

Two things from #337 are **not** addressed here, and are left for separate work:

- the secondary observation that `materialTangentField()` forwards only the passive law's tangent even though the active stress depends on `F`
- the constant active tension path itself, which is preserved as-is

## Testing

Not compiled locally — this was written against `development` without an OpenFOAM build available. The change is two arithmetic operators on symbols already in scope (`J` is declared immediately above each edited line), so CI compilation is the meaningful check. Please treat it as unverified until CI is green.