### PR TITLE
Fix hidden correct overload warning

### DIFF
--- a/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticMisesPlastic/linearElasticMisesPlastic.H
+++ b/src/solids4FoamModels/materialModels/mechanicalModel/mechanicalLaws/linearGeometryLaws/linearElasticMisesPlastic/linearElasticMisesPlastic.H
@@ -277,6 +277,8 @@ public:
 
     // Member Functions
 
+        using mechanicalLaw::correct;
+
         //- Return the implicit stiffness
         //  This is the diffusivity for the Laplacian term
         virtual tmp<volScalarField> impK() const;


### PR DESCRIPTION
## Summary

- expose the base-class `mechanicalLaw::correct` overload set in `linearElasticMisesPlastic`
- remove the Clang `-Woverloaded-virtual` diagnostics when compiling vertex-centred solid models
- preserve the existing derived overloads and virtual dispatch behavior

## Testing

- `source ~/bin/load-openfoam v2412 && ./Allwmake` (from `src/solids4FoamModels`)
