### PR TITLE
fixedValueCorrected: write the value entry on the scalar variant

### DIFF
--- a/src/solids4FoamModels/fluidModels/fvPatchFields/correctedFvPatchFields/fixedValueCorrected/fixedValueCorrectedFvPatchScalarField.C
+++ b/src/solids4FoamModels/fluidModels/fvPatchFields/correctedFvPatchFields/fixedValueCorrected/fixedValueCorrectedFvPatchScalarField.C
@@ -148,7 +148,7 @@ Foam::fixedValueCorrectedFvPatchScalarField::gradientBoundaryCoeffs() const
 
 void Foam::fixedValueCorrectedFvPatchScalarField::write(Ostream& os) const
 {
-    fvPatchField<scalar>::write(os);
+    fixedValueFvPatchScalarField::write(os);
 
     os.writeKeyword("nonOrthogonalCorrections")
         << nonOrthogonalCorrections_ << token::END_STATEMENT << nl;


### PR DESCRIPTION
Refs #409.

## The problem

`fixedValueCorrectedFvPatchScalarField::write()` called `fvPatchField<scalar>::write(os)`, which emits only the `type`. The vector variant in the same directory, otherwise identical, correctly calls `fixedValueFvPatchVectorField::write(os)`.

`fixedValueFvPatchField<Type>::write` is:

```cpp
void Foam::fixedValueFvPatchField<Type>::write(Ostream& os) const
{
    fvPatchField<Type>::write(os);
    fvPatchField<Type>::writeValueEntry(os);
}
```

so the scalar variant never wrote its `value` entry.

The dictionary constructor delegates to `fixedValueFvPatchScalarField(p, iF, dict)`, whose `requireValue` parameter defaults to `IOobjectOption::MUST_READ`. So `value` is required on read but was never written: every time directory this condition produced was one the case could not be restarted from.

```
Required entry 'value' missing in dictionary
"<time>/<field>/boundaryField/<patch>"
```

## The change

One line, making the scalar variant match its vector sibling:

```cpp
-    fvPatchField<scalar>::write(os);
+    fixedValueFvPatchScalarField::write(os);
```

The class already inherits `public fixedValueFvPatchScalarField`, so the name is in scope — this is character-for-character what the vector variant does.

## Relationship to #409

Same failure mode, different mechanism. #409's pattern is a condition that reads a dictionary entry it never writes. Here `nonOrthogonalCorrections` **is** written correctly; what goes missing is the inherited `value` entry, because the wrong base class is invoked.

That is why `fixedValueCorrected` does not appear on #409's candidate list — that list was built by looking for entries read but never written, which does not catch this. It may be worth widening that sweep to check which `write()` implementations call a base class other than their immediate parent.

## How it was found

While testing whether a corrected boundary condition changes the convergence rate of the `cellPointLeastSquares` gradient.

## Testing

Not compiled locally — no OpenFOAM build was available. The change is one line calling a base class the type already inherits, mirroring a sibling that compiles today, so CI is the meaningful check. Please treat it as unverified until CI is green.