### PR TITLE
[Fix] preCICE 3dTube tutorial: use valid solidModel type

### DIFF
--- a/tutorials/fluidSolidInteraction-preCICE/3dTube/solid/constant/solidProperties
+++ b/tutorials/fluidSolidInteraction-preCICE/3dTube/solid/constant/solidProperties
@@ -16,10 +16,10 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-solidModel linearGeometry;
+solidModel linearGeometryTotalDisplacement;
 //solidModel nonLinearGeometryUpdatedLagrangian;
 
-"linearGeometryCoeffs|nonLinearGeometryUpdatedLagrangianCoeffs"
+"linearGeometryTotalDisplacementCoeffs|nonLinearGeometryUpdatedLagrangianCoeffs"
 {
     // Maximum number of momentum correctors
     nCorrectors             20000;


### PR DESCRIPTION
## Problem

`tutorials/fluidSolidInteraction-preCICE/3dTube/solid/constant/solidProperties` selected

```
solidModel linearGeometry;
```

`linearGeometry` is not a `solidModel` run-time selection name — it is a `nonLinearGeometry`
enumerator. Confirmed against the registered `TypeName`s in `src/solids4FoamModels/solidModels/`:
the cell-centred, linear-geometry, total-displacement model is registered as
`linearGeometryTotalDisplacement` (`linGeomTotalDispSolid`). With the old entry,
`solidModel::New` cannot find the type in the selection table and the case aborts.

## Change

Two lines in that one dictionary:

- `solidModel linearGeometry;` -> `solidModel linearGeometryTotalDisplacement;`
- the coefficients sub-dictionary regex
  `"linearGeometryCoeffs|nonLinearGeometryUpdatedLagrangianCoeffs"` ->
  `"linearGeometryTotalDisplacementCoeffs|nonLinearGeometryUpdatedLagrangianCoeffs"`,
  so the coefficients are still matched for the (now correctly named) active model.

The second edit is needed as well as the first: leaving the old regex would silently
drop `nCorrectors`, the tolerances and `infoFrequency` and fall back to defaults.

## Other preCICE cases

Checked. `tutorials/fluidSolidInteraction-preCICE/` contains only two cases with a
`solidProperties`; the other one, `flexibleOversetCylinder`, already uses
`linearGeometryTotalDisplacement` with a matching `linearGeometryTotalDisplacementCoeffs`
sub-dictionary, so no change was needed there.

## Verification

Done:
- Grepped every `TypeName(...)` under `src/solids4FoamModels/solidModels/` to confirm
  `linearGeometry` is not registered and `linearGeometryTotalDisplacement` is.
- Grepped all of `tutorials/fluidSolidInteraction-preCICE/` for other occurrences.

NOT done (please be aware):
- The library was **not** rebuilt and the case was **not** run. This machine's worktrees
  share a single `platforms/` directory, so building here would clobber other work.
  No preCICE run or regression test was executed. The change is dictionary-only
  (no C++ touched), but someone should confirm the 3dTube case actually runs to
  completion before this is relied upon.

Closes #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)
