### PR TITLE
[Fix] neoHookeanElasticMisesPlastic: face correction reads cell plastic strain on boundaries (#338)

### DIFF
--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/neoHookeanElasticMisesPlastic/neoHookeanElasticMisesPlastic.C
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/nonLinearGeometryLaws/neoHookeanElasticMisesPlastic/neoHookeanElasticMisesPlastic.C
@@ -227,14 +227,16 @@ void Foam::neoHookeanElasticMisesPlastic::newtonLoop
 
         // fTrial will go to zero at convergence
         fTrial = yieldFunction(epsilonPEqOld, magSTrial, DLambda, muBar,  J);
-
-        if (i == MaxNewtonIter_)
-        {
-            WarningIn("neoHookeanElasticMisesPlastic::newtonLoop()")
-                << "Plasticity Newton loop not converging" << endl;
-        }
     }
     while ((mag(residual) > LoopTol_) && ++i < MaxNewtonIter_);
+
+    if (mag(residual) > LoopTol_)
+    {
+        WarningIn("neoHookeanElasticMisesPlastic::newtonLoop()")
+            << "Plasticity Newton loop not converging: residual = "
+            << mag(residual) << ", tolerance = " << LoopTol_
+            << ", iterations = " << MaxNewtonIter_ << endl;
+    }
 
     // Update current yield stress
     // Note: we divide by J to change the Kirchhoff yield stress to Cauchy yield
@@ -1376,7 +1378,7 @@ void Foam::neoHookeanElasticMisesPlastic::correct(surfaceSymmTensorField& sigma)
             const scalarField& JP = Jf().boundaryField()[patchI];
             const scalarField& sigmaYP = sigmaYf_.boundaryField()[patchI];
             const scalarField& epsilonPEqOldP =
-                epsilonPEq_.oldTime().boundaryField()[patchI];
+                epsilonPEqf_.oldTime().boundaryField()[patchI];
 
             forAll(fTrialP, faceI)
             {
@@ -1671,7 +1673,7 @@ Foam::scalar Foam::neoHookeanElasticMisesPlastic::newDeltaT()
             (
                 "Foam::scalar Foam::neoHookeanElasticMisesPlastic::newDeltaT()"
                 " const"
-            )   << "The error in the plastic strain is lover 50 times larger "
+            )   << "The error in the plastic strain is over 50 times larger "
                 << "than the desired value!\n    Consider starting the "
                 << "simulation with a smaller initial time-step" << endl;
         }


### PR DESCRIPTION
## What this changes

In `neoHookeanElasticMisesPlastic::correct(surfaceSymmTensorField&)` (the
face-based overload used by the `uns` solid models), the boundary loop read the
old equivalent plastic strain from the **cell** field `epsilonPEq_`:

```cpp
const scalarField& epsilonPEqOldP =
    epsilonPEq_.oldTime().boundaryField()[patchI];
```

Every other field taken in that same loop is the face variant (`sigmaYf_`,
`Jf()`, `plasticNf_`, `DSigmaYf_`, `DLambdaf_`), and the internal-field part of
the same routine already uses `epsilonPEqf_.oldTime()`. The boundary field of a
`volScalarField` has the same size as the boundary field of a
`surfaceScalarField` on a given patch, so the mistake was silent — it compiled
and ran, just with the wrong history.

The fix is the one-line change to `epsilonPEqf_.oldTime().boundaryField()[patchI]`.

Two minor items reported in the same issue are also addressed:

- The non-convergence warning in `newtonLoop()` tested `i == MaxNewtonIter_`
  *inside* the do-while, but the loop terminates as `i` reaches that value, so
  the body never saw it and a non-converged return mapping was silent. The check
  is moved after the loop and now tests the residual against the tolerance,
  reporting both values.
- `newDeltaT()` warning typo: "lover 50 times larger" -> "over 50 times larger".

## Behaviour change

This **is a behaviour change** for `uns` solid models using
`neoHookeanElasticMisesPlastic` with plasticity: boundary faces now see the
correct plastic-strain history in the return mapping. With linear hardening the
difference is small; with a non-linear hardening table the boundary yield stress
was previously looked up from the wrong history, so boundary stresses could
drift as plastic strain accumulated. **Regression reference values for affected
tutorials may move**, and should be re-baselined after review.

The `newtonLoop()` change may also surface previously-hidden "not converging"
warnings in runs where the return mapping was genuinely not converging. That is
the intent — the information was being discarded.

## Scope check

I checked whether any sibling field has the same mistake:

- The cell-based `correct(volSymmTensorField&)` overload in the same file uses
  `epsilonPEq_` throughout, which is correct there.
- `linearElasticMisesPlastic.C:1095` also uses
  `epsilonPEq_.oldTime().boundaryField()[patchI]`, but that occurrence is inside
  the cell-based `correct(volSymmTensorField&)` overload, so it is correct.
- No other cell-field reference appears in the face-based routine.

## Verification

Done:

- Independent reading of the file, comparing the face-based boundary loop
  against the face-based internal loop and against the cell-based overload;
  the reported bug is confirmed.
- `g++ -fsyntax-only` on the edited translation unit against OpenFOAM v2512
  (`-std=c++17 -DOPENFOAM_COM -DOPENFOAM_NOT_EXTEND`): clean, exit 0.

Not done (deliberately — this machine shares one `platforms/` library directory
across worktrees, so a build would clobber concurrent work):

- No `wmake` / `Allwmake`.
- No tutorial or solver runs, and therefore no numerical before/after comparison
  and no check of which regression reference values move.
- Not compiled against foam-extend or the OpenFOAM.org forks (the edited lines
  are inside `#ifdef`-independent code, but this is untested).

Reviewers with a free build slot should run the plasticity tutorials for the
`uns` solid models and re-baseline as needed.

Closes #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)
