### PR TITLE
[Fix] Preserve face-centre restart history in newMovingWallVelocity and elasticSlipWallVelocity

### DIFF
--- a/src/solids4FoamModels/fluidModels/fvPatchFields/elasticSlipWallVelocity/elasticSlipWallVelocityFvPatchVectorField.C
+++ b/src/solids4FoamModels/fluidModels/fvPatchFields/elasticSlipWallVelocity/elasticSlipWallVelocityFvPatchVectorField.C
@@ -106,6 +106,29 @@ elasticSlipWallVelocityFvPatchVectorField
     oldFc_ = Fc_;
     oldoldFc_ = Fc_;
 
+    if (dict.found("oldFaceCentres") && dict.found("oldOldFaceCentres"))
+    {
+        // Restore the face-centre histories written by write(). myTimeIndex_
+        // is already the current time index, so the histories are not shifted
+        // again for this time
+        oldFc_ = vectorField("oldFaceCentres", dict, p.size());
+        oldoldFc_ = vectorField("oldOldFaceCentres", dict, p.size());
+    }
+    else if (dict.found("oldFaceCentres") || dict.found("oldOldFaceCentres"))
+    {
+        WarningInFunction
+            << "Only one of oldFaceCentres and oldOldFaceCentres is given"
+            << " for patch " << p.name() << " of field "
+#ifdef OPENFOAM_NOT_EXTEND
+            << internalField().name()
+#else
+            << dimensionedInternalField().name()
+#endif
+            << ": both entries are required to restore the face-centre"
+            << " history" << nl
+            << "    The current face centres will be used instead" << endl;
+    }
+
     //
     if (dict.found("refValue"))
     {
@@ -348,8 +371,12 @@ void elasticSlipWallVelocityFvPatchVectorField::write(Ostream& os) const
     fvPatchVectorField::write(os);
 #ifdef OPENFOAM_ORG
     writeEntry(os, "value", *this);
+    writeEntry(os, "oldFaceCentres", oldFc_);
+    writeEntry(os, "oldOldFaceCentres", oldoldFc_);
 #else
     writeEntry("value", os);
+    oldFc_.writeEntry("oldFaceCentres", os);
+    oldoldFc_.writeEntry("oldOldFaceCentres", os);
 #endif
 }
 

--- a/src/solids4FoamModels/fluidModels/fvPatchFields/newMovingWallVelocity/newMovingWallVelocityFvPatchVectorField.C
+++ b/src/solids4FoamModels/fluidModels/fvPatchFields/newMovingWallVelocity/newMovingWallVelocityFvPatchVectorField.C
@@ -102,6 +102,29 @@ newMovingWallVelocityFvPatchVectorField::newMovingWallVelocityFvPatchVectorField
 
     oldFc_ = Fc_;
     oldoldFc_ = Fc_;
+
+    if (dict.found("oldFaceCentres") && dict.found("oldOldFaceCentres"))
+    {
+        // Restore the face-centre histories written by write(). myTimeIndex_
+        // is already the current time index, so the histories are not shifted
+        // again for this time
+        oldFc_ = vectorField("oldFaceCentres", dict, p.size());
+        oldoldFc_ = vectorField("oldOldFaceCentres", dict, p.size());
+    }
+    else if (dict.found("oldFaceCentres") || dict.found("oldOldFaceCentres"))
+    {
+        WarningInFunction
+            << "Only one of oldFaceCentres and oldOldFaceCentres is given"
+            << " for patch " << p.name() << " of field "
+#ifdef OPENFOAM_NOT_EXTEND
+            << internalField().name()
+#else
+            << dimensionedInternalField().name()
+#endif
+            << ": both entries are required to restore the face-centre"
+            << " history" << nl
+            << "    The current face centres will be used instead" << endl;
+    }
 }
 
 
@@ -475,8 +498,12 @@ void newMovingWallVelocityFvPatchVectorField::write(Ostream& os) const
     fvPatchVectorField::write(os);
 #ifdef OPENFOAM_ORG
     writeEntry(os, "value", *this);
+    writeEntry(os, "oldFaceCentres", oldFc_);
+    writeEntry(os, "oldOldFaceCentres", oldoldFc_);
 #else
     writeEntry("value", os);
+    oldFc_.writeEntry("oldFaceCentres", os);
+    oldoldFc_.writeEntry("oldOldFaceCentres", os);
 #endif
 }
 


### PR DESCRIPTION
Addresses #369.

## The change

`newMovingWallVelocity` and `elasticSlipWallVelocity` keep a three-level
face-centre history (`Fc_`, `oldFc_`, `oldoldFc_`), but `write()` emitted only
`value`. Their dictionary constructors therefore reset `oldFc_` and `oldoldFc_`
to the current face centres on restart, discarding the history.

`write()` now emits `oldFaceCentres` and `oldOldFaceCentres`, and the dictionary
constructor restores them when both are present, warning if only one is. This
mirrors PR #364, which fixed the same defect in `elasticWallVelocity`.
`myTimeIndex_` is already initialised to the current time index in both
constructors, so it needs no adjustment.

## Two corrections to the issue

**Scope: two conditions, not four.** In `normalInletVelocity` and
`outflowPressure` every use of `Fc_`, `oldFc_` and `oldoldFc_` is commented out,
in both the header and the implementation — neither carries any history to lose.
They are left unchanged.

**Impact: backward only, not "zero boundary velocity".** #369 states the first
step after a restart sees a zero boundary velocity. That is not what happens.
Both the Euler and backward branches shift `oldFc_ = Fc_` on the first step after
the restart, and `Fc_` is rebuilt from the current mesh in the constructor, so
the first-order term is already correct. Only `oldoldFc_` is genuinely lost, and
the Euler branch never reads it. The defect is specific to the `backward` scheme,
where the second-order correction term is silently dropped for one step.

## Verification

`cavityFlexibleBottom`, OpenFOAM v2512, `ddt(U) = backward`, restart at t = 10,
with a temporary `Info` in the backward branch (not committed):

| run | `max\|oldFc − oldoldFc\|` at t = 10.5 |
|---|---|
| uninterrupted | 9.71190e-04 |
| restart, with this fix | 9.71168e-04 |
| restart, without it | **0** |

`coefft00` was 0.5 and `deltaT0` 0.5 in all three, so the dropped term is a real
contribution and not one suppressed by the `deltaT0 = GREAT` guard.

With `ddt(U) = Euler` the restarted interface velocity is unchanged by this fix,
as the analysis above predicts — I checked that too, and `|continuous − restarted|`
was bit-identical before and after.

Each build was a full `src/Allwmake` against a clean `development` tree; the
before and after continuous runs agree exactly, so only the restart path moves.

## Not covered

`elasticSlipWallVelocity` has no tutorial anywhere in the repository, so its
change is by analogy with `newMovingWallVelocity` and is not exercised by this
verification or by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)