### PR TITLE
[1/5] Three fixes that stand alone from the constitutive-law framework

### DIFF
--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/anisotropicBiotElastic/anisotropicBiotElastic.C
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/anisotropicBiotElastic/anisotropicBiotElastic.C
@@ -46,7 +46,13 @@ Foam::anisotropicBiotElastic::anisotropicBiotElastic
 )
 :
     mechanicalLaw(name, mesh, dict, nonLinGeom),
-    model2d_(bool(mesh.solutionD()[vector::Z] > 0)),
+    // A mesh is two-dimensional when z is the empty direction, so the test is
+    // that z is NOT solved. It read the other way round for as long as this
+    // law has been here, which selected the reduced plane model on precisely
+    // the three-dimensional meshes it should not have, and the full model on
+    // two-dimensional ones - where it would then ask for the out-of-plane
+    // constants that a 2-D setup has no reason to supply
+    model2d_(bool(mesh.solutionD()[vector::Z] < 0)),
     A11_(0.0),
     A22_(0.0),
     A33_(0.0),
@@ -71,16 +77,36 @@ Foam::anisotropicBiotElastic::anisotropicBiotElastic
         dimensionedSymmTensor("zero", dimless, symmTensor::zero)
     )
 {
+    // A mesh empty in x or y is two-dimensional too, and this law has no
+    // reduction for that orientation. Without this it would quietly fall
+    // through to the three-dimensional branch and solve a model the mesh
+    // cannot represent
+    if (mesh.solutionD()[vector::X] < 0 || mesh.solutionD()[vector::Y] < 0)
+    {
+        FatalErrorIn(type() + "::" + type())
+            << "This law supports 3-D meshes and 2-D meshes empty in z. "
+            << "This mesh is empty in x or y, which it has no reduction for."
+            << abort(FatalError);
+    }
+
     // Set elastic stiffness parameters
     if (model2d_)
     {
-        // Only the z direction is allow for 2-D models
-        if (mesh.solutionD()[vector::X] < 0 || mesh.solutionD()[vector::Y] < 0)
+
+        // The reduced constants below are the plane stress ones: they come
+        // from eliminating a zero out-of-plane stress, not a zero out-of-plane
+        // strain. This law has no plane strain form, so a case that asked for
+        // one is told rather than quietly given the other
+        if (!planeStress())
         {
             FatalErrorIn(type() + "::" + type())
-                << "For 2-D models, z must be the empty direction"
+                << "This law's two-dimensional reduction is plane stress, but "
+                << "planeStress is not set in mechanicalProperties." << nl
+                << "Set 'planeStress yes;', or use a law that offers a plane "
+                << "strain reduction."
                 << abort(FatalError);
         }
+
 
         const scalar Ex = readScalar(dict.lookup("Ex"));
         const scalar Ey = readScalar(dict.lookup("Ey"));
@@ -239,6 +265,17 @@ void Foam::anisotropicBiotElastic::correct(volSymmTensorField& sigma)
             sigmaI[celli][symmTensor::XX] = A11_*e11 + A12_*e22;
             sigmaI[celli][symmTensor::YY] = A21_*e11 + A22_*e22;
             sigmaI[celli][symmTensor::XY] = A44_*e12;
+
+            // The reduced constants above are the plane stress ones, so the
+            // out-of-plane stress is zero by construction. Said rather than
+            // left: what was standing in these components was not
+            // necessarily zero. Under poroMechanicalLaw it is the seeded
+            // effective stress, which for this case's initial pore pressure
+            // of 79.29 kPa made a von Mises stress of that size appear at
+            // zero strain
+            sigmaI[celli][symmTensor::ZZ] = 0.0;
+            sigmaI[celli][symmTensor::YZ] = 0.0;
+            sigmaI[celli][symmTensor::XZ] = 0.0;
         }
         else
         {
@@ -276,6 +313,9 @@ void Foam::anisotropicBiotElastic::correct(volSymmTensorField& sigma)
                 sigmaP[faceI][symmTensor::XX] = A11_*e11 + A12_*e22;
                 sigmaP[faceI][symmTensor::YY] = A21_*e11 + A22_*e22;
                 sigmaP[faceI][symmTensor::XY] = A44_*e12;
+                sigmaP[faceI][symmTensor::ZZ] = 0.0;
+                sigmaP[faceI][symmTensor::YZ] = 0.0;
+                sigmaP[faceI][symmTensor::XZ] = 0.0;
             }
             else
             {

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/anisotropicBiotElastic/anisotropicBiotElastic.C
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/anisotropicBiotElastic/anisotropicBiotElastic.C
@@ -92,7 +92,6 @@ Foam::anisotropicBiotElastic::anisotropicBiotElastic
     // Set elastic stiffness parameters
     if (model2d_)
     {
-
         // The reduced constants below are the plane stress ones: they come
         // from eliminating a zero out-of-plane stress, not a zero out-of-plane
         // strain. This law has no plane strain form, so a case that asked for
@@ -106,7 +105,6 @@ Foam::anisotropicBiotElastic::anisotropicBiotElastic
                 << "strain reduction."
                 << abort(FatalError);
         }
-
 
         const scalar Ex = readScalar(dict.lookup("Ex"));
         const scalar Ey = readScalar(dict.lookup("Ey"));

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/HolzapfelGasserOgdenElastic/HolzapfelGasserOgdenElastic.C
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/HolzapfelGasserOgdenElastic/HolzapfelGasserOgdenElastic.C
@@ -254,26 +254,29 @@ Foam::tmp<Foam::volScalarField> Foam::HolzapfelGasserOgdenElastic::impK() const
 Foam::tmp<Foam::volScalarField>
 Foam::HolzapfelGasserOgdenElastic::shearModulus() const
 {
-    // The ground substance shear modulus. Added so that this law can be used
-    // with a solid model that asks for it - the mixed formulation in
-    // nonLinGeomTotalLagTotalDispSolid does, to build its implicit stiffness -
-    // rather than failing as notImplemented. The fibre stiffness is not
-    // included: it varies with the fibre stretch, and this is a coefficient
-    // for a Laplacian that is added and subtracted
+    // The effective shear modulus, which is the field impK() is built from.
+    // Added so that this law can be used with a solid model that asks for one
+    // - the mixed formulation in nonLinGeomTotalLagTotalDispSolid does, to
+    // build its implicit stiffness - rather than failing as notImplemented.
+    //
+    // muEff_ rather than the ground substance mu_, so that the two agree:
+    // calcEffectiveShearModulus() refreshes it from the current deformation
+    // each time step, so it carries the fibre stiffness, and a caller building
+    // a Laplacian coefficient from this gets the same material it would get
+    // from impK()
     return tmp<volScalarField>
     (
         new volScalarField
         (
             IOobject
             (
-                "shearModulusLaw",
+                "shearModulus",
                 mesh().time().timeName(),
                 mesh(),
                 IOobject::NO_READ,
                 IOobject::NO_WRITE
             ),
-            mesh(),
-            mu_
+            muEff_
         )
     );
 }

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/HolzapfelGasserOgdenElastic/HolzapfelGasserOgdenElastic.C
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/HolzapfelGasserOgdenElastic/HolzapfelGasserOgdenElastic.C
@@ -251,6 +251,34 @@ Foam::tmp<Foam::volScalarField> Foam::HolzapfelGasserOgdenElastic::impK() const
 }
 
 
+Foam::tmp<Foam::volScalarField>
+Foam::HolzapfelGasserOgdenElastic::shearModulus() const
+{
+    // The ground substance shear modulus. Added so that this law can be used
+    // with a solid model that asks for it - the mixed formulation in
+    // nonLinGeomTotalLagTotalDispSolid does, to build its implicit stiffness -
+    // rather than failing as notImplemented. The fibre stiffness is not
+    // included: it varies with the fibre stretch, and this is a coefficient
+    // for a Laplacian that is added and subtracted
+    return tmp<volScalarField>
+    (
+        new volScalarField
+        (
+            IOobject
+            (
+                "shearModulusLaw",
+                mesh().time().timeName(),
+                mesh(),
+                IOobject::NO_READ,
+                IOobject::NO_WRITE
+            ),
+            mesh(),
+            mu_
+        )
+    );
+}
+
+
 Foam::tmp<Foam::volScalarField> Foam::HolzapfelGasserOgdenElastic::bulkModulus() const
 {
     return tmp<volScalarField>

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/HolzapfelGasserOgdenElastic/HolzapfelGasserOgdenElastic.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/HolzapfelGasserOgdenElastic/HolzapfelGasserOgdenElastic.H
@@ -178,10 +178,10 @@ public:
         //  This is the diffusivity for the Laplacian term
         virtual tmp<volScalarField> impK() const;
 
-        //- Return bulk modulus
-        //- Return the ground substance shear modulus
+        //- Return the effective shear modulus
         virtual tmp<volScalarField> shearModulus() const;
 
+        //- Return bulk modulus
         virtual tmp<volScalarField> bulkModulus() const;
 
         //- Calculate the stress

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/HolzapfelGasserOgdenElastic/HolzapfelGasserOgdenElastic.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/HolzapfelGasserOgdenElastic/HolzapfelGasserOgdenElastic.H
@@ -179,6 +179,9 @@ public:
         virtual tmp<volScalarField> impK() const;
 
         //- Return bulk modulus
+        //- Return the ground substance shear modulus
+        virtual tmp<volScalarField> shearModulus() const;
+
         virtual tmp<volScalarField> bulkModulus() const;
 
         //- Calculate the stress

--- a/src/solids4FoamModels/solidModels/fvPatchFields/normalDisplacement/normalDisplacementFvPatchVectorField.C
+++ b/src/solids4FoamModels/solidModels/fvPatchFields/normalDisplacement/normalDisplacementFvPatchVectorField.C
@@ -262,10 +262,14 @@ void normalDisplacementFvPatchVectorField::write(Ostream& os) const
     }
     else
     {
+        // The same keyword it is read with. It was written as 'normalDisp',
+        // which nothing reads, so a case using this condition wrote a time
+        // directory it could not start again from: the field came back and the
+        // condition it carried did not
 #ifdef OPENFOAM_ORG
-        writeEntry(os, "normalDisp", normalDisp_);
+        writeEntry(os, "normalDisplacement", normalDisp_);
 #else
-        normalDisp_.writeEntry("normalDisp", os);
+        normalDisp_.writeEntry("normalDisplacement", os);
 #endif
     }
 

--- a/src/solids4FoamModels/solidModels/fvPatchFields/normalDisplacementZeroShear/normalDisplacementZeroShearFvPatchVectorField.C
+++ b/src/solids4FoamModels/solidModels/fvPatchFields/normalDisplacementZeroShear/normalDisplacementZeroShearFvPatchVectorField.C
@@ -241,10 +241,13 @@ void normalDisplacementZeroShearFvPatchVectorField::write(Ostream& os) const
     }
     else
     {
+        // The same keyword it is read with, as for normalDisplacement: this
+        // condition had the identical defect and the identical consequence,
+        // a time directory the case could not be started again from
 #ifdef OPENFOAM_ORG
-        writeEntry(os, "normalDisp", normalDisp_);
+        writeEntry(os, "normalDisplacement", normalDisp_);
 #else
-        normalDisp_.writeEntry("normalDisp", os);
+        normalDisp_.writeEntry("normalDisplacement", os);
 #endif
     }
 

--- a/tutorials/solids/poroelasticity/rodAndSeabed/regressionTest.sh
+++ b/tutorials/solids/poroelasticity/rodAndSeabed/regressionTest.sh
@@ -12,11 +12,22 @@ CASE_DIR="${REGRESSION_ROOT}/main"
 # ============================================================
 
 # Reference ranges (order-of-magnitude + robustness)
-EPSILON_MIN=6e-5
-EPSILON_MAX=1.1e-4
+#
+# These moved when anisotropicBiotElastic stopped selecting its reduced plane
+# model on this three-dimensional mesh. The old values were not self-consistent
+# with the declared material: 80 kPa against a strain of 9.3e-5 implies a
+# stiffness near 9e8 Pa, where the moduli here are 1.2e7 to 2e7 Pa. Forcing the
+# out-of-plane stress to zero while xx and yy were not manufactured a large
+# deviator, so von Mises read high against a small strain - and under
+# poroMechanicalLaw the value standing in those components was the seeded
+# effective stress, which for this case's initial pore pressure of 79.29 kPa is
+# a von Mises stress of that size at zero strain. The values below sit on the
+# declared moduli
+EPSILON_MIN=1.4e-3
+EPSILON_MAX=2.2e-3
 
-SIGMA_MIN=70e3
-SIGMA_MAX=90e3
+SIGMA_MIN=40e3
+SIGMA_MAX=58e3
 
 # Log files
 SOLVER_LOGFILE="log.solids4Foam"


### PR DESCRIPTION
Stage 1 of the staged merge in #418. Base: `development`.

Three fixes that are independent of the `mechanicalConstitutiveLaw` framework.
They are here on their own because each changes behaviour, and one moves a
tutorial's published numbers - that deserves to be seen rather than buried in
a large change.

## `anisotropicBiotElastic` selected the wrong model

The test read `model2d_ = (solutionD[vector::Z] > 0)`, which is true when z
**is** solved. So it ran the reduced plane-stress law on exactly the
three-dimensional meshes it should not have, and silently ignored the
out-of-plane constants those cases supply.

**This moves `rodAndSeabed`**: `epsilonEq` 9.31e-5 to 1.78e-3, `sigmaEq`
80.1 kPa to 49.1 kPa.

The old numbers were an artifact, and it is worth being precise about why. The
tutorial declares `Ez`, `nuyz`, `nuzx`, `Gyz` and `Gzx` and was ignoring all
five. `poroMechanicalLaw` seeds the effective stress as
`sigma + b*(p + p0)*I`, so a sub-law that writes only xx and yy leaves an
effective stress of `diag(0, 0, p)` - and with this case's initial pore
pressure of 79.29 kPa that is a von Mises stress of 79.29 kPa at zero strain,
against the 80.1 kPa observed. The new pair is also the self-consistent one:
the moduli here are 1.2e7 to 2e7 Pa, and the old ratio implied a stiffness
near 9e8 Pa. The reference ranges carry that reasoning beside them.

Two related refusals added while there: a mesh empty in x or y, which this law
has no reduction for and which previously fell through to the 3-D branch; and
a 2-D case asking for plane strain, which would previously have been handed
the plane-stress reduction without being told.

## `normalDisplacement` wrote a keyword it could not read back

`normalDisplacement` and `normalDisplacementZeroShear` read their value with
the keyword `normalDisplacement` and **wrote** it as `normalDisp`. The read
side was right; the write side was not, and nothing reads `normalDisp`.

So every time directory a case using either condition produced was one the
case could not be restarted from - the field came back and the condition it
carried did not:

```
Required entry 'normalDisplacement' missing in dictionary
"<time>/D/boundaryField/<patch>"
```

The fix is on the write side, in `write()`, which now emits the keyword the
constructor reads. Note that this does not rescue time directories already
written with `normalDisp`; it stops new ones being written that way.

This fixes the two confirmed cases in #409. That issue also lists eight
further conditions as candidates for the same read/write asymmetry, none of
them checked yet, so it stays open for that sweep.

## The legacy `HolzapfelGasserOgdenElastic` had no `shearModulus()`

It was `notImplemented`, which means that law cannot be used with any solid
model that asks for one - much of why it has only ever run under
`coupledPressureDisplacementSolid`. It now returns `muEff_`, the same field
`impK()` on this law is built from: `calcEffectiveShearModulus()` refreshes it
from the current deformation each time step, so a caller building a Laplacian
coefficient from `shearModulus()` gets the same material `impK()` would give
it.

## What is not here

Two fixes that might be expected in this stage share files with framework work
and so arrive with stage 4: the pore pressure rename from `p` to
`porePressure`, which needs `poroLinGeomSolid`, and the removal of the uncalled
`solidModel::newDeltaT`, which needs `solidModel`.

## A note for users of `anisotropicBiotElastic` on 2-D meshes

Because the flag was inverted, a 2-D case was silently taking the
three-dimensional branch. With it corrected such a case reaches the plane
stress reduction, and if it does not set `planeStress yes` it now stops with
an explanation rather than being handed a reduction it did not ask for. No
shipped tutorial is affected - `rodAndSeabed` is three-dimensional - but a
user case can be.

## Verification

Builds on OpenFOAM.com v2512, OpenFOAM.org 9 and foam-extend 4.1. The
regression suite passes: 15 of 15 tutorials that have a test on `development`.

The two tutorials these fixes touch, re-run on v2512 after the review pass:

```
rodAndSeabed   PASS  Max epsilonEq = 0.00177705   (bounds 1.4e-3 .. 2.2e-3)
               PASS  Max sigmaEq   = 49131.1      (bounds 40e3 .. 58e3)
viscoTube      PASS  Max epsilonEq = 0.000199874
               PASS  Max sigmaEq   = 1.14801e+07
```

and the restart that #409 is about, checked end to end: `viscoTube` now writes
`normalDisplacement uniform -1e-06;` into its time directories, and a run
restarted from one of them continues (`Time = 7700`) instead of stopping on the
missing entry.

