### PR TITLE
[Bug] linearElasticMohrCoulombPlastic: reject a near-zero friction angle instead of dividing by zero

### DIFF
--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticMohrCoulombPlastic/README.md
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticMohrCoulombPlastic/README.md
@@ -68,8 +68,13 @@ that overload is not compiled for foam-extend.
 
 `planeStress` is read from the enclosing `mechanicalProperties` dictionary,
 not from the law dictionary. It changes the value of `lambda` as shown above.
-The constructor does not check the ranges of `nu`, `frictionAngle`, or
-`dilationAngle`.
+The constructor checks that the magnitude of `frictionAngle` is at least
+`1e-3` degrees, because `k` tends to 1 and the apex stress
+`2*cohesion*sqrt(k)/(k - 1)` becomes singular as the friction angle tends to
+zero; a fatal error is given otherwise. The purely cohesive (Tresca-like)
+limit is not implemented by this law: use `linearElasticMisesPlastic` for a
+pressure-independent yield surface. The constructor does not check the ranges
+of `nu` or `dilationAngle`.
 
 The base class reads `solvePressureEqn` and
 `pressureSmoothingScaleFactor`, but this law never calls

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticMohrCoulombPlastic/linearElasticMohrCoulombPlastic.C
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticMohrCoulombPlastic/linearElasticMohrCoulombPlastic.C
@@ -407,6 +407,49 @@ void Foam::linearElasticMohrCoulombPlastic::calculateEigens
     }
 }
 
+// * * * * * * * * * * * Private Member Functions  * * * * * * * * * * * * * //
+
+Foam::dimensionedScalar
+Foam::linearElasticMohrCoulombPlastic::readFrictionAngle
+(
+    const dictionary& dict
+)
+{
+    const dimensionedScalar varPhi(dict.lookup("frictionAngle"));
+
+    // The derived parameter k = (1 + sin(varPhi))/(1 - sin(varPhi)) tends to 1
+    // as varPhi tends to zero, and the apex stress
+    // sigma_a = 2*c*sqrt(k)/(k - 1) then tends to infinity, i.e. the apex of
+    // the Mohr-Coulomb surface moves to infinity. This limiting (Tresca-like)
+    // case is not implemented, so it is rejected here rather than dividing by
+    // zero when constructing the derived parameters below
+    const scalar smallFrictionAngle = 1e-3;
+
+    if (mag(varPhi.value()) < smallFrictionAngle)
+    {
+        FatalErrorIn
+        (
+            "Foam::dimensionedScalar"
+            " Foam::linearElasticMohrCoulombPlastic::readFrictionAngle"
+            "(const dictionary&)"
+        )   << "The 'frictionAngle' entry in the '" << dict.name()
+            << "' dictionary is " << varPhi.value() << " degrees, which is at "
+            << "or near zero." << nl
+            << "The linearElasticMohrCoulombPlastic law cannot be used in this "
+            << "limit: as the friction angle tends to zero, the apex of the "
+            << "Mohr-Coulomb surface moves to infinity and the derived "
+            << "parameters become singular (division by zero)." << nl
+            << "Please specify a 'frictionAngle' with a magnitude of at least "
+            << smallFrictionAngle << " degrees, or, for a pressure-independent "
+            << "(Tresca/von Mises type) law, use the "
+            << "'linearElasticMisesPlastic' mechanical law instead."
+            << abort(FatalError);
+    }
+
+    return varPhi;
+}
+
+
 // * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
 
 // Construct from dictionary
@@ -429,7 +472,7 @@ Foam::linearElasticMohrCoulombPlastic::linearElasticMohrCoulombPlastic
     ),
     mu_(E_/(2.0*(1.0 + nu_))),
     K_(lambda_ + (2.0/3.0)*mu_),
-    varPhi_(dict.lookup("frictionAngle")),
+    varPhi_(readFrictionAngle(dict)),
     c_(dict.lookup("cohesion")),
     varPsi_(dict.lookup("dilationAngle")),
     k_

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticMohrCoulombPlastic/linearElasticMohrCoulombPlastic.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticMohrCoulombPlastic/linearElasticMohrCoulombPlastic.H
@@ -157,6 +157,11 @@ class linearElasticMohrCoulombPlastic
 
     // Private Member Functions
 
+        //- Read the frictionAngle entry from the dictionary and check that it
+        //  is not at or near zero, as the derived parameters are singular in
+        //  that limit
+        static dimensionedScalar readFrictionAngle(const dictionary& dict);
+
         //- Calculate the stress
         void calculateStress(symmTensor& sigma, scalar& activeYield) const;
 


### PR DESCRIPTION
## Problem

`linearElasticMohrCoulombPlastic` derives

```
k = (1 + sin(varPhi))/(1 - sin(varPhi))
```

and then the apex stress `sigma_a = 2*c*sqrt(k)/(k - 1)`. For
`frictionAngle 0`, `sin(0) = 0` so `k = 1` and the apex stress divides by
zero at construction, giving an infinite or NaN value that propagates
silently into the return mapping. Nothing validated the entry beforehand.

## Change

The `frictionAngle` entry is now read through a new private static helper,
`readFrictionAngle(const dictionary&)`, which fails with an explicit
`FatalError` when `mag(frictionAngle) < 1e-3` degrees. The message names the
entry and the dictionary, explains that the apex of the Mohr-Coulomb surface
moves to infinity as the friction angle tends to zero, and points the user at
`linearElasticMisesPlastic` for a pressure-independent (Tresca/von Mises type)
yield surface — there is no Tresca law in the repository.

A small tolerance is used rather than an exact `== 0` test, so values that are
merely near zero (and would give an enormous, effectively singular apex
stress) are also caught.

The check necessarily runs **before** the division: `varPhi_` is declared
before `k_` and `sigma_a_` in the class, so its initialiser — and hence the
helper — is evaluated first.

The law's `README.md` is updated, since it previously stated that the
constructor does not check the range of `frictionAngle`.

## Existing valid inputs are unaffected

This is purely an added guard on an input that previously crashed or produced
NaNs. No behaviour changes for any admissible friction angle. Both tutorials
using this law (`tutorials/solids/poroelasticity/stripFooting` and
`.../suctionCaission`) specify `frictionAngle 30`.

## Still open

The richer fix — implementing the `k == 1` limiting case properly, i.e. the
purely cohesive Tresca-like limit that is meaningful for undrained clay — is
**not** attempted here and remains open. This PR only converts a silent
division by zero into a clear error.

## Verification

Done:
- Read `linearElasticMohrCoulombPlastic.C` and confirmed the singularity and
  the member-initialisation order independently of the issue report.
- `g++ -fsyntax-only` on the edited translation unit against OpenFOAM v2512
  (`-std=c++17 -DOPENFOAM_COM -DOPENFOAM_NOT_EXTEND`): zero errors; only the
  pre-existing `dimensioned(Istream&)` deprecation warnings that every other
  `dict.lookup(...)` in this constructor already produces.
- Grepped the tutorials for `frictionAngle` to confirm no case relies on a
  zero or near-zero value.

Not done:
- No `wmake`/`Allwmake` link or full library build (this machine shares one
  `platforms/` directory across worktrees, so a build would clobber other
  users' work).
- No tutorial or solver runs, so the error path was not exercised at runtime.
- Not syntax-checked against foam-extend or OpenFOAM.org; the added code uses
  only `dictionary::lookup`, `dictionary::name`, `mag` and `FatalErrorIn`,
  which are common to all supported forks.

Closes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFtsPKfZb9WoT45M8Qw6nD
