### PR TITLE
[Fix] electroMechanicalLaw: divide the face active stress by J

### DIFF
--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/electroMechanicalLaw/electroMechanicalLaw.C
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/electroMechanicalLaw/electroMechanicalLaw.C
@@ -221,7 +221,7 @@ void Foam::electroMechanicalLaw::correct(surfaceSymmTensorField& sigma)
         const surfaceScalarField Taf(fvc::interpolate(Ta));
 
         // Add active stress: convert 2nd Piola-Kirchhoff to Cauchy
-        sigma += J*symm(F & (Taf*f0f0f_) & F.T());
+        sigma += symm(F & (Taf*f0f0f_) & F.T())/J;
     }
     else
     {
@@ -232,7 +232,7 @@ void Foam::electroMechanicalLaw::correct(surfaceSymmTensorField& sigma)
             currentTa = (mesh().time().value()/rampTime_)*Ta_;
         }
 
-        sigma += J*symm(F & (currentTa*f0f0f_) & F.T());
+        sigma += symm(F & (currentTa*f0f0f_) & F.T())/J;
     }
 }
 


### PR DESCRIPTION
## What

`electroMechanicalLaw` pushes an active second Piola-Kirchhoff stress `S = Ta * (f0 f0)` forward to a Cauchy stress. The correct transformation is

```
sigma = (1/J) F S F^T,   J = det(F)
```

The **cell** overload `correct(volSymmTensorField&)` already did this:

```cpp
sigma += symm(F & (Ta*f0f0_) & F.T())/J;
```

but the **surface** overload `correct(surfaceSymmTensorField&)` multiplied by `J`:

```cpp
sigma += J*symm(F & (Taf*f0f0f_) & F.T());
```

so the face-based active contribution was in error by a factor of `J^2` relative to the cell-based one.

## The maths

For a second Piola-Kirchhoff stress `S` defined on the reference configuration, the Kirchhoff stress is `tau = F S F^T` and the Cauchy stress is `sigma = tau / J`. Multiplying by `J` instead of dividing gives `J F S F^T = J^2 * sigma_correct`. The two forms coincide only at `J = 1`, which is why nearly incompressible cardiac cases masked the discrepancy; for any compressible or moderately volumetric deformation the cell and face paths disagreed, and the disagreement grew with `J`.

## The change

Both branches of the surface overload (field-based `Ta` interpolated to faces, and the constant/ramped `Ta`) now use `symm(F & S & F.T())/J`, exactly matching the cell overload. Two lines, nothing else touched.

Affected solid models are those that take the face stress path: `unsLinGeomSolid`, `unsNonLinGeomTotalLagSolid`, `unsNonLinGeomUpdatedLagSolid` and `coupledPressureDisplacementSolid`.

## Deliberately out of scope

- The `Ta` refactor discussed in #282 is **not** included; the backward-compatible `Ta` handling merged via #237 is untouched.
- The secondary observation in #337 — that `materialTangentField()` forwards only the passive law's tangent even though the active stress depends on `F` — is **not** addressed here. It affects Newton convergence rate rather than the converged answer, and deserves its own change; it should stay tracked in #337.

## Verification: what was and was not done

Done:

- The changed translation unit was verified to compile with `g++ -fsyntax-only` (OpenFOAM.com v2512, `-std=c++17`), clean apart from pre-existing deprecation warnings unrelated to this change.
- The corrected expressions were checked to be textually identical in form to the cell overloads, so the two paths now agree by construction for equivalent inputs.

**Not** done, and stated plainly:

- The library was **not** built (`wmake`/`Allwmake` were not run) and no solver or tutorial was executed. The change is therefore not run-time verified.
- **No regression test is included.** The acceptance criteria in #320 ask for a focused electromechanical test exercising the face path at `J != 1` that would fail under multiplication by `J`. Such a test needs a reference value that can only be produced by actually running the case, and it would be wrong to commit an invented tolerance or an unrun `Allrun`/`regressionTest.sh` pair. I would suggest adding the test as a follow-up once the fix can be built and run — a small compressible block with a prescribed uniaxial stretch (so `J != 1`), an `uns*` solid model and a constant `Ta`, comparing peak `sigmaEq` against the cell-based path, would discriminate the two forms by a factor of `J^2`.

Reviewers should build and run the electromechanical cases before merging.

Closes #320
Also addresses #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFtsPKfZb9WoT45M8Qw6nD
