### PR TITLE
[Fix] linearElasticFromFile/linearElasticCt: shear stress was twice the Hookean value

### DIFF
--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticCt/README.md
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticCt/README.md
@@ -18,9 +18,7 @@ linearElasticCt
 happens, and selecting `linearElasticCt` in `mechanicalProperties` fails with
 an unknown-type error. The source is present and this page describes it, but
 the law has to be added to a build list before it can be used. This is tracked
-as [issue #336](https://github.com/solids4foam/solids4foam/issues/336); note
-that [issue #335](https://github.com/solids4foam/solids4foam/issues/335)
-applies to this law too once it is built.
+as [issue #336](https://github.com/solids4foam/solids4foam/issues/336).
 ```
 
 ---
@@ -48,7 +46,7 @@ they are found.
 The elastic coefficients and stress are then evaluated as implemented:
 
 ```text
-mu     = E/(1 + nu)
+mu     = E/(2*(1 + nu))
 lambda = E*nu/((1 + nu)*(1 - 2*nu))         // plane strain / 3-D
 lambda = E*nu/((1 + nu)*(1 - nu))           // planeStress yes
 
@@ -166,7 +164,7 @@ offset and path entries are then not read.
 
 - `E`: cell-wise Young's modulus. It has zero-gradient boundaries and is
   explicitly written during construction.
-- `mu`: cell-wise coefficient `E/(1 + nu)` with its face interpolation
+- `mu`: cell-wise shear modulus `E/(2*(1 + nu))` with its face interpolation
   maintained in `muf_`.
 - `lambda`: cell-wise first Lame coefficient with its face interpolation
   maintained in `lambdaf_`.

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticCt/linearElasticCt.C
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticCt/linearElasticCt.C
@@ -431,7 +431,7 @@ Foam::linearElasticCt::linearElasticCt
             IOobject::NO_READ,
             IOobject::NO_WRITE
         ),
-        E_/(1.0 + nu_)
+        E_/(2.0*(1.0 + nu_))
     ),
     lambda_
     (
@@ -485,7 +485,7 @@ Foam::linearElasticCt::linearElasticCt
     setYoungsModulusFromCt();
 
     // Reset mechanical fields after E has been updated
-    mu_ = E_/(1.0 + nu_);
+    mu_ = E_/(2.0*(1.0 + nu_));
     lambda_ = E_*nu_/((1.0 + nu_)*(1.0 - 2.0*nu_));
 
     muf_ = fvc::interpolate(mu_);

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticFromFile/README.md
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticFromFile/README.md
@@ -11,19 +11,6 @@ Young's modulus field from disk. The runtime type is:
 linearElasticFromFile
 ```
 
-```warning
-The shear term of this law appears to be twice the Hookean value. It sets
-`mu = E/(1 + nu)`, whereas the shear modulus is `E/(2*(1 + nu))`, and then
-forms the stress as `mu*twoSymm(grad(D))`, which is `2*mu*epsilon`. The
-resulting deviatoric stress is therefore `2*E/(1 + nu)*epsilon` rather than
-`E/(1 + nu)*epsilon`. For comparison, `linearElastic` sets
-`mu = E/(2*(1 + nu))` for the same stress expression. The volumetric term and
-the `planeStress` handling are correct. Treat results from this law with
-caution until this is resolved; `linearElasticCt` contains the same
-expression. This is tracked as
-[issue #335](https://github.com/solids4foam/solids4foam/issues/335).
-```
-
 ---
 
 ## User Guide
@@ -34,7 +21,7 @@ The law reads the `E` field and evaluates the elastic coefficients as
 implemented:
 
 ```text
-mu     = E/(1 + nu)
+mu     = E/(2*(1 + nu))
 lambda = E*nu/((1 + nu)*(1 - 2*nu))        // plane strain / 3-D
 lambda = E*nu/((1 + nu)*(1 - nu))          // planeStress yes
 
@@ -110,7 +97,7 @@ distribution used by the law.
 
 - `E`: cell-wise Young's modulus, read from the current time directory and
   marked for automatic writing.
-- `mu`: cell-wise coefficient `E/(1 + nu)`.
+- `mu`: cell-wise shear modulus `E/(2*(1 + nu))`.
 - `lambda`: cell-wise first Lame coefficient, with the plane-stress form used
   when requested.
 - `muf_`, `lambdaf_`: face interpolations of `mu` and `lambda`, calculated

--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticFromFile/linearElasticFromFile.C
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticFromFile/linearElasticFromFile.C
@@ -71,7 +71,7 @@ Foam::linearElasticFromFile::linearElasticFromFile
             IOobject::NO_READ,
             IOobject::NO_WRITE
         ),
-        E_/(1.0 + nu_)
+        E_/(2.0*(1.0 + nu_))
     ),
     lambda_
     (


### PR DESCRIPTION
## The problem

`linearElasticFromFile` and `linearElasticCt` both set the shear coefficient to

```cpp
mu_ = E_/(1.0 + nu_);
```

and then form the stress as

```cpp
sigma = mu_*twoSymm(gradD) + lambda_*tr(gradD)*I;
```

`twoSymm(gradD)` is `gradD + gradD.T()`, i.e. `2*epsilon`, so the deviatoric term evaluates to

```text
2*mu*epsilon = 2*E/(1 + nu)*epsilon
```

Hooke's law requires `2*G*epsilon` with `G = E/(2*(1 + nu))`, i.e. `E/(1 + nu)*epsilon`. The shear response was therefore exactly a factor of two too stiff.

`linearElastic.C:73` uses `mu_ = E_/(2.0*(1.0 + nu_))` for the same stress form, and it is correct; these two laws were the only ones in `linearGeometryLaws` combining `mu = E/(1 + nu)` with `twoSymm`.

## The fix

Set `mu = E/(2*(1 + nu))` at every place the shear coefficient is assigned:

- `linearElasticFromFile.C` constructor initialiser list (1 site)
- `linearElasticCt.C` constructor initialiser list, and the reset that follows `setYoungsModulusFromCt()` (2 sites)

Everything else is left alone, having been checked and found correct:

- `lambda_ = E*nu/((1 + nu)*(1 - 2*nu))` (3-D / plane strain) is unchanged and correct.
- The `planeStress()` branches only override `lambda_` (`nu*E/((1 + nu)*(1 - nu))`), which matches `linearElastic`; `mu` is correctly independent of plane stress in both laws, so the fix is complete for that branch too.
- `impK()` returns `2*mu + lambda`, which is the same expression `linearElastic` uses and which stays consistent with the corrected stress — no separate change needed.
- The face-centred `correct(surfaceSymmTensorField&)` overloads use `muf_ = fvc::interpolate(mu_)`, so they are fixed by the same change.

The in-repo README warnings for both laws are updated: the `linearElasticFromFile` warning block is removed, the stale `mu = E/(1 + nu)` formulas are corrected, and the `linearElasticCt` warning no longer cross-references #335 (its remaining not-built warning for #336 stands).

## Behaviour change

**This changes results.** `linearElasticFromFile` is built on both forks (`Make/files.openfoam:60`, `Make/files.foamextend:60`) and is selectable today, so any existing user case that selects it will now produce half its previous shear stress. That is the intended correction — the previous output was not Hookean — but users with saved results from this law should re-run.

`linearElasticCt` is listed in neither `Make/files`, so it is not compiled and the change has no effect until #336 is resolved.

### Tutorials and regression values

I grepped the whole repository: no tutorial, `caseOptions/` variant, or `regressionTest.sh` references either law. **No regression reference value moves.** Both laws remain without tutorial coverage; adding a `linearElasticFromFile` case, as the issue suggests, is left as follow-up work so this PR stays a focused one-line-per-site fix.

## Verification

Done:

- Independently re-derived the maths and confirmed the issue's claim by reading all three laws before changing anything.
- Audited every `mu_` assignment in both files (including the post-CT reset in `linearElasticCt`, which the issue did not call out explicitly) so no site is left inconsistent.
- `g++ -fsyntax-only` (OpenFOAM.com v2512, `-std=c++17`) on both edited translation units. `linearElasticFromFile.C` compiles clean (deprecation warnings only). `linearElasticCt.C` still reports two errors at line 452 (`dict()` not callable, `lookupOrAddDefault<Switch>`) — I confirmed these are **pre-existing and identical** on unmodified `origin/development`, are unrelated to this change, and are the reason the file is not in any build list (#336).
- Grepped for tutorial/regression usage of both laws.

Not done:

- No `wmake`/`Allwmake` and no tutorial or solver runs: this machine shares one `platforms/` library directory across all worktrees, so a build here would clobber other users' work. A full build and a numerical check against the analytical `2*G*epsilon` should be done by CI.

Closes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFtsPKfZb9WoT45M8Qw6nD
