### PR TITLE
[Fix] rotatingBlock/Allclean: drop the stale blockMeshDict stash lines

### DIFF
--- a/tutorials/solids/hyperelasticity/rigidRotation/rotatingBlock/Allclean
+++ b/tutorials/solids/hyperelasticity/rigidRotation/rotatingBlock/Allclean
@@ -6,14 +6,7 @@
 # Source solids4Foam scripts
 source solids4FoamScripts.sh
 
-# In OpenFOAM.org, cleanCase removes constant/polyMesh entirely, which would
-# delete the blockMeshDict stored there in this case and leave the case unable
-# to re-run. Stash the blockMeshDict and restore it after cleanCase, as is done
-# in the cooksMembrane tutorial.
-[ -f constant/polyMesh/blockMeshDict ] && cp constant/polyMesh/blockMeshDict system/
 cleanCase
-[ -f system/blockMeshDict ] && mkdir -p constant/polyMesh \
-    && mv system/blockMeshDict constant/polyMesh/
 
 \rm -rf constant/polyMesh/sets constant/polyMesh/*Zones*
 \rm -rf VTK case.foam postProcessing 0/DD


### PR DESCRIPTION
Scope reduced after review: this PR previously added a general
`solids4Foam::cleanCasePreservingBlockMeshDict` helper. That was dropped as
unnecessary — see below — and only the `rotatingBlock/Allclean` cleanup remains.

## The premise of #319 has expired

#319 lists 11 tutorials that store `blockMeshDict` at
`constant/polyMesh/blockMeshDict` and lose it to OpenFOAM.org's `cleanCase`.
PR #303 (`db3a989f`, *Store tutorial cases in the OpenFOAM.com format*, merged
2026-08-04, four days after #319 was filed) relocated every tutorial
`blockMeshDict` to `system/`:

```console
$ git ls-tree -r --name-only origin/development tutorials | grep -c 'constant/polyMesh/blockMeshDict'
0
```

So none of the listed tutorials is still affected, and no preservation helper is
needed:

- only OpenFOAM.org's `cleanCase` removes `constant/polyMesh` wholesale, and on
  .org `solids4Foam::blockMeshDictDir` places the dictionary in `system/`, so it
  is never in the directory that gets removed;
- foam-extend-4.1's `cleanCase` removes named files under `constant/polyMesh`
  (`owner*`, `face*`, `point*`, `sets/`, …) and leaves `blockMeshDict` alone;
- OpenFOAM.com's `cleanCase` calls `cleanPolyMesh`, which preserves it.

## What this PR does fix

`rotatingBlock/Allclean` still carries the stash lines from `c432c039`, written
for the pre-#303 layout:

```bash
[ -f constant/polyMesh/blockMeshDict ] && cp constant/polyMesh/blockMeshDict system/
cleanCase
[ -f system/blockMeshDict ] && mkdir -p constant/polyMesh \
    && mv system/blockMeshDict constant/polyMesh/
```

The first line is now a no-op. The third fires unconditionally and `mv`s the
**tracked** `system/blockMeshDict` into `constant/polyMesh`. That is undone by
`solids4Foam::restoreCaseFormat` at the end of the script, so there is no net
damage today — but an unconditional `mv` of a version-controlled file that
depends on a later function to put it back is a trap for the next person to edit
this script.

The three lines are replaced with a plain `cleanCase`.

## Verification

Ran `./Allclean` on a copy of the case with OpenFOAM v2512: exit 0,
`system/blockMeshDict` unchanged, and the log no longer contains the
`Moving ./constant/polyMesh/blockMeshDict to ./system` round-trip it showed
before. No `wmake`, no solver run.

The matching `Allclean` files under `regressionTests/` carry the same lines but
are untracked generated artefacts, so they are not touched here.

## On #319 itself

This does not deliver what #319 asked for, because what it asked for is no
longer needed. Suggest closing #319 as obsolete rather than treating this as its
fix — hence no `Closes` keyword.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFtsPKfZb9WoT45M8Qw6nD