### PR TITLE
[Fix] Centralize GNU sed resolution for macOS portability

### DIFF
--- a/applications/scripts/README.md
+++ b/applications/scripts/README.md
@@ -709,3 +709,45 @@ is simply replaced with:
 number of processors `nProcs`.
 
 In case that `$FOAM_MPI` is set to `msmpi`, `mpirun` is replaced with `msmpi`.
+
+---
+
+## `solids4foam::requireGnuSed()`
+
+The case-format conversion functions, and the `D`/`DD` renaming in
+`solids4Foam::runSolidModel()`, rely on GNU `sed`, in particular on in-place
+editing with `-i` and no backup suffix.
+
+- **Function purpose**
+  Resolves the GNU `sed` command once and stores it in the `SOLIDS4FOAM_SED`
+  variable, which every function that needs GNU `sed` then uses. GNU `sed`
+  exposed as `sed` is preferred, as on Linux and on macOS when the Homebrew
+  `gnubin` directory is first in the `PATH`; otherwise the Homebrew `gsed`
+  command is used. If neither provides GNU `sed`, a clear error is printed and
+  the script exits.
+
+- **Function arguments**
+  None
+
+On macOS, the system `sed` is BSD `sed`, so GNU `sed` must be installed:
+
+```bash
+brew install gnu-sed
+```
+
+This provides `gsed`, which the scripts use automatically. Optionally, the GNU
+versions can be placed first in the `PATH`:
+
+```bash
+echo 'export PATH="$(brew --prefix gnu-sed)/libexec/gnubin:$PATH"' \
+    >> "$HOME/.bash_profile"
+```
+
+The resolution and its callers are covered by the shell tests in
+`applications/scripts/tests/testGnuSedResolution.sh`, which emulate the macOS
+situation with stub commands and require neither macOS nor a build of
+`solids4foam`:
+
+```bash
+./applications/scripts/tests/testGnuSedResolution.sh
+```

--- a/applications/scripts/solids4FoamScripts.sh
+++ b/applications/scripts/solids4FoamScripts.sh
@@ -24,6 +24,13 @@ Darwin)
     ;;
 esac
 
+# Command used for GNU sed specific operations, e.g. in-place editing with
+# "-i" and no backup suffix. It is resolved lazily by
+# solids4Foam::requireGnuSed, but initialised here so that referencing it can
+# never fail under "set -u".
+SOLIDS4FOAM_SED="${SOLIDS4FOAM_SED:-}"
+export SOLIDS4FOAM_SED
+
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
 # Case format
 #
@@ -88,18 +95,46 @@ function solids4Foam::blockMeshDictDir()
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
 # requireGnuSed
-#     Exits if GNU sed is not available, as the conversion functions rely on it
+#     Resolves the GNU sed command once and stores it in SOLIDS4FOAM_SED, which
+#     every function requiring GNU sed then uses.
+#
+#     GNU sed exposed as "sed" is preferred, as is the case on Linux and on
+#     macOS when the Homebrew gnubin directory is first in the PATH; otherwise
+#     the Homebrew "gsed" command is used. Exits with a clear message if neither
+#     provides GNU sed.
+#
+#     The resolution is cached, so the function is cheap to call at the start of
+#     every function that needs GNU sed.
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
 function solids4Foam::requireGnuSed()
 {
-    if sed --version 2>/dev/null | grep -q "GNU sed"
+    # Return immediately if GNU sed has already been resolved
+    if [[ -n "${SOLIDS4FOAM_SED:-}" ]]
     then
-        echo "GNU sed detected"
-    else
-        echo "Error: This script requires GNU sed. Please install it (e.g."
-        echo "via Homebrew: 'brew install gnu-sed') and use 'gsed' instead."
-        exit 1
+        return 0
     fi
+
+    local CANDIDATE
+
+    for CANDIDATE in sed gsed
+    do
+        if command -v "${CANDIDATE}" > /dev/null 2>&1 &&
+            "${CANDIDATE}" --version 2>/dev/null | grep -q "GNU sed"
+        then
+            SOLIDS4FOAM_SED="${CANDIDATE}"
+            export SOLIDS4FOAM_SED
+            echo "GNU sed detected: using '${SOLIDS4FOAM_SED}'"
+            return 0
+        fi
+    done
+
+    echo "Error: This script requires GNU sed, which was not found as 'sed'"
+    echo "or 'gsed'. On macOS, install it with 'brew install gnu-sed' and"
+    echo "either use the resulting 'gsed' command or place the GNU versions"
+    echo "first in the PATH, e.g. by adding"
+    echo "    export PATH=\"\$(brew --prefix gnu-sed)/libexec/gnubin:\$PATH\""
+    echo "to your shell profile."
+    exit 1
 }
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
@@ -233,6 +268,9 @@ function solids4Foam::applyFoamExtendTweaks()
     local FILE
     local DIR
 
+    # Ensure GNU sed is available and resolved into SOLIDS4FOAM_SED
+    solids4Foam::requireGnuSed
+
     # 1. symmetry in OpenFOAM becomes symmetryPlane in foam extend
     #    Patches are given as "symmetry;" in field files, boundary files and
     #    createPatchDict, and as "symmetry <patchName>" in blockMeshDict
@@ -242,8 +280,8 @@ function solids4Foam::applyFoamExtendTweaks()
         if grep -qE "symmetry;|^[[:space:]]*symmetry[[:space:]]" "${FILE}"
         then
             echo "Changing symmetry to symmetryPlane in ${FILE}"
-            sed -i 's|symmetry;|symmetryPlane;|g' "${FILE}"
-            sed -i -E 's|^([[:space:]]*)symmetry([[:space:]]+)|\1symmetryPlane\2|' \
+            "${SOLIDS4FOAM_SED}" -i 's|symmetry;|symmetryPlane;|g' "${FILE}"
+            "${SOLIDS4FOAM_SED}" -i -E 's|^([[:space:]]*)symmetry([[:space:]]+)|\1symmetryPlane\2|' \
                 "${FILE}"
         fi
     done < <(find "${CASE_DIR}" \( -name 'blockMeshDict*' -o -name boundary \
@@ -256,7 +294,7 @@ function solids4Foam::applyFoamExtendTweaks()
             if grep -q "symmetry;" "${FILE}"
             then
                 echo "Changing symmetry to symmetryPlane in ${FILE}"
-                sed -i 's|symmetry;|symmetryPlane;|g' "${FILE}"
+                "${SOLIDS4FOAM_SED}" -i 's|symmetry;|symmetryPlane;|g' "${FILE}"
             fi
         done < <(find "${DIR}" -type f -print0)
     done < <(solids4Foam::fieldDirs "${CASE_DIR}")
@@ -298,7 +336,7 @@ function solids4Foam::applyFoamExtendTweaks()
     then
         echo "Changing RAS to RASModel in turbulenceProperties"
         find "${CASE_DIR}" -name turbulenceProperties \
-            -exec sed -i "s/RAS;/RASModel;/g" {} +
+            -exec "${SOLIDS4FOAM_SED}" -i "s/RAS;/RASModel;/g" {} +
     fi
 
     # 4. Use the foam extend boundaryData, if present
@@ -319,9 +357,9 @@ function solids4Foam::applyFoamExtendTweaks()
     then
         echo "Changing uniformFixedValue to timeVaryingUniformFixedValue in p"
         find "${CASE_DIR}" -name p \
-            -exec sed -i "s|^\([[:space:]]*\)type\(.*\)uniformFixedValue;|\1//type\2uniformFixedValue;|g" {} +
+            -exec "${SOLIDS4FOAM_SED}" -i "s|^\([[:space:]]*\)type\(.*\)uniformFixedValue;|\1//type\2uniformFixedValue;|g" {} +
         find "${CASE_DIR}" -name p \
-            -exec sed -i "s|^\([[:space:]]*\)//type\(.*\)timeVaryingUniformFixedValue;|\1type\2timeVaryingUniformFixedValue;|g" {} +
+            -exec "${SOLIDS4FOAM_SED}" -i "s|^\([[:space:]]*\)//type\(.*\)timeVaryingUniformFixedValue;|\1type\2timeVaryingUniformFixedValue;|g" {} +
     fi
 
     # 7. Use the foam extend changeDictionaryDict, if present
@@ -353,13 +391,13 @@ function solids4Foam::applyFoamExtendTweaks()
     then
         echo "foam extend specific: replacing 'pointCellsLeastSquares' with"
         echo "'leastSquares' in system/fvSchemes"
-        sed -i "s/ pointCellsLeastSquares;/ leastSquares;/g" \
+        "${SOLIDS4FOAM_SED}" -i "s/ pointCellsLeastSquares;/ leastSquares;/g" \
             "${CASE_DIR}"/system/fvSchemes
     elif [[ -f "${CASE_DIR}"/constant/solid/solidProperties ]]
     then
         echo "foam extend specific: replacing 'pointCellsLeastSquares' with"
         echo "'leastSquares' in system/solid/fvSchemes"
-        sed -i "s/ pointCellsLeastSquares;/ leastSquares;/g" \
+        "${SOLIDS4FOAM_SED}" -i "s/ pointCellsLeastSquares;/ leastSquares;/g" \
             "${CASE_DIR}"/system/solid/fvSchemes
     fi
 
@@ -371,8 +409,8 @@ function solids4Foam::applyFoamExtendTweaks()
     for FILE in $(find "${CASE_DIR}" -name plot.gnuplot)
     do
         echo "Updating ${FILE}"
-        sed -i "s@postProcessing/sample/@postProcessing/sets/@g" "${FILE}"
-        sed -i "s@postProcessing/sample.surfaces/@postProcessing/surfaces/@g" "${FILE}"
+        "${SOLIDS4FOAM_SED}" -i "s@postProcessing/sample/@postProcessing/sets/@g" "${FILE}"
+        "${SOLIDS4FOAM_SED}" -i "s@postProcessing/sample.surfaces/@postProcessing/surfaces/@g" "${FILE}"
     done
 
     # 13. foam extend uses basePoint and normalVector in mirrorMeshDict
@@ -383,8 +421,8 @@ function solids4Foam::applyFoamExtendTweaks()
         then
             echo "foam extend specific: replacing 'point' and 'normal' with"
             echo "'basePoint' and 'normalVector' in ${FILE}"
-            sed -i -E 's/^([[:space:]]*)point([[:space:]])/\1basePoint\2/g' "${FILE}"
-            sed -i -E 's/^([[:space:]]*)normal([[:space:]])/\1normalVector\2/g' "${FILE}"
+            "${SOLIDS4FOAM_SED}" -i -E 's/^([[:space:]]*)point([[:space:]])/\1basePoint\2/g' "${FILE}"
+            "${SOLIDS4FOAM_SED}" -i -E 's/^([[:space:]]*)normal([[:space:]])/\1normalVector\2/g' "${FILE}"
         fi
     done
 }
@@ -403,13 +441,16 @@ function solids4Foam::undoFoamExtendTweaks()
     local FILE
     local DIR
 
+    # Ensure GNU sed is available and resolved into SOLIDS4FOAM_SED
+    solids4Foam::requireGnuSed
+
     # 1. symmetryPlane in foam extend becomes symmetry in OpenFOAM
     while IFS= read -r -d '' FILE
     do
         if grep -q "symmetryPlane" "${FILE}"
         then
             echo "Changing symmetryPlane to symmetry in ${FILE}"
-            sed -i 's|symmetryPlane|symmetry|g' "${FILE}"
+            "${SOLIDS4FOAM_SED}" -i 's|symmetryPlane|symmetry|g' "${FILE}"
         fi
     done < <(find "${CASE_DIR}" \( -name 'blockMeshDict*' -o -name boundary \
         -o -name createPatchDict \) -print0)
@@ -421,7 +462,7 @@ function solids4Foam::undoFoamExtendTweaks()
             if grep -q "symmetryPlane;" "${FILE}"
             then
                 echo "Changing symmetryPlane to symmetry in ${FILE}"
-                sed -i 's|symmetryPlane;|symmetry;|g' "${FILE}"
+                "${SOLIDS4FOAM_SED}" -i 's|symmetryPlane;|symmetry;|g' "${FILE}"
             fi
         done < <(find "${DIR}" -type f -print0)
     done < <(solids4Foam::fieldDirs "${CASE_DIR}")
@@ -471,7 +512,7 @@ function solids4Foam::undoFoamExtendTweaks()
     then
         echo "Changing RASModel to RAS in turbulenceProperties"
         find "${CASE_DIR}" -name turbulenceProperties \
-            -exec sed -i "s/RASModel;/RAS;/g" {} +
+            -exec "${SOLIDS4FOAM_SED}" -i "s/RASModel;/RAS;/g" {} +
     fi
 
     # 4. Restore the OpenFOAM boundaryData, if it was replaced
@@ -492,9 +533,9 @@ function solids4Foam::undoFoamExtendTweaks()
     then
         echo "Changing timeVaryingUniformFixedValue to uniformFixedValue in p"
         find "${CASE_DIR}" -name p \
-            -exec sed -i "s|^\([[:space:]]*\)//type\(.*\)uniformFixedValue;|\1type\2uniformFixedValue;|g" {} +
+            -exec "${SOLIDS4FOAM_SED}" -i "s|^\([[:space:]]*\)//type\(.*\)uniformFixedValue;|\1type\2uniformFixedValue;|g" {} +
         find "${CASE_DIR}" -name p \
-            -exec sed -i "s|^\([[:space:]]*\)type\(.*\)timeVaryingUniformFixedValue;|\1//type\2timeVaryingUniformFixedValue;|g" {} +
+            -exec "${SOLIDS4FOAM_SED}" -i "s|^\([[:space:]]*\)type\(.*\)timeVaryingUniformFixedValue;|\1//type\2timeVaryingUniformFixedValue;|g" {} +
     fi
 
     # 7. Restore the OpenFOAM changeDictionaryDict, if it was replaced
@@ -526,13 +567,13 @@ function solids4Foam::undoFoamExtendTweaks()
     then
         echo "OpenFOAM specific: replacing 'leastSquares' with"
         echo "'pointCellsLeastSquares' in system/fvSchemes"
-        sed -i "s/ leastSquares;/ pointCellsLeastSquares;/g" \
+        "${SOLIDS4FOAM_SED}" -i "s/ leastSquares;/ pointCellsLeastSquares;/g" \
             "${CASE_DIR}"/system/fvSchemes
     elif [[ -f "${CASE_DIR}"/constant/solid/solidProperties ]]
     then
         echo "OpenFOAM specific: replacing 'leastSquares' with"
         echo "'pointCellsLeastSquares' in system/solid/fvSchemes"
-        sed -i "s/ leastSquares;/ pointCellsLeastSquares;/g" \
+        "${SOLIDS4FOAM_SED}" -i "s/ leastSquares;/ pointCellsLeastSquares;/g" \
             "${CASE_DIR}"/system/solid/fvSchemes
     fi
 
@@ -544,8 +585,8 @@ function solids4Foam::undoFoamExtendTweaks()
     for FILE in $(find "${CASE_DIR}" -name plot.gnuplot)
     do
         echo "Updating ${FILE}"
-        sed -i "s@postProcessing/sets/@postProcessing/sample/@g" "${FILE}"
-        sed -i "s@postProcessing/surfaces/@postProcessing/sample.surfaces/@g" "${FILE}"
+        "${SOLIDS4FOAM_SED}" -i "s@postProcessing/sets/@postProcessing/sample/@g" "${FILE}"
+        "${SOLIDS4FOAM_SED}" -i "s@postProcessing/surfaces/@postProcessing/sample.surfaces/@g" "${FILE}"
     done
 
     # 13. OpenFOAM uses point and normal in mirrorMeshDict
@@ -556,8 +597,8 @@ function solids4Foam::undoFoamExtendTweaks()
         then
             echo "OpenFOAM specific: replacing 'basePoint' and 'normalVector'"
             echo "with 'point' and 'normal' in ${FILE}"
-            sed -i -E 's/\bbasePoint\b/point/g' "${FILE}"
-            sed -i -E 's/\bnormalVector\b/normal/g' "${FILE}"
+            "${SOLIDS4FOAM_SED}" -i -E 's/\bbasePoint\b/point/g' "${FILE}"
+            "${SOLIDS4FOAM_SED}" -i -E 's/\bnormalVector\b/normal/g' "${FILE}"
         fi
     done
 }
@@ -573,16 +614,19 @@ function solids4Foam::applyOpenFOAMOrgTweaks()
 {
     local CASE_DIR="$1"
 
+    # Ensure GNU sed is available and resolved into SOLIDS4FOAM_SED
+    solids4Foam::requireGnuSed
+
     # 5. OpenFOAM.org renamed the uniform and face sampledSet types
     if [[ -f "${CASE_DIR}"/system/sample ]]
     then
         echo "OpenFOAM.org specific: replacing 'uniform' with 'lineUniform' in"
         echo "system/sample"
-        sed -i "s/type.*uniform;/type lineUniform;/g" "${CASE_DIR}"/system/sample
+        "${SOLIDS4FOAM_SED}" -i "s/type.*uniform;/type lineUniform;/g" "${CASE_DIR}"/system/sample
 
         echo "OpenFOAM.org specific: replacing 'face' with 'lineFace' in"
         echo "system/sample"
-        sed -i "s/type.*face;/type lineFace;/g" "${CASE_DIR}"/system/sample
+        "${SOLIDS4FOAM_SED}" -i "s/type.*face;/type lineFace;/g" "${CASE_DIR}"/system/sample
     fi
 
     # 10. OpenFOAM.org writes forces.dat rather than force.dat
@@ -600,14 +644,17 @@ function solids4Foam::undoOpenFOAMOrgTweaks()
 {
     local CASE_DIR="$1"
 
+    # Ensure GNU sed is available and resolved into SOLIDS4FOAM_SED
+    solids4Foam::requireGnuSed
+
     # 5. OpenFOAM.org renamed the uniform and face sampledSet types
     if [[ -f "${CASE_DIR}"/system/sample ]]
     then
         echo "Replacing 'lineUniform' with 'uniform' in system/sample"
-        sed -i "s/type.*lineUniform;/type uniform;/g" "${CASE_DIR}"/system/sample
+        "${SOLIDS4FOAM_SED}" -i "s/type.*lineUniform;/type uniform;/g" "${CASE_DIR}"/system/sample
 
         echo "Replacing 'lineFace' with 'face' in system/sample"
-        sed -i "s/type.*lineFace;/type face;/g" "${CASE_DIR}"/system/sample
+        "${SOLIDS4FOAM_SED}" -i "s/type.*lineFace;/type face;/g" "${CASE_DIR}"/system/sample
     fi
 
     # 10. OpenFOAM.com writes force.dat rather than forces.dat
@@ -633,16 +680,19 @@ function solids4Foam::useForcesDat()
     local CASE_DIR="$1"
     local FILE
 
+    # Ensure GNU sed is available and resolved into SOLIDS4FOAM_SED
+    solids4Foam::requireGnuSed
+
     # Convert the OpenFOAM.com filename and total-force columns to the
     # foam-extend/OpenFOAM.org filename and pressure-plus-viscous columns
     for FILE in $(find "${CASE_DIR}" -name force.gnuplot)
     do
         echo "Changing force.dat to forces.dat in ${FILE}"
-        sed -i "s|force\.dat|forces.dat|g" "${FILE}"
+        "${SOLIDS4FOAM_SED}" -i "s|force\.dat|forces.dat|g" "${FILE}"
 
         echo "Summing the pressure and viscous forces in ${FILE}"
-        sed -i 's|(\$2)|($2+$5)|g' "${FILE}"
-        sed -i 's|(\$3)|($3+$6)|g' "${FILE}"
+        "${SOLIDS4FOAM_SED}" -i 's|(\$2)|($2+$5)|g' "${FILE}"
+        "${SOLIDS4FOAM_SED}" -i 's|(\$3)|($3+$6)|g' "${FILE}"
     done
 }
 
@@ -651,16 +701,19 @@ function solids4Foam::useForceDat()
     local CASE_DIR="$1"
     local FILE
 
+    # Ensure GNU sed is available and resolved into SOLIDS4FOAM_SED
+    solids4Foam::requireGnuSed
+
     # Reverse useForcesDat: restore the OpenFOAM.com filename and total-force
     # columns from the foam-extend/OpenFOAM.org form
     for FILE in $(find "${CASE_DIR}" -name force.gnuplot)
     do
         echo "Changing forces.dat to force.dat in ${FILE}"
-        sed -i "s|forces\.dat|force.dat|g" "${FILE}"
+        "${SOLIDS4FOAM_SED}" -i "s|forces\.dat|force.dat|g" "${FILE}"
 
         echo "Using the total force in ${FILE}"
-        sed -i 's|(\$2+\$5)|($2)|g' "${FILE}"
-        sed -i 's|(\$3+\$6)|($3)|g' "${FILE}"
+        "${SOLIDS4FOAM_SED}" -i 's|(\$2+\$5)|($2)|g' "${FILE}"
+        "${SOLIDS4FOAM_SED}" -i 's|(\$3+\$6)|($3)|g' "${FILE}"
     done
 }
 
@@ -1057,18 +1110,19 @@ function solids4Foam::runSolidModel()
 
     if [ ! -f "${DICTS_DIR}/0/${DISP}" ]; then
         # The DISP field is not present. Check if we can copy a field that is
-        # present
+        # present; renaming the field requires GNU sed
+        solids4Foam::requireGnuSed
 
         if [ "${DISP}" = "D" ] && [ -f "${CASE_DIR}/0/DD" ]; then
             echo "Renaming ${CASE_DIR}/0/DD to ${CASE_DIR}/0/D"
             \mv "${CASE_DIR}/0/DD" "${CASE_DIR}/0/D"
-            sed -i "s/object.*DD;/object D;/g" "${CASE_DIR}/0/D"
+            "${SOLIDS4FOAM_SED}" -i "s/object.*DD;/object D;/g" "${CASE_DIR}/0/D"
         fi
 
         if [ "${DISP}" = "DD" ] && [ -f "${CASE_DIR}/0/D" ]; then
             echo "Renaming ${CASE_DIR}/0/D to ${CASE_DIR}/0/DD"
             \mv "${CASE_DIR}/0/D" "${CASE_DIR}/0/DD"
-            sed -i "s/object.*D;/object DD;/g" "${CASE_DIR}/0/DD"
+            "${SOLIDS4FOAM_SED}" -i "s/object.*D;/object DD;/g" "${CASE_DIR}/0/DD"
         fi
 
         if [ "${DISP}" != "D" ] && [ "${DISP}" != "DD" ]; then

--- a/applications/scripts/tests/testGnuSedResolution.sh
+++ b/applications/scripts/tests/testGnuSedResolution.sh
@@ -1,0 +1,485 @@
+#!/bin/bash
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
+# Script
+#     testGnuSedResolution.sh
+#
+# Description
+#     Focused shell tests for the centralised GNU sed resolution in
+#     applications/scripts/solids4FoamScripts.sh.
+#
+#     The tests run entirely in a temporary directory and do not require an
+#     OpenFOAM installation, a build of solids4foam, or a macOS machine: the
+#     macOS situation, where the system "sed" is BSD sed and GNU sed is
+#     installed by Homebrew as "gsed", is emulated with stub commands placed
+#     first in the PATH.
+#
+#     Tests:
+#       1. GNU sed exposed as "sed"
+#       2. GNU sed exposed only as "gsed", with a BSD-like "sed" that fails on
+#          in-place editing (the macOS case)
+#       3. A clear error when neither provides GNU sed
+#       4. SOLIDS4FOAM_SED is always set, so "set -u" is safe
+#       5. Both case-format conversion directions, under "set -u", with GNU sed
+#          as "sed" and as "gsed"
+#       6. The D -> DD and DD -> D rename paths in runSolidModel(), under
+#          "set -u", with GNU sed as "sed" and as "gsed"
+#
+# Usage
+#     ./testGnuSedResolution.sh
+#
+# License
+#     GNU Lesser General Public License, version 3.
+#     https://www.gnu.org/licenses/lgpl-3.0.en.html
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
+
+set -u
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS="${TEST_DIR}/../solids4FoamScripts.sh"
+
+if [[ ! -f ${SCRIPTS} ]]
+then
+    echo "Cannot find ${SCRIPTS}"
+    exit 1
+fi
+
+if ! sed --version 2>/dev/null | grep -q "GNU sed"
+then
+    echo "These tests require GNU sed to be available as 'sed' on the test"
+    echo "machine, as it is used to build the 'gsed' stub"
+    exit 1
+fi
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+REAL_SED="$(command -v sed)"
+
+N_PASS=0
+N_FAIL=0
+
+function pass()
+{
+    echo "  PASS: $1"
+    N_PASS=$((N_PASS + 1))
+}
+
+function fail()
+{
+    echo "  FAIL: $1"
+    N_FAIL=$((N_FAIL + 1))
+}
+
+function check()
+{
+    # 1: description, 2: expected, 3: actual
+    if [[ "$2" == "$3" ]]
+    then
+        pass "$1"
+    else
+        fail "$1: expected '$2' but got '$3'"
+    fi
+}
+
+function checkFileContains()
+{
+    # 1: description, 2: file, 3: pattern
+    if [[ -f "$2" ]] && grep -qF -- "$3" "$2"
+    then
+        pass "$1"
+    else
+        fail "$1: '$3' not found in '$2'"
+    fi
+}
+
+function checkFileLacks()
+{
+    # 1: description, 2: file, 3: pattern
+    if [[ -f "$2" ]] && ! grep -qF -- "$3" "$2"
+    then
+        pass "$1"
+    else
+        fail "$1: '$3' unexpectedly found in '$2'"
+    fi
+}
+
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
+# Stub PATHs
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
+
+# macOS-like: "sed" is BSD sed, which does not understand "--version" and
+# rejects "-i" without a backup suffix; GNU sed is available as "gsed"
+MACOS_STUB="${WORK_DIR}/stubs-macos"
+mkdir -p "${MACOS_STUB}"
+
+cat > "${MACOS_STUB}/sed" <<EOF
+#!/bin/bash
+# BSD-like sed stub: no --version, and "-i" requires a backup suffix
+for arg in "\$@"
+do
+    if [[ \${arg} == "--version" ]]
+    then
+        echo "sed: illegal option -- -" 1>&2
+        exit 1
+    fi
+    if [[ \${arg} == "-i" ]]
+    then
+        echo "sed: -i may not be used without a backup suffix" 1>&2
+        exit 1
+    fi
+done
+exec "${REAL_SED}" "\$@"
+EOF
+chmod +x "${MACOS_STUB}/sed"
+
+cat > "${MACOS_STUB}/gsed" <<EOF
+#!/bin/bash
+exec "${REAL_SED}" "\$@"
+EOF
+chmod +x "${MACOS_STUB}/gsed"
+
+# No GNU sed at all: both "sed" and "gsed" are BSD-like
+NOGNU_STUB="${WORK_DIR}/stubs-nognu"
+mkdir -p "${NOGNU_STUB}"
+\cp "${MACOS_STUB}/sed" "${NOGNU_STUB}/sed"
+\cp "${MACOS_STUB}/sed" "${NOGNU_STUB}/gsed"
+
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
+# Fixture case
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
+
+function makeCase()
+{
+    # 1: case directory to create
+    local DIR="$1"
+
+    mkdir -p "${DIR}"/0 "${DIR}"/system "${DIR}"/constant/polyMesh
+
+    cat > "${DIR}"/0/D <<'EOF'
+FoamFile { version 2.0; format ascii; class volVectorField; object D; }
+boundaryField
+{
+    front { type symmetry; }
+}
+EOF
+
+    cat > "${DIR}"/constant/polyMesh/boundary <<'EOF'
+(
+    front { type symmetry; }
+)
+EOF
+
+    cat > "${DIR}"/system/blockMeshDict <<'EOF'
+boundary
+(
+    symmetry front ((0 1 2 3));
+);
+EOF
+
+    echo "solidModel linearGeometryTotalDisplacement;" \
+        > "${DIR}"/constant/solidProperties
+
+    cat > "${DIR}"/system/fvSchemes <<'EOF'
+gradSchemes
+{
+    default extendedLeastSquares 0;
+    grad(D) pointCellsLeastSquares;
+}
+EOF
+
+    cat > "${DIR}"/system/mirrorMeshDict <<'EOF'
+planeType pointAndNormal;
+pointAndNormalDict
+{
+    point (0 0 0);
+    normal (0 1 0);
+}
+EOF
+
+    cat > "${DIR}"/force.gnuplot <<'EOF'
+plot "postProcessing/sample/0/force.dat" u 1:($2) w l, "" u 1:($3) w l
+EOF
+
+    cat > "${DIR}"/plot.gnuplot <<'EOF'
+plot "postProcessing/sample/0/data.xy", "postProcessing/sample.surfaces/x.raw"
+EOF
+}
+
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
+# solidModelDicts fixture, for runSolidModel
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
+
+function makeDicts()
+{
+    # 1: parent directory, 2: model name, 3: displacement name
+    local PARENT="$1"
+    local MODEL="$2"
+    local DISP="$3"
+    local DICTS="${PARENT}/solidModelDicts/${MODEL}"
+
+    mkdir -p "${DICTS}"
+    echo "solidModel ${MODEL};" > "${DICTS}"/solidProperties
+    echo "solvers {}" > "${DICTS}"/fvSolution
+    echo "gradSchemes {}" > "${DICTS}"/fvSchemes
+    echo "${DISP}" > "${DICTS}"/displacementName
+}
+
+# A copy of solids4FoamScripts.sh whose DICTS_PARENT_DIR points at the fixture
+function scriptsWithDicts()
+{
+    # 1: dicts parent dir, 2: output script path
+    "${REAL_SED}" \
+        "s|^    DICTS_PARENT_DIR=.*|    DICTS_PARENT_DIR=$1|" \
+        "${SCRIPTS}" > "$2"
+}
+
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
+# Tests 1 to 4: resolution of the GNU sed command
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
+
+echo "Test 1: GNU sed exposed as 'sed'"
+RESULT=$(
+    set -u
+    unset SOLIDS4FOAM_SED
+    # shellcheck disable=SC1090
+    source "${SCRIPTS}"
+    solids4Foam::requireGnuSed > /dev/null
+    echo "${SOLIDS4FOAM_SED}"
+)
+check "SOLIDS4FOAM_SED resolves to sed" "sed" "${RESULT}"
+
+echo "Test 2: GNU sed exposed only as 'gsed' (macOS-like)"
+RESULT=$(
+    set -u
+    unset SOLIDS4FOAM_SED
+    export PATH="${MACOS_STUB}:${PATH}"
+    # shellcheck disable=SC1090
+    source "${SCRIPTS}"
+    solids4Foam::requireGnuSed > /dev/null
+    echo "${SOLIDS4FOAM_SED}"
+)
+check "SOLIDS4FOAM_SED resolves to gsed" "gsed" "${RESULT}"
+
+echo "Test 3: neither 'sed' nor 'gsed' provides GNU sed"
+OUTPUT=$(
+    set -u
+    unset SOLIDS4FOAM_SED
+    export PATH="${NOGNU_STUB}:${PATH}"
+    # shellcheck disable=SC1090
+    source "${SCRIPTS}"
+    solids4Foam::requireGnuSed
+    echo "SHOULD-NOT-REACH-HERE"
+) && STATUS=0 || STATUS=$?
+check "requireGnuSed exits with status 1" "1" "${STATUS}"
+if echo "${OUTPUT}" | grep -q "requires GNU sed" &&
+    echo "${OUTPUT}" | grep -q "brew install gnu-sed" &&
+    ! echo "${OUTPUT}" | grep -q "SHOULD-NOT-REACH-HERE"
+then
+    pass "requireGnuSed prints a clear installation message"
+else
+    fail "requireGnuSed error message: ${OUTPUT}"
+fi
+
+echo "Test 4: SOLIDS4FOAM_SED is set on sourcing, so 'set -u' is safe"
+RESULT=$(
+    set -u
+    unset SOLIDS4FOAM_SED
+    # shellcheck disable=SC1090
+    source "${SCRIPTS}"
+    echo "unset-safe:[${SOLIDS4FOAM_SED}]"
+) && STATUS=0 || STATUS=$?
+check "sourcing under set -u succeeds" "0" "${STATUS}"
+check "SOLIDS4FOAM_SED is empty but set" "unset-safe:[]" "${RESULT}"
+
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
+# Tests 5 and 6: both conversion directions, GNU sed as 'sed' and as 'gsed'
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
+
+function testConversion()
+{
+    # 1: label, 2: extra PATH prefix (may be empty), 3: expected sed command
+    local LABEL="$1"
+    local PATH_PREFIX="$2"
+    local EXPECTED_SED="$3"
+
+    local CASE_DIR="${WORK_DIR}/case-${LABEL}"
+    local LOG="${WORK_DIR}/log-${LABEL}"
+    local PRISTINE="${WORK_DIR}/pristine-${LABEL}"
+    local STATUS
+
+    makeCase "${CASE_DIR}"
+    \cp -r "${CASE_DIR}" "${PRISTINE}"
+
+    # Convert to the foam extend format and back, under 'set -u'
+    (
+        set -u
+        unset SOLIDS4FOAM_SED
+        if [[ -n ${PATH_PREFIX} ]]
+        then
+            export PATH="${PATH_PREFIX}:${PATH}"
+        fi
+        export WM_PROJECT="foam"
+        export WM_PROJECT_VERSION="4.1"
+        # shellcheck disable=SC1090
+        source "${SCRIPTS}"
+
+        solids4Foam::convertCaseFormat "${CASE_DIR}"
+
+        echo "RESOLVED_SED=${SOLIDS4FOAM_SED}"
+
+        # Check the forward conversion before restoring
+        grep -q "symmetryPlane;" "${CASE_DIR}/0/D" ||
+            { echo "FORWARD-FAIL: 0/D"; exit 1; }
+        grep -q "symmetryPlane front" \
+            "${CASE_DIR}/constant/polyMesh/blockMeshDict" ||
+            { echo "FORWARD-FAIL: blockMeshDict"; exit 1; }
+        grep -q " leastSquares;" "${CASE_DIR}/system/fvSchemes" ||
+            { echo "FORWARD-FAIL: fvSchemes"; exit 1; }
+        grep -q "basePoint" "${CASE_DIR}/system/mirrorMeshDict" ||
+            { echo "FORWARD-FAIL: mirrorMeshDict basePoint"; exit 1; }
+        grep -q "normalVector" "${CASE_DIR}/system/mirrorMeshDict" ||
+            { echo "FORWARD-FAIL: mirrorMeshDict normalVector"; exit 1; }
+        grep -q "forces.dat" "${CASE_DIR}/force.gnuplot" ||
+            { echo "FORWARD-FAIL: force.gnuplot"; exit 1; }
+        grep -q 'postProcessing/sets/' "${CASE_DIR}/plot.gnuplot" ||
+            { echo "FORWARD-FAIL: plot.gnuplot"; exit 1; }
+        echo "FORWARD-OK"
+
+        solids4Foam::restoreCaseFormat "${CASE_DIR}"
+        echo "RESTORE-DONE"
+    ) > "${LOG}" 2>&1 && STATUS=0 || STATUS=$?
+
+    check "${LABEL}: conversion round trip exits cleanly" "0" "${STATUS}"
+    check "${LABEL}: uses '${EXPECTED_SED}'" \
+        "RESOLVED_SED=${EXPECTED_SED}" \
+        "$(grep '^RESOLVED_SED=' "${LOG}" || true)"
+    check "${LABEL}: forward conversion (com -> foam extend)" \
+        "FORWARD-OK" "$(grep '^FORWARD-OK' "${LOG}" || true)"
+
+    # Reverse conversion: the case should be back in the stored format
+    checkFileContains "${LABEL}: reverse conversion restores symmetry in 0/D" \
+        "${CASE_DIR}/0/D" "symmetry;"
+    checkFileLacks "${LABEL}: no symmetryPlane remains in 0/D" \
+        "${CASE_DIR}/0/D" "symmetryPlane"
+    checkFileContains "${LABEL}: reverse conversion restores fvSchemes" \
+        "${CASE_DIR}/system/fvSchemes" "pointCellsLeastSquares;"
+    checkFileContains "${LABEL}: reverse conversion restores mirrorMeshDict" \
+        "${CASE_DIR}/system/mirrorMeshDict" "    point ("
+    checkFileLacks "${LABEL}: no basePoint remains in mirrorMeshDict" \
+        "${CASE_DIR}/system/mirrorMeshDict" "basePoint"
+    checkFileContains "${LABEL}: reverse conversion restores force.gnuplot" \
+        "${CASE_DIR}/force.gnuplot" "force.dat"
+    checkFileContains "${LABEL}: reverse conversion restores plot.gnuplot" \
+        "${CASE_DIR}/plot.gnuplot" "postProcessing/sample/"
+
+    if diff -r "${PRISTINE}/0" "${CASE_DIR}/0" > /dev/null 2>&1 &&
+        diff "${PRISTINE}/system/fvSchemes" "${CASE_DIR}/system/fvSchemes" \
+            > /dev/null 2>&1 &&
+        diff "${PRISTINE}/system/mirrorMeshDict" \
+            "${CASE_DIR}/system/mirrorMeshDict" > /dev/null 2>&1 &&
+        diff "${PRISTINE}/force.gnuplot" "${CASE_DIR}/force.gnuplot" \
+            > /dev/null 2>&1 &&
+        diff "${PRISTINE}/plot.gnuplot" "${CASE_DIR}/plot.gnuplot" \
+            > /dev/null 2>&1
+    then
+        pass "${LABEL}: round trip is lossless for the edited files"
+    else
+        fail "${LABEL}: round trip changed the edited files"
+    fi
+}
+
+echo "Test 5: case-format conversion, GNU sed as 'sed'"
+testConversion "sed" "" "sed"
+
+echo "Test 6: case-format conversion, GNU sed as 'gsed' (macOS-like)"
+testConversion "gsed" "${MACOS_STUB}" "gsed"
+
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
+# Tests 7 to 10: the D/DD rename paths in runSolidModel
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
+
+function testRunSolidModel()
+{
+    # 1: label, 2: PATH prefix, 3: expected sed, 4: field present, 5: wanted
+    local LABEL="$1"
+    local PATH_PREFIX="$2"
+    local EXPECTED_SED="$3"
+    local HAVE="$4"
+    local WANT="$5"
+
+    local BASE="${WORK_DIR}/rsm-${LABEL}"
+    local CASE_DIR="${BASE}/case"
+    local LOG="${WORK_DIR}/log-rsm-${LABEL}"
+    local STATUS
+
+    mkdir -p "${CASE_DIR}/0" "${CASE_DIR}/constant" "${CASE_DIR}/system"
+    makeDicts "${BASE}" "testModel" "${WANT}"
+    scriptsWithDicts "${BASE}" "${BASE}/solids4FoamScripts.sh"
+
+    cat > "${CASE_DIR}/0/${HAVE}" <<EOF
+FoamFile
+{
+    class volVectorField;
+    object ${HAVE};
+}
+internalField uniform (0 0 0);
+EOF
+
+    # Stub Allrun, so that no OpenFOAM solver is run
+    echo '#!/bin/bash' > "${CASE_DIR}/Allrun"
+    echo 'echo "stub Allrun"' >> "${CASE_DIR}/Allrun"
+    chmod +x "${CASE_DIR}/Allrun"
+
+    (
+        set -u
+        unset SOLIDS4FOAM_SED
+        if [[ -n ${PATH_PREFIX} ]]
+        then
+            export PATH="${PATH_PREFIX}:${PATH}"
+        fi
+        cd "${CASE_DIR}" || exit 1
+        # shellcheck disable=SC1090
+        source "${BASE}/solids4FoamScripts.sh"
+        solids4Foam::runSolidModel "${CASE_DIR}" testModel
+        echo "RESOLVED_SED=${SOLIDS4FOAM_SED}"
+    ) > "${LOG}" 2>&1 && STATUS=0 || STATUS=$?
+
+    check "${LABEL}: runSolidModel exits cleanly under set -u" "0" "${STATUS}"
+    check "${LABEL}: uses '${EXPECTED_SED}'" \
+        "RESOLVED_SED=${EXPECTED_SED}" \
+        "$(grep '^RESOLVED_SED=' "${LOG}" || true)"
+
+    if [[ -f "${CASE_DIR}/0/${WANT}" && ! -f "${CASE_DIR}/0/${HAVE}" ]]
+    then
+        pass "${LABEL}: 0/${HAVE} renamed to 0/${WANT}"
+    else
+        fail "${LABEL}: 0/${HAVE} was not renamed to 0/${WANT}"
+    fi
+
+    checkFileContains "${LABEL}: object entry updated to ${WANT}" \
+        "${CASE_DIR}/0/${WANT}" "object ${WANT};"
+}
+
+echo "Test 7: runSolidModel DD -> D rename, GNU sed as 'sed'"
+testRunSolidModel "DD-to-D-sed" "" "sed" "DD" "D"
+
+echo "Test 8: runSolidModel D -> DD rename, GNU sed as 'sed'"
+testRunSolidModel "D-to-DD-sed" "" "sed" "D" "DD"
+
+echo "Test 9: runSolidModel DD -> D rename, GNU sed as 'gsed' (macOS-like)"
+testRunSolidModel "DD-to-D-gsed" "${MACOS_STUB}" "gsed" "DD" "D"
+
+echo "Test 10: runSolidModel D -> DD rename, GNU sed as 'gsed' (macOS-like)"
+testRunSolidModel "D-to-DD-gsed" "${MACOS_STUB}" "gsed" "D" "DD"
+
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
+
+echo
+echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+echo "| ${N_PASS} passed, ${N_FAIL} failed"
+echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+
+if [[ ${N_FAIL} -ne 0 ]]
+then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

The case-format conversion functions and the `D`/`DD` renaming in
`solids4Foam::runSolidModel()` rely on GNU `sed`, in particular on in-place
editing with `-i` and no backup suffix, which BSD `sed` on macOS does not
support. Previously `solids4Foam::requireGnuSed()` only asserted that `sed` was
GNU `sed`, and every caller then invoked `sed` directly, so a macOS user with
GNU `sed` installed by Homebrew as `gsed` had no working path.

This PR centralises the resolution, as requested in #322:

- `solids4Foam::requireGnuSed()` now resolves the GNU `sed` command once and
  caches it in `SOLIDS4FOAM_SED`. GNU `sed` exposed as `sed` is preferred
  (Linux, and macOS with the Homebrew `gnubin` directory first in the `PATH`);
  otherwise Homebrew's `gsed` is used; if neither is GNU `sed`, a clear
  installation message is printed and the script exits with status 1.
- `SOLIDS4FOAM_SED` is initialised at the top of the script
  (`SOLIDS4FOAM_SED="${SOLIDS4FOAM_SED:-}"`), so referencing it can never fail
  under `set -u`.
- Every in-place `sed` call now uses `"${SOLIDS4FOAM_SED}"` (35 call sites,
  including the `find -exec` ones), and every function that needs GNU `sed`
  calls `solids4Foam::requireGnuSed` first:
  `applyFoamExtendTweaks`, `undoFoamExtendTweaks`, `applyOpenFOAMOrgTweaks`,
  `undoOpenFOAMOrgTweaks`, `useForcesDat`, `useForceDat`, and `runSolidModel`
  (resolved immediately before the `D`/`DD` rename, which is the only part of
  that function needing GNU `sed`). `convertCaseFormat()` and
  `restoreCaseFormat()` keep their existing calls.
  The one remaining bare `sed` is the portable `sed 's/;//g'` in
  `getNumberOfProcessors()`, which works with BSD `sed` and is deliberately
  left alone.
- The resolution is cached, so the repeated calls print `GNU sed detected` only
  once per shell.
- New shell tests in `applications/scripts/tests/testGnuSedResolution.sh`.
- `applications/scripts/README.md` documents the function, the macOS
  requirement (`brew install gnu-sed`) and how to run the tests.

Linux behaviour is unchanged: `sed` is GNU `sed` there and is still what gets
used.

## Acceptance criteria

| Criterion from #322 | Where |
| --- | --- |
| One shared GNU sed resolver | `solids4Foam::requireGnuSed()`, storing `SOLIDS4FOAM_SED` |
| Prefer GNU `sed`, fall back to `gsed` | `for CANDIDATE in sed gsed` loop |
| Clear error if neither exists | error message naming `brew install gnu-sed` and the `gnubin` `PATH` option; `exit 1` |
| Used in both conversion functions, `runSolidModel()`, and every other function needing GNU sed | all 35 in-place `sed` call sites; 7 functions now call the resolver |
| Focused shell tests, GNU sed as both `sed` and `gsed` | tests 1, 2, 5, 6, 9, 10 |
| Tests exercise both conversion directions | test 5 (`sed`) and test 6 (`gsed`): forward `com -> foam-extend` assertions plus reverse assertions and a lossless round-trip check |
| Tests exercise the `D`/`DD` rename paths in `runSolidModel()` | tests 7-10: `DD -> D` and `D -> DD`, each with `sed` and with `gsed` |
| No unset-variable failure under `set -u` | every test body runs `set -u` with `SOLIDS4FOAM_SED` unset; test 4 asserts sourcing under `set -u` leaves the variable set-but-empty |
| Existing Linux behaviour unchanged | tests 1, 5, 7, 8 run with the unmodified `PATH`, where `sed` is GNU sed |

## Tests

The tests are pure shell and touch no OpenFOAM build. Since the repository had
no existing test directory, they live in a new `applications/scripts/tests/`
directory next to the script they cover.

The macOS situation is emulated with stub commands placed first in the `PATH`:
a BSD-like `sed` that rejects `--version` and rejects `-i` without a backup
suffix, alongside a `gsed` that is real GNU sed. A second stub directory
provides BSD-like versions of both `sed` and `gsed` for the error case.

```console
$ ./applications/scripts/tests/testGnuSedResolution.sh
Test 1: GNU sed exposed as 'sed'
  PASS: SOLIDS4FOAM_SED resolves to sed
Test 2: GNU sed exposed only as 'gsed' (macOS-like)
  PASS: SOLIDS4FOAM_SED resolves to gsed
Test 3: neither 'sed' nor 'gsed' provides GNU sed
  PASS: requireGnuSed exits with status 1
  PASS: requireGnuSed prints a clear installation message
Test 4: SOLIDS4FOAM_SED is set on sourcing, so 'set -u' is safe
  PASS: sourcing under set -u succeeds
  PASS: SOLIDS4FOAM_SED is empty but set
Test 5: case-format conversion, GNU sed as 'sed'
  PASS: sed: conversion round trip exits cleanly
  PASS: sed: uses 'sed'
  PASS: sed: forward conversion (com -> foam extend)
  PASS: sed: reverse conversion restores symmetry in 0/D
  PASS: sed: no symmetryPlane remains in 0/D
  PASS: sed: reverse conversion restores fvSchemes
  PASS: sed: reverse conversion restores mirrorMeshDict
  PASS: sed: no basePoint remains in mirrorMeshDict
  PASS: sed: reverse conversion restores force.gnuplot
  PASS: sed: reverse conversion restores plot.gnuplot
  PASS: sed: round trip is lossless for the edited files
Test 6: case-format conversion, GNU sed as 'gsed' (macOS-like)
  PASS: gsed: conversion round trip exits cleanly
  PASS: gsed: uses 'gsed'
  PASS: gsed: forward conversion (com -> foam extend)
  PASS: gsed: reverse conversion restores symmetry in 0/D
  PASS: gsed: no symmetryPlane remains in 0/D
  PASS: gsed: reverse conversion restores fvSchemes
  PASS: gsed: reverse conversion restores mirrorMeshDict
  PASS: gsed: no basePoint remains in mirrorMeshDict
  PASS: gsed: reverse conversion restores force.gnuplot
  PASS: gsed: reverse conversion restores plot.gnuplot
  PASS: gsed: round trip is lossless for the edited files
Test 7: runSolidModel DD -> D rename, GNU sed as 'sed'
  PASS: DD-to-D-sed: runSolidModel exits cleanly under set -u
  PASS: DD-to-D-sed: uses 'sed'
  PASS: DD-to-D-sed: 0/DD renamed to 0/D
  PASS: DD-to-D-sed: object entry updated to D
Test 8: runSolidModel D -> DD rename, GNU sed as 'sed'
  PASS: D-to-DD-sed: runSolidModel exits cleanly under set -u
  PASS: D-to-DD-sed: uses 'sed'
  PASS: D-to-DD-sed: 0/D renamed to 0/DD
  PASS: D-to-DD-sed: object entry updated to DD
Test 9: runSolidModel DD -> D rename, GNU sed as 'gsed' (macOS-like)
  PASS: DD-to-D-gsed: runSolidModel exits cleanly under set -u
  PASS: DD-to-D-gsed: uses 'gsed'
  PASS: DD-to-D-gsed: 0/DD renamed to 0/D
  PASS: DD-to-D-gsed: object entry updated to D
Test 10: runSolidModel D -> DD rename, GNU sed as 'gsed' (macOS-like)
  PASS: D-to-DD-gsed: runSolidModel exits cleanly under set -u
  PASS: D-to-DD-gsed: uses 'gsed'
  PASS: D-to-DD-gsed: 0/D renamed to 0/DD
  PASS: D-to-DD-gsed: object entry updated to DD

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
| 44 passed, 0 failed
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

## Verification done

- `bash -n` on both scripts.
- The 44 assertions above, on Linux with GNU sed 4.x, all passing.
- The `runSolidModel()` tests run the real function against a temporary
  `solidModelDicts` fixture (`DICTS_PARENT_DIR` redirected in a copy of the
  script, as `Allwmake` does at install time) with a stub `Allrun`, so the
  actual rename and `object` substitution are exercised, not a reimplementation.

## Verification not done

- **No macOS machine was available**, so the `gsed` path is exercised through a
  PATH stub that emulates BSD `sed` (no `--version`, `-i` requires a backup
  suffix) rather than against real BSD `sed`. Running an actual tutorial on
  macOS with Homebrew `gnu-sed` installed would be a useful confirmation.
- No compilation or tutorial runs: this PR touches only shell scripts and
  documentation.
- `shellcheck` was not available on the machine used, so the script was not
  re-linted; the changes preserve the existing quoting style.

## Notes for reviewers

The diff is deliberately restricted to sed resolution, to merge cleanly
alongside the other in-flight PRs touching `solids4FoamScripts.sh` (#318, #319,
#384). Most of the changed lines are the mechanical `sed -i` ->
`"${SOLIDS4FOAM_SED}" -i` substitution.

`SOLIDS4FOAM_SED` is exported so that the resolution is inherited by child
scripts that re-source `solids4FoamScripts.sh`; a user who deliberately sets it
in their environment overrides the detection.

Closes #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFtsPKfZb9WoT45M8Qw6nD
