### PR TITLE
[Doc] Correct thermalSolid header Description

### DIFF
--- a/src/solids4FoamModels/solidModels/thermalSolid/thermalSolid.H
+++ b/src/solids4FoamModels/solidModels/thermalSolid/thermalSolid.H
@@ -19,15 +19,17 @@ Class
     thermalSolid
 
 Description
-    Mathematical model where linear geometry is assumed i.e. small strains and
-    small rotations are assumed.
+    Heat-conduction-only solid model: the transient heat equation is solved for
+    the temperature field T, using the run-time selectable thermal model for the
+    specific heat capacity and thermal conductivity.
 
-    The heat equation and momentum equation are solved in a strongly coupled
-    fashion i.e. just like in solidDisplacementFoam.
+    No mechanical problem is solved: there is no momentum equation, no
+    displacement, strain or stress solution, and tractionBoundarySnGrad()
+    returns a zero field. The mechanical law is only consulted for the density
+    used in the heat capacity term.
 
-    The stress is calculated by the run-time selectable mechanical law.
-
-    Added functions required for CHT explicit coupling
+    This model is intended for the solid side of conjugate heat transfer, where
+    it provides the functions required for explicit CHT coupling.
 
 Author
     Philip Cardiff, UCD.
@@ -87,7 +89,7 @@ class thermalSolid
 
     // Private Member Functions
 
-        //- Check if the momentum equation is converged
+        //- Check if the heat equation is converged
         bool converged
         (
             const int iCorr,


### PR DESCRIPTION
## What

Comment-only fix to `src/solids4FoamModels/solidModels/thermalSolid/thermalSolid.H`.

The `Description` block claimed:

> Mathematical model where linear geometry is assumed i.e. small strains and small rotations are assumed.
>
> The heat equation and momentum equation are solved in a strongly coupled fashion i.e. just like in solidDisplacementFoam.
>
> The stress is calculated by the run-time selectable mechanical law.

None of that describes the class. It is reworded to state that `thermalSolid` is a heat-conduction-only solid model intended for the solid side of conjugate heat transfer, and that no mechanical problem is solved.

Also fixed one stale comment in the same header: the private `converged()` helper was documented as "Check if the momentum equation is converged"; it checks the heat equation (it takes `solverPerfT` and `T_`).

## Verification done

Checked against `thermalSolid.C` before rewording:

- `thermalSolid::evolve()` assembles only `fvScalarMatrix TEqn (rhoC_*fvm::ddt(T_) - fvm::laplacian(k_, T_, "laplacian(k,T)"))`. There is no `fvVectorMatrix` anywhere in the file and no displacement, strain or stress solution.
- `tractionBoundarySnGrad()` returns `vectorField(patch.size(), vector::zero)`.
- `mechanical()` is referenced exactly once, at the `rhoC_` construction (`thermal_.C()*mechanical().rho()`), i.e. only for the density — hence the new wording "the mechanical law is only consulted for the density used in the heat capacity term".
- The thermal model supplies `C()` and `k()`, matching the new first paragraph.

## Verification NOT done

No build was run (`wmake`/`Allwmake`) and no tutorials were run. This machine shares one `platforms/` directory between worktrees, so building here would clobber other work. The change touches only text inside comment blocks, so it cannot affect compilation or behaviour.

Closes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)