### PR TITLE
[Fix] Propagate application exit code from solids4Foam::runApplication (#318)

### DIFF
--- a/applications/scripts/solids4FoamScripts.sh
+++ b/applications/scripts/solids4FoamScripts.sh
@@ -877,11 +877,21 @@ function solids4Foam::runApplication()
              "remove log file '$logFile' to re-run"
     else
         echo "Running $appRun on $PWD"
+        local rc=0
         if [ "$logMode" = append ]
         then
-            $appRun $appArgs "$@" >> $logFile 2>&1 || echo "ERROR" >> $logFile
+            $appRun $appArgs "$@" >> $logFile 2>&1 || rc=$?
         else
-            $appRun $appArgs "$@" > $logFile 2>&1 || echo "ERROR" >> $logFile
+            $appRun $appArgs "$@" > $logFile 2>&1 || rc=$?
+        fi
+
+        if [ "$rc" -ne 0 ]
+        then
+            # Keep the ERROR marker that existing scripts grep for
+            echo "ERROR" >> $logFile
+            echo "Error: $appName failed with exit code $rc;" \
+                 "see $PWD/$logFile" 1>&2
+            return "$rc"
         fi
     fi
 }


### PR DESCRIPTION
## What this changes

`solids4Foam::runApplication` recorded a failure with `|| echo "ERROR" >> $logFile`. The `echo` succeeds, so the compound command always succeeded and the function always returned 0. A `FOAM FATAL ERROR`, a missing dictionary or a diverged solver therefore left the calling `Allrun` exiting 0, and CI reported a downstream symptom ("could not extract sigmaEq") instead of the real error.

The fix is the one suggested in the issue, and is confined to the body of `runApplication` (12 insertions, 2 deletions in `applications/scripts/solids4FoamScripts.sh`):

- capture the application's exit code into a local `rc`;
- on failure, still write the `ERROR` marker to the log, additionally print `Error: <app> failed with exit code <rc>; see <path>/<log>` to stderr, and `return "$rc"`.

Deliberately unchanged:

- the `ERROR` marker in the log file — `tutorials/Allrun` derives its aggregate pass/fail counts from `grep "ERROR" AllrunReport`, so that accounting is unaffected;
- the "already run … remove log file to re-run" short circuit, which still returns 0;
- the success path, which writes no marker.

The diff is kept minimal and local to `runApplication` because PRs for #319, #322 and #384 also touch this file.

## Callers surveyed

`grep -rn "solids4Foam::runApplication" .` gives 251 call sites across 70 files. Almost all are in tutorial `Allrun` scripts that do **not** set `errexit`, so for those the only visible change is the new stderr line — the return value was being ignored before and still is. Points worth flagging:

**Callers that already assumed a meaningful return value (previously dead code, now live — an improvement):**

- `tutorials/solids/linearElasticity/wobblyNewton/regressionTest.sh:168,175,209,216` — `if ! solids4Foam::runApplication …`
- `tutorials/solids/linearElasticity/ellipticPlate/regressionTest.sh:239,250,255` — same form
- `tutorials/solids/linearElasticity/cooksMembrane/regressionTest.sh:186,189,218` — the enclosing functions are invoked as `if run_gradient_test` / `if ! run_high_order_grad_test …`, so `errexit` is suspended inside them and a failure is now reported as a per-test `FAIL` instead of being silently treated as a pass.

**No caller was found that deliberately tolerates a failing `runApplication`.** There is no `|| true`, `|| :` or `set +e` around any call site. The applications that are most plausibly optional (`sample`, `postProcess`, `foamCalc`, `setSet`, `gmsh`, `icoFoam`) are all invoked unconditionally and, where the application is version-specific, behind an explicit `$WM_PROJECT` guard (e.g. `tutorials/solids/linearElasticity/pressurisedCylinder/Allrun:124-129`). So nothing needed an `|| true` workaround, and none was added.

**The 13 `Allrun` scripts under `set -Eeuo pipefail` that will now abort at the point of failure** (this is the intended outcome of the issue, but it changes which log files exist afterwards):

`tutorials/solids/hyperelasticity/rigidRotation/rotatingBlock`, `.../rotatingSphere`, `tutorials/solids/hyperelasticity/idealisedVentricle`, `.../cylindricalPressureVessel`, `.../heartTissueBeam`, `tutorials/solids/linearElasticity/cooksMembrane`, `.../sphericalCavity`, `.../pressurisedCylinder`, `.../cantilever2d`, `.../ellipticPlate`, `.../narrowTmember`, `.../plateHole`, `tutorials/fluidSolidInteraction/cerebralAneurysm`.

**One caller that will now abort the whole script rather than report a per-approach failure — reported, not worked around** (issue checklist item 3):

`tutorials/solids/linearElasticity/sphericalCavity/regressionTest.sh:285` calls `run_parallel_case > "${CASE_DIR}/${ALLRUN_LOGFILE}" 2>&1` outside any conditional, under `set -euo pipefail`; the same applies to the `./Allrun "${RUN_APPROACH}"` subshell at lines 288-293. If one approach fails, the loop over `APPROACHES` will now abort instead of counting a failure and continuing to the remaining approaches. That is louder and more accurate than the old silent pass, but a follow-up may want to capture the status per approach so one broken approach does not hide the others' results. I have not changed it here, to keep this PR to the single function.

**Skip path (issue checklist item 4) is unaffected.** `solids4Foam::requirePetscOrExitSilently` and the `caseOnlyRunsWith…` / `caseDoesNotRunWith…` helpers `exit 0` from the `Allrun` itself before any application runs, so `solids4Foam::regressionCaseSkipped` still sees an exit-0 log with the skip message and a genuine skip stays distinguishable from a real failure.

**`Alltest` / `tutorials/Allrun` accounting (item 5) is unaffected**, because it counts `ERROR` markers in `AllrunReport`, and the marker is preserved.

**Out of scope, noted for a follow-up:** `solids4Foam::runParallel` (same file) already propagates its exit code, because the `mpirun` subshell is the function's last command — but it writes *no* `ERROR` marker at all, so a failed parallel run is invisible to the `tutorials/Allrun` accounting. Not touched here.

## Verification done / not done

Done:

- `bash -n applications/scripts/solids4FoamScripts.sh` passes.
- A standalone harness extracts the `runApplication` function and runs it against stub applications. All pass on this branch and the failure-related assertions fail on `origin/development`:
  - exit code 0 → returns 0, no `ERROR` marker;
  - exit code 1 → returns 1, `ERROR` marker written;
  - exit code 77 → returns 77 (exact code preserved, not collapsed to 1);
  - `-a`/append mode → returns 1 and appends a second `ERROR` marker;
  - already-run short circuit → still returns 0;
  - a `set -Eeuo pipefail` caller aborts at the failing call;
  - the stderr diagnostic is emitted and does not pollute stdout.

Not done (deliberately, per the constraints I was given):

- No compilation (`wmake` / `Allwmake`) — this machine shares one `platforms/` directory between worktrees.
- No tutorial or solver was executed, so the acceptance reproducer from the issue (delete `blockMeshDict` in `rotatingBlock` and check `./Allrun totalLagrangian` now exits non-zero) has **not** been run here; it should be exercised in CI or by a reviewer.
- The full regression suite has not been run, so the practical impact on `sphericalCavity/regressionTest.sh` described above is reasoned from the source rather than observed.

Closes #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFtsPKfZb9WoT45M8Qw6nD
