### PR TITLE
[Fix] diffusionHyperElastic: apply diffusivity scaling on the enforceLinear path

### DIFF
--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/diffusionHyperElastic/diffusionHyperElastic.C
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/diffusionHyperElastic/diffusionHyperElastic.C
@@ -184,7 +184,11 @@ void Foam::diffusionHyperElastic::correct(volSymmTensorField& sigma)
     // Update the deformation gradient field
     // Note: if true is returned, it means that linearised elasticity was
     // enforced by the solver via the enforceLinear switch
-    if (updateF(sigma, mu_, K_))
+    // The diffusivity scaling d_ is applied to the moduli passed to updateF,
+    // rather than to sigma afterwards, so that the stress calculated on the
+    // enforced-linear path is scaled by d_ as well; note that the incremental
+    // forms of that path add to sigma.oldTime(), which must not be re-scaled
+    if (updateF(sigma, mu(d_*mu_), K(d_*K_)))
     {
         return;
     }
@@ -196,10 +200,12 @@ void Foam::diffusionHyperElastic::correct(volSymmTensorField& sigma)
     const volSymmTensorField bEbar(pow(J, -2.0/3.0)*symm(F() & F().T()));
 
     // Calculate the deviatoric stress
-    const volSymmTensorField s(mu_*dev(bEbar));
+    // Note: mu() is mu_ scaled by d_, as set in the updateF call above
+    const volSymmTensorField s(mu()*dev(bEbar));
 
     // Calculate the Cauchy stress
-    sigma = d_*(s + 0.5*K()*(pow(J, 2.0) - 1.0)*I)/J;
+    // Note: K() is K_ scaled by d_, as set in the updateF call above
+    sigma = (s + 0.5*K()*(pow(J, 2.0) - 1.0)*I)/J;
 }
 
 

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/diffusionHyperElastic/diffusionHyperElastic.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/diffusionHyperElastic/diffusionHyperElastic.H
@@ -67,7 +67,7 @@ class diffusionHyperElastic
 
         //- Maximum factor
         //  The max value of d is limit to maxFactor*average(d)
-        //  Defaults to 10
+        //  Defaults to 100
         const scalar maxFactor_;
 
         //- Minimum factor


### PR DESCRIPTION
## What

`diffusionHyperElastic` exists so a solid model can act as a mesh motion solver: its stress is the neo-Hookean stress scaled by a diffusivity field `d_`. As reported in #343, that scaling was skipped whenever the solver enforced linear elasticity, because `correct()` returns early from `updateF()` and `d_` was only applied to the hyperelastic expression below the early return.

## Change

`diffusionHyperElastic::correct(volSymmTensorField&)` now passes the scaled moduli into `updateF()`:

```cpp
if (updateF(sigma, mu(d_*mu_), K(d_*K_)))
{
    return;
}
```

using the existing `volScalarField` overload of `updateF()`. The hyperelastic expression below then uses `mu()` and `K()` (which now hold the scaled moduli) and the explicit `d_*` factor is dropped, so `d_` is applied exactly once on both paths.

Why scale the moduli rather than multiply `sigma` by `d_` after the early return (the alternative suggested in the issue): two of the three enforced-linear branches in `mechanicalLaw::updateF()` are incremental and compute `sigma = sigma.oldTime() + 2*mu*... + K*...`. Multiplying the result by `d_` would also re-scale `sigma.oldTime()`, compounding the factor every increment. Scaling the moduli is correct for all three branches (updated Lagrangian incremental, total Lagrangian incremental, total Lagrangian non-incremental) and leaves the shared `updateF()` untouched.

The `correct(surfaceSymmTensorField&)` overload is `NotImplemented`, so there is nothing to fix there.

Also fixes the header inaccuracy noted at the end of the issue: `maxFactor_` was documented as defaulting to 10 while the code reads it with a default of 100.

## Behaviour

Behaviour changes only on the `enforceLinear` path, where the stress is now scaled by `d_` as intended. The normal hyperelastic path is algebraically identical to before (`d_*(mu_*dev(bEbar) + 0.5*K_*(J^2-1)*I)/J`). `bulkModulus()`, `shearModulus()` and `impK()` already returned `d_`-scaled values and are unchanged; the `mu()`/`K()` member fields now carry the scaling too, which is consistent with those accessors.

## Verification

Done:
- `g++ -fsyntax-only` on `diffusionHyperElastic.C` against OpenFOAM v2512 headers: clean (only the pre-existing `dict.lookup(...)`-into-`dimensionedScalar` deprecation warnings).
- Read `mechanicalLaw::updateF()` and the `mu(const volScalarField&)` / `K(const volScalarField&)` setters to confirm the overload resolution and that all three enforced-linear branches are covered.

Not done:
- No `wmake` / full library build (the shared `platforms/` directory on this machine is used by other work).
- No tutorial or solver runs, so no numerical comparison of a mesh motion case with and without `enforceLinear` triggering.

Closes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFtsPKfZb9WoT45M8Qw6nD
