### PR TITLE
[Fix] Correct mechanical law header descriptions and one error string

### DIFF
--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/thermoMechanicalLaw/thermoMechanicalLaw.C
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/thermoMechanicalLaw/thermoMechanicalLaw.C
@@ -296,7 +296,7 @@ Foam::thermoMechanicalLaw::lookupTemperatureField()
     }
     else
     {
-        FatalErrorIn("Foam::poroMechanicalLaw::lookupTemperatureField()")
+        FatalErrorIn("Foam::thermoMechanicalLaw::lookupTemperatureField()")
             << "No T field found in memory or on disk. Make sure you have "
             << "either specified a solidModel that solves for temperature "
             << "or give the T field in at least the starting time "

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/YeohElastic/YeohElastic.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/YeohElastic/YeohElastic.H
@@ -30,7 +30,7 @@ Description
                   + 2*(
                           c1
                         + 2*c2*(isoI1 - 3)
-                        + 3*c3*(isoI1 - 3)
+                        + 3*c3*(isoI1 - 3)^2
                      )*dev(isoB)
 
     where:

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/diffusionHyperElastic/diffusionHyperElastic.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/diffusionHyperElastic/diffusionHyperElastic.H
@@ -67,7 +67,7 @@ class diffusionHyperElastic
 
         //- Maximum factor
         //  The max value of d is limit to maxFactor*average(d)
-        //  Defaults to 10
+        //  Defaults to 100
         const scalar maxFactor_;
 
         //- Minimum factor

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/isotropicFungElastic/isotropicFungElastic.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/isotropicFungElastic/isotropicFungElastic.H
@@ -27,7 +27,7 @@ Description
     The Cauchy stress tensor for the compressible case is then given by:
 
         J*sigma =   0.5*K*(J^2 - 1)*I
-                  + c1*exp(c2*(isoI1 - 3))*dev(isoB)
+                  + c1*exp(0.5*c2*(isoI1 - 3))*dev(isoB)
 
     where:
 


### PR DESCRIPTION
Documentation-only fixes for the four discrepancies collected in #344. In every case the implementation was checked against the `.C` file and found to be correct, so only the comment (or error string) changed. No behaviour changes, no results affected.

## The four fixes

1. **`YeohElastic.H`** — the third deviatoric stress term read `+ 3*c3*(isoI1 - 3)`; it is now `+ 3*c3*(isoI1 - 3)^2`. `YeohElastic.C:180` implements `3.0*c3_*pow((I1 - 3.0), 2)`, which is the correct derivative of the `c3*(isoI1 - 3)^3` strain energy term given in the same header.

2. **`isotropicFungElastic.H`** — the Cauchy stress line read `+ c1*exp(c2*(isoI1 - 3))*dev(isoB)`; it is now `+ c1*exp(0.5*c2*(isoI1 - 3))*dev(isoB)`. Both `isotropicFungElastic.C:149` (cell) and `:185` (face) use `0.5*c2_`, consistent with the strain energy function two lines above in the header.

3. **`diffusionHyperElastic.H`** — the `maxFactor_` comment said "Defaults to 10"; the constructor at `diffusionHyperElastic.C:72` uses `lookupOrDefault<scalar>("maxFactor", 100)`, so the comment now says 100. (The law's `README.md` already documented 100.)

4. **`thermoMechanicalLaw.C:299`** — `FatalErrorIn("Foam::poroMechanicalLaw::lookupTemperatureField()")` is now `FatalErrorIn("Foam::thermoMechanicalLaw::lookupTemperatureField()")`. A one-token string change so the reported location matches the class actually raising the error.

## Verification

Done:
- Each header statement was read against the corresponding `.C` implementation before editing; all four discrepancies reproduce on `development` exactly as reported.
- `thermoMechanicalLaw.C` (the only `.C` file touched) passes `g++ -fsyntax-only` against OpenFOAM v2512 — clean apart from pre-existing deprecation warnings.

Not done:
- No `wmake`/`Allwmake` build and no tutorial runs. This machine shares one `platforms/` library directory across worktrees, so a build here would clobber other running work. Given that three of the four changes are inside comment blocks and the fourth is a string literal, there is nothing here that a build could catch that the syntax check did not.

Not addressed in this PR: the similar copy-paste artefact noted at the end of the issue in `linearElastic.C:109,125` (errors naming `linearElasticMisesPlastic`), which was listed as a side note rather than one of the four items. Happy to fold it in if wanted.

Closes #344

🤖 Generated with [Claude Code](https://claude.com/claude-code)