### PR TITLE
[Fix] Regression tests: fail, not pass, when a tutorial produces no output without declaring a skip

### DIFF
--- a/tutorials/fluidSolidInteraction/3dTube/regressionTest.sh
+++ b/tutorials/fluidSolidInteraction/3dTube/regressionTest.sh
@@ -112,6 +112,13 @@ else
     echo "Running in check-only mode: skipping Allclean and Allrun"
 fi
 
+# A skip is only valid if the tutorial declared one in the Allrun log. Anything
+# else that leaves the expected output missing or incomplete is a failure.
+if solids4Foam::regressionCaseSkipped "${CASE_DIR}/${ALLRUN_LOGFILE}"; then
+    echo "Skipping regression checks because the tutorial skipped in this environment"
+    exit 0
+fi
+
 disp_time=$(latest_numeric_time "${CASE_DIR}/${DISP_FILE}" || true)
 force_file=""
 if force_file=$(find_force_file); then
@@ -121,18 +128,22 @@ else
 fi
 
 if [[ -z "${disp_time}" || -z "${force_file}" || -z "${force_time}" ]]; then
-    echo "Skipping regression checks because the case did not complete in this environment"
-    exit 0
+    echo "FAIL: the case did not run or did not complete in this environment:"
+    echo "      expected output is missing and the tutorial did not declare a skip"
+    echo "      (see ${CASE_DIR}/${ALLRUN_LOGFILE})"
+    exit 1
 fi
 
 if ! awk "BEGIN {exit !(${disp_time} + 0 >= ${REG_END_TIME})}"; then
-    echo "Skipping regression checks because the case did not reach the requested end time"
-    exit 0
+    echo "FAIL: the displacement history stops at t = ${disp_time}, short of the"
+    echo "      requested end time ${REG_END_TIME}: the case did not complete"
+    exit 1
 fi
 
 if ! awk "BEGIN {exit !(${force_time} + 0 >= ${REG_END_TIME})}"; then
-    echo "Skipping regression checks because the force history did not reach the requested end time"
-    exit 0
+    echo "FAIL: the force history stops at t = ${force_time}, short of the"
+    echo "      requested end time ${REG_END_TIME}: the case did not complete"
+    exit 1
 fi
 
 # OpenFOAM variant compatibility

--- a/tutorials/fluidSolidInteraction/HronTurekFsi3/regressionTest.sh
+++ b/tutorials/fluidSolidInteraction/HronTurekFsi3/regressionTest.sh
@@ -148,6 +148,13 @@ find_force_file() {
 prepare_case
 run_case
 
+# A skip is only valid if the tutorial declared one in the Allrun log. Anything
+# else that leaves the expected output missing or incomplete is a failure.
+if solids4Foam::regressionCaseSkipped "${CASE_DIR}/${ALLRUN_LOGFILE}"; then
+    echo "Skipping regression checks because the tutorial skipped in this environment"
+    exit 0
+fi
+
 tip_time=$(latest_numeric_time "${CASE_DIR}/${DISP_FILE}" || true)
 force_file=""
 if force_file=$(find_force_file); then
@@ -157,18 +164,22 @@ else
 fi
 
 if [[ -z "${tip_time}" || -z "${force_file}" || -z "${force_time}" ]]; then
-    echo "Skipping regression checks because the case did not complete in this environment"
-    exit 0
+    echo "FAIL: the case did not run or did not complete in this environment:"
+    echo "      expected output is missing and the tutorial did not declare a skip"
+    echo "      (see ${CASE_DIR}/${ALLRUN_LOGFILE})"
+    exit 1
 fi
 
 if ! awk "BEGIN {exit !(${tip_time} + 0 >= ${REG_END_TIME})}"; then
-    echo "Skipping regression checks because the tip displacement history did not reach the requested end time"
-    exit 0
+    echo "FAIL: the tip displacement history stops at t = ${tip_time}, short of the"
+    echo "      requested end time ${REG_END_TIME}: the case did not complete"
+    exit 1
 fi
 
 if ! awk "BEGIN {exit !(${force_time} + 0 >= ${REG_END_TIME})}"; then
-    echo "Skipping regression checks because the force history did not reach the requested end time"
-    exit 0
+    echo "FAIL: the force history stops at t = ${force_time}, short of the"
+    echo "      requested end time ${REG_END_TIME}: the case did not complete"
+    exit 1
 fi
 
 tip_uy=$(extract_final_tip_uy)

--- a/tutorials/fluidSolidInteraction/beamInCrossFlow/regressionTest.sh
+++ b/tutorials/fluidSolidInteraction/beamInCrossFlow/regressionTest.sh
@@ -9,6 +9,9 @@ IFS=$'\n\t'
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 REGRESSION_ROOT="${SCRIPT_DIR}/regressionTests"
 
+# Source solids4Foam scripts
+source "${SCRIPT_DIR}/../../../applications/scripts/solids4FoamScripts.sh"
+
 # ------------------------------------------------------------
 # Regression tolerances
 # ------------------------------------------------------------
@@ -255,19 +258,33 @@ check_case() {
         force_time=""
     fi
 
-    if [[ -z "${disp_time}" || -z "${force_file}" || -z "${force_time}" ]]; then
-        echo "Skipping ${coupling} regression checks because the case did not complete in this environment"
+    # A skip is only valid if the tutorial declared one in the Allrun log.
+    # Anything else that leaves the expected output missing or incomplete is a
+    # failure.
+    if solids4Foam::regressionCaseSkipped "${case_dir}/${ALLRUN_LOGFILE}"; then
+        echo "Skipping ${coupling} regression checks because the tutorial skipped in this environment"
         return 0
+    fi
+
+    if [[ -z "${disp_time}" || -z "${force_file}" || -z "${force_time}" ]]; then
+        echo "FAIL [${coupling}]: the case did not run or did not complete in this"
+        echo "      environment: expected output is missing and the tutorial did"
+        echo "      not declare a skip (see ${case_dir}/${ALLRUN_LOGFILE})"
+        return 1
     fi
 
     if ! awk "BEGIN {exit !(${disp_time} + 0 >= ${REGRESSION_END_TIME})}"; then
-        echo "Skipping ${coupling} regression checks because the displacement history did not reach the requested end time"
-        return 0
+        echo "FAIL [${coupling}]: the displacement history stops at t = ${disp_time},"
+        echo "      short of the requested end time ${REGRESSION_END_TIME}: the case"
+        echo "      did not complete"
+        return 1
     fi
 
     if ! awk "BEGIN {exit !(${force_time} + 0 >= ${REGRESSION_END_TIME})}"; then
-        echo "Skipping ${coupling} regression checks because the force history did not reach the requested end time"
-        return 0
+        echo "FAIL [${coupling}]: the force history stops at t = ${force_time},"
+        echo "      short of the requested end time ${REGRESSION_END_TIME}: the case"
+        echo "      did not complete"
+        return 1
     fi
 
     max_disp=$(extract_max_displacement "${case_dir}")

--- a/tutorials/fluidSolidInteraction/cerebralAneurysm/regressionTest.sh
+++ b/tutorials/fluidSolidInteraction/cerebralAneurysm/regressionTest.sh
@@ -6,6 +6,9 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 REGRESSION_ROOT="${SCRIPT_DIR}/regressionTests"
 CASE_DIR="${REGRESSION_ROOT}/main"
 
+# Source solids4Foam scripts
+source "${SCRIPT_DIR}/../../../applications/scripts/solids4FoamScripts.sh"
+
 # ============================================================
 # cerebralAneurysm FSI regression test
 #
@@ -94,29 +97,42 @@ else
     echo "Running in check-only mode: skipping Allclean and Allrun"
 fi
 
-# The case requires PETSc and cartesianMesh: Allrun exits silently when either
-# is unavailable, in which case there is nothing to check
-if [[ ! -f "${CASE_DIR}/${DISP_FILE}" || ! -f "${CASE_DIR}/${FORCE_FILE}" ]]; then
-    echo "Skipping regression checks because the case did not run in this environment"
+# The case requires PETSc and cartesianMesh: when either is unavailable Allrun
+# writes a declared skip message, which is the only valid reason to skip the
+# checks. Anything else that leaves the expected output missing or incomplete
+# is a failure.
+if solids4Foam::regressionCaseSkipped "${CASE_DIR}/${ALLRUN_LOGFILE}"; then
+    echo "Skipping regression checks because the tutorial skipped in this environment"
     exit 0
+fi
+
+if [[ ! -f "${CASE_DIR}/${DISP_FILE}" || ! -f "${CASE_DIR}/${FORCE_FILE}" ]]; then
+    echo "FAIL: the case did not run in this environment:"
+    echo "      expected output is missing and the tutorial did not declare a skip"
+    echo "      (see ${CASE_DIR}/${ALLRUN_LOGFILE})"
+    exit 1
 fi
 
 disp_time=$(latest_numeric_time "${CASE_DIR}/${DISP_FILE}" || true)
 force_time=$(latest_numeric_time "${CASE_DIR}/${FORCE_FILE}" || true)
 
 if [[ -z "${disp_time}" || -z "${force_time}" ]]; then
-    echo "Skipping regression checks because the case did not complete in this environment"
-    exit 0
+    echo "FAIL: the case did not complete in this environment:"
+    echo "      the output files contain no time data and the tutorial did not"
+    echo "      declare a skip (see ${CASE_DIR}/${ALLRUN_LOGFILE})"
+    exit 1
 fi
 
 if ! awk "BEGIN {exit !(${disp_time} + 0 >= ${REG_END_TIME})}"; then
-    echo "Skipping regression checks because the case did not reach the requested end time"
-    exit 0
+    echo "FAIL: the displacement history stops at t = ${disp_time}, short of the"
+    echo "      requested end time ${REG_END_TIME}: the case did not complete"
+    exit 1
 fi
 
 if ! awk "BEGIN {exit !(${force_time} + 0 >= ${REG_END_TIME})}"; then
-    echo "Skipping regression checks because the force history did not reach the requested end time"
-    exit 0
+    echo "FAIL: the force history stops at t = ${force_time}, short of the"
+    echo "      requested end time ${REG_END_TIME}: the case did not complete"
+    exit 1
 fi
 
 # ------------------------------------------------------------

--- a/tutorials/fluidSolidInteraction/fillingElasticContainer/regressionTest.sh
+++ b/tutorials/fluidSolidInteraction/fillingElasticContainer/regressionTest.sh
@@ -115,6 +115,8 @@ extract_final_fsi_residual() {
 prepare_case
 run_case
 
+# A skip is only valid if the tutorial declared one in the Allrun log. Anything
+# else that leaves the expected output missing or incomplete is a failure.
 if solids4Foam::regressionCaseSkipped "${CASE_DIR}/${ALLRUN_LOGFILE}"; then
     echo "Skipping regression checks because the tutorial skipped in this environment"
     exit 0
@@ -124,18 +126,22 @@ apex_time=$(latest_numeric_time "${CASE_DIR}/${DISP_FILE}" || true)
 fsi_time=$(latest_numeric_time "${CASE_DIR}/${FSI_RES_FILE}" || true)
 
 if [[ -z "${apex_time}" || -z "${fsi_time}" ]]; then
-    echo "Skipping regression checks because the case did not complete in this environment"
-    exit 0
+    echo "FAIL: the case did not run or did not complete in this environment:"
+    echo "      expected output is missing and the tutorial did not declare a skip"
+    echo "      (see ${CASE_DIR}/${ALLRUN_LOGFILE})"
+    exit 1
 fi
 
 if ! awk "BEGIN {exit !(${apex_time} + 0 >= ${REG_END_TIME})}"; then
-    echo "Skipping regression checks because the apex history did not reach the requested end time"
-    exit 0
+    echo "FAIL: the apex history stops at t = ${apex_time}, short of the"
+    echo "      requested end time ${REG_END_TIME}: the case did not complete"
+    exit 1
 fi
 
 if ! awk "BEGIN {exit !(${fsi_time} + 0 >= ${REG_END_TIME})}"; then
-    echo "Skipping regression checks because the FSI residual history did not reach the requested end time"
-    exit 0
+    echo "FAIL: the FSI residual history stops at t = ${fsi_time}, short of the"
+    echo "      requested end time ${REG_END_TIME}: the case did not complete"
+    exit 1
 fi
 
 apex_dy=$(extract_final_apex_dy)

--- a/tutorials/solids/linearElasticity/narrowTmember/regressionTest.sh
+++ b/tutorials/solids/linearElasticity/narrowTmember/regressionTest.sh
@@ -62,13 +62,18 @@ else
     echo "Running in check-only mode: skipping Allclean and Allrun"
 fi
 
+# A skip is only valid if the tutorial declared one in the Allrun log. Anything
+# else that leaves the expected output missing is a failure.
 if solids4Foam::regressionCaseSkipped "${CASE_DIR}/${ALLRUN_LOGFILE}"; then
     echo "Skipping regression checks because the tutorial skipped in this environment"
     exit 0
 fi
 
 extract_max_sigma() {
-    grep "Max sigmaEq (von Mises stress)" "${CASE_DIR}/${SOLVER_LOGFILE}" \
+    # A missing solver log or a log without the expected line is reported as an
+    # empty result, so that the check below can fail with a clear message
+    { grep "Max sigmaEq (von Mises stress)" "${CASE_DIR}/${SOLVER_LOGFILE}" \
+        2> /dev/null || true; } \
         | tail -n 1 \
         | awk '{print $NF}'
 }
@@ -76,8 +81,11 @@ extract_max_sigma() {
 sigma=$(extract_max_sigma)
 
 if [[ -z "${sigma}" ]]; then
-    echo "Skipping regression checks because the case did not complete in this environment"
-    exit 0
+    echo "FAIL: the case did not run or did not complete in this environment:"
+    echo "      no 'Max sigmaEq' line was found in ${CASE_DIR}/${SOLVER_LOGFILE}"
+    echo "      and the tutorial did not declare a skip"
+    echo "      (see ${CASE_DIR}/${ALLRUN_LOGFILE})"
+    exit 1
 fi
 
 failures=0


### PR DESCRIPTION
## What this changes

Some regression scripts inferred a skip from missing data: if the expected
output file was absent, empty, or stopped short of the requested end time, they
printed "Skipping regression checks because the case did not complete in this
environment" and `exit 0`. That cannot distinguish "this tutorial is not meant
to run on this flavour" from "this tutorial ran and crashed", so a crashed case
was reported as `PASS` (issue #384).

This PR makes the **declared** skip the sole authority:

- If `solids4Foam::regressionCaseSkipped` matches the `Allrun` log — the
  existing, deliberate mechanism that looks for messages such as "This case
  currently does not run with OpenFOAM.org" — the checks are skipped and the
  script exits 0, exactly as before.
- Otherwise, missing expected output, or output that does not reach the
  requested end time, is now a **failure** (`exit 1`, or `return 1` for
  `beamInCrossFlow`'s per-coupling `check_case`), with a message saying the case
  did not run or did not complete and pointing at the `Allrun` log.

## Scripts touched

| Script | Change |
| --- | --- |
| `tutorials/fluidSolidInteraction/3dTube/regressionTest.sh` | added declared-skip check; 3 inferred skips → FAIL |
| `tutorials/fluidSolidInteraction/HronTurekFsi3/regressionTest.sh` | added declared-skip check; 3 inferred skips → FAIL |
| `tutorials/fluidSolidInteraction/beamInCrossFlow/regressionTest.sh` | now sources the helper; added per-coupling declared-skip check; 3 inferred skips → FAIL |
| `tutorials/fluidSolidInteraction/cerebralAneurysm/regressionTest.sh` | now sources the helper; added declared-skip check; 4 inferred skips → FAIL |
| `tutorials/fluidSolidInteraction/fillingElasticContainer/regressionTest.sh` | already had the declared-skip check; 3 inferred skips → FAIL |
| `tutorials/solids/linearElasticity/narrowTmember/regressionTest.sh` | already had the declared-skip check; 1 inferred skip → FAIL; `extract_max_sigma` made tolerant of a missing solver log so the new FAIL message is reached instead of the script dying on `grep` under `set -e` |

`applications/scripts/solids4FoamScripts.sh` is **not** modified: the helper
already does what is needed, and other PRs are in flight against that file.

### Discrepancy with the issue's list

The issue listed five scripts. A fresh grep for the inferred-skip pattern finds
**six**: `fluidSolidInteraction/cerebralAneurysm` has the same construct
(`"the case did not run in this environment"` plus three end-time skips) and is
included here. After this PR, no `regressionTest.sh` under `tutorials/` still
infers a skip from missing data; the only remaining "Skipping regression checks"
messages are declared skips via `solids4Foam::regressionCaseSkipped` and two
explicit "Gmsh is not installed" guards, which are genuine environment checks.

Both `beamInCrossFlow` and `cerebralAneurysm` previously did not source
`solids4FoamScripts.sh` at all; they now do, so every converted script has the
helper available.

## Verification

Done:

- `bash -n` on all six scripts.
- A self-contained shell test (not committed; run locally) that builds fake
  tutorial trees with stub `Allrun`/`Allclean` scripts and fake `log.Allrun`
  files, requiring no OpenFOAM, no solver and no build. For each of the six
  scripts it asserts two scenarios:
  1. `log.Allrun` contains a declared skip message → exit 0 and a "Skipping
     regression checks" line (unchanged behaviour);
  2. `log.Allrun` contains only a FOAM fatal error and no output was written →
     exit 1 and a "FAIL: the case did not run/complete" line (previously exit
     0).

  Result: 12/12 assertions pass. Before the change, the second scenario exited
  0 for all six.

Not done:

- No compilation (`wmake`/`Allwmake`) and no tutorial or solver was run: this PR
  changes only shell scripts, and the worktree shares a `platforms/` directory
  with other work.
- `shellcheck` is not installed on the machine used, so only `bash -n` was run.
- The real end-to-end behaviour on each OpenFOAM flavour is left to CI.

## Expected impact on CI

**This makes CI stricter and may turn currently-green jobs red.** Any tutorial
that has been crashing or diverging without producing its expected output — and
without declaring a skip — was previously reported as `PASS` and will now fail.
That is the intent of #384: such failures are real and pre-existing, and were
simply invisible. If a case legitimately cannot run on a given flavour, the fix
is to add the declared skip message in its `Allrun` (recognised by
`solids4Foam::regressionCaseSkipped`), not to restore the inferred skip.

Closes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFtsPKfZb9WoT45M8Qw6nD
