### PR TITLE
[Fix] weakCouplingInterface: update elasticWallPressure history fields

### DIFF
--- a/src/solids4FoamModels/fluidSolidInterfaces/weakCouplingInterface/weakCouplingInterface.C
+++ b/src/solids4FoamModels/fluidSolidInterfaces/weakCouplingInterface/weakCouplingInterface.C
@@ -108,6 +108,9 @@ void weakCouplingInterface::updateWeakDisplacement()
     // Update movingWallPressure boundary conditions, if found
     fluidSolidInterface::updateMovingWallPressureAcceleration();
 
+    // Update elasticWallPressure boundary conditions, if found
+    fluidSolidInterface::updateElasticWallPressureAcceleration();
+
     // Make sure that displacement on all processors is equal to one
     // calculated on master processor
     fluidSolidInterface::syncFluidZonePointsDispl(fluidZonesPointsDispls());

--- a/tutorials/fluidSolidInteraction/3dTube/Allrun
+++ b/tutorials/fluidSolidInteraction/3dTube/Allrun
@@ -10,6 +10,7 @@ source solids4FoamScripts.sh
 # ./Allrun # default behaviour is Robin-Neumann coupling
 # ./Allrun dirichletNeumann
 # ./Allrun sonicLiquidFluid
+# ./Allrun weakCoupling
 
 # This case requires PETSc to be installed
 solids4Foam::requirePetscOrExitSilently
@@ -22,6 +23,15 @@ if [[ "$1" == "sonicLiquidFluid" ]]; then
     do
         ln -vnsf ${file##*/} ${file%.*}
     done
+elif [[ "$1" == "weakCoupling" ]]; then
+    # Weak (explicit) coupling, with the Robin-Neumann fluid setup
+    echo "Using the weak coupling approach"
+    for file in $(find ./0 ./constant ./system -name '*.robin')
+    do
+        ln -vnsf ${file##*/} ${file%.*}
+    done
+    # Override the interface with the weak coupling variant
+    ln -vnsf fsiProperties.weakCoupling constant/fsiProperties
 elif [[ "$1" == "dirichletNeumann" ]]; then
     # Dirichlet-Neumann pimpleFluid approach
     echo "Using the Dirichlet-Neumann pimpleFluid approach"

--- a/tutorials/fluidSolidInteraction/3dTube/README.md
+++ b/tutorials/fluidSolidInteraction/3dTube/README.md
@@ -82,7 +82,7 @@ convergence, for example, see
 effects in strongly coupled fluid–solid interaction problems,” Engineering with
 Computers, 2019, doi: 10.1007/s00366-019-00880-4.](https://doi.org/10.1007/s00366-019-00880-4).
 
-In this tutorial, we will compare six variants of the approaches above:
+In this tutorial, we will compare seven variants of the approaches above:
 
 1. **Dirichlet-Neumann formulation with Aitken's acceleration and an
    incompressible fluid model**: We use the `pimpleFluid` fluid model.
@@ -105,6 +105,13 @@ In this tutorial, we will compare six variants of the approaches above:
    solids4foam's `pimpleFluid` fluid model). Due to implementation differences,
    this preCICE IQNILS approach may perform differently than the built-in
    solids4foam approach.
+
+7. **Robin-Neumann formulation with weak (explicit) coupling**: The fluid setup
+   is the same as approach 5, but the interface is advanced once per time-step
+   with no outer iterations, using the `weakCoupling` interface. Weak coupling
+   is not expected to reproduce the strongly coupled result on this case; the
+   variant is included so that the `weakCoupling` code path is exercised with a
+   Robin pressure condition.
 
 In all approaches, the solid domain setup is the same, where an
 incremental small strain formulation is used (the `linearGeometry` solid model).
@@ -134,6 +141,7 @@ The tutorial case can be run using the included `Allrun` script, i.e.
 # ./Allrun # default behaviour is Robin-Neumann coupling
 # ./Allrun dirichletNeumann
 # ./Allrun sonicLiquidFluid
+# ./Allrun weakCoupling
 
 # Select approach
 if [[ "$1" == "sonicLiquidFluid" ]]; then
@@ -205,7 +213,10 @@ As can be seen above, the `Allrun` script can be run with different values for
  weakly compressible fluid model (approaches 3 and 4) can be used by running the
  `Allrun` script with the argument `sonicLiquidFluid`, i.e. `./Allrun sonicLiquidFluid`.
  Once again, switching between approach 3 (Aitken's) and 4 (IQNILS) is controlled
- via the `fluidSolidInterface` setting in `constant/fsiProperties`.
+ via the `fluidSolidInterface` setting in `constant/fsiProperties`. Weak
+ coupling (approach 7) is selected with `./Allrun weakCoupling`, which uses the
+ same Robin-Neumann fluid setup as approach 5 but overrides
+ `constant/fsiProperties` with `constant/fsiProperties.weakCoupling`.
  Examining the `U` and `p` files in `0/fluid.robin/` shows that the Robin
  approach uses the custom conditions `elasticWallVelocity` and `elasticWallPressure`
  at the interface.

--- a/tutorials/fluidSolidInteraction/3dTube/constant/fsiProperties.weakCoupling
+++ b/tutorials/fluidSolidInteraction/3dTube/constant/fsiProperties.weakCoupling
@@ -1,0 +1,46 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| solids4foam: solid mechanics and fluid-solid interaction simulations        |
+| Version:     v2.4                                                           |
+| Web:         https://solids4foam.github.io                                  |
+| Disclaimer:  This offering is not approved or endorsed by OpenCFD Limited,  |
+|              producer and distributor of the OpenFOAM software via          |
+|              www.openfoam.com, and owner of the OPENFOAM® and OpenCFD®      |
+|              trade marks.                                                   |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    object      fsiProperties;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+// Weak (explicit) coupling: the interface is advanced once per time-step with
+// no outer iterations. This variant uses the same Robin-Neumann fluid setup as
+// the default approach, i.e. an elasticWallPressure condition on the fluid
+// wall patch, so it exercises the Robin pressure boundary under weak coupling.
+//
+// Weak coupling is not expected to match the strongly coupled result: it is
+// here to cover the weakCoupling code path, which is otherwise untested.
+
+fluidSolidInterface    weakCoupling;
+
+weakCouplingCoeffs
+{
+    solidPatch          inner-wall;
+    fluidPatch          wall;
+
+    // Weak coupling performs a single interface update per time-step
+    nOuterCorr          1;
+
+    interpolatorUpdateFrequency 0;
+    interfaceDeformationLimit   0;
+
+    coupled yes;
+
+    // Write fsi residuals to file
+    writeResidualsToFile yes;
+}
+
+// ************************************************************************* //


### PR DESCRIPTION
Fixes #361.

## The problem

`weakCouplingInterface::updateDisplacement()` called only
`fluidSolidInterface::updateMovingWallPressureAcceleration()`. The other three
couplers that update the interface displacement — `fixedRelaxationCouplingInterface`,
`AitkenCouplingInterface` and `IQNILSCouplingInterface` — also call
`fluidSolidInterface::updateElasticWallPressureAcceleration()`, which refreshes
both `prevPressure_` and `prevAcceleration_` of an `elasticWallPressure` boundary.

Under weak coupling an `elasticWallPressure` boundary therefore ran with both
history fields permanently at their constructed values — zero, unless restored
from a checkpoint. `prevPressure_` feeds the Robin right-hand side directly
(`elasticWallPressureFvPatchScalarField.C:411, 418, 455, 463`), so the condition
the fluid saw was not the intended one.

Both helpers guard themselves with a per-patch `isA<>` check, so the added call
is a no-op when the boundary type is not present.

## The other couplers, checked

- `thermalCouplingInterface` needs **no change**: it derives from
  `fixedRelaxationCouplingInterface` and does not override `updateDisplacement()`,
  so it already inherits both calls. (A grep of its own `.C` shows neither call,
  which is misleading.)
- `oneWayCouplingInterface` calls neither, which is correct — the fluid does not
  see the solid.

## Tutorial coverage

The `weakCoupling` path had no case exercising it, so a `weakCoupling` variant is
added to `3dTube`. It reuses the Robin-Neumann fluid setup of the default approach
(`elasticWallPressure` on the fluid `wall` patch) and overrides only
`constant/fsiProperties`, so the new file is a single `fsiProperties.weakCoupling`
plus an `Allrun` branch. The README describes it as approach 7, and notes that weak
coupling is not expected to reproduce the strongly coupled result on this case —
it is there to cover the code path.

## Verification

Built and run on OpenFOAM v2512 (clean rebuild of `development`, then the same tree
with only this change). Same case, 20 time steps, `writeFormat ascii`, comparing the
`prevPressure` entry written into `<time>/fluid/p`:

| time | before (`development`) | after |
|---|---|---|
| 1e-4 | `uniform 0` | nonuniform, 1599/1599 non-zero, max 822.6 Pa |
| 2e-4 | `uniform 0` | max 1046.6 Pa |
| 3e-4 | `uniform 0` | max 1210.6 Pa |
| 4e-4 | `uniform 0` | max 1273.7 Pa |
| 5e-4 | `uniform 0` | max 1265.9 Pa |

Both runs completed all 20 steps with no `ERROR` marker in the log. `endTime` was
shortened to `5e-4` in the scratch copies for turnaround; the committed variant
keeps the tutorial's `endTime 0.02`.

## Not done

The variant is **not** wired into `regressionTest.sh`. Adding it would give #361
permanent coverage but adds a full FSI run to the suite, so that is left as a
maintainer decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)